### PR TITLE
The simulation seam: free-space physics and the onboard-loop model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,15 @@ def includeDesktopSupport = true
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
+// Departs from the template: the two natives GradleRIO's JNI list omits, for the configuration
+// blocks below.
+def wpilibNatives = { String platform, boolean debug ->
+    def classifier = debug ? "${platform}debug" : platform
+    ['org.wpilib.telemetry:telemetry-cpp', 'org.wpilib.tunables:tunables-cpp'].collect {
+        "${it}:${wpi.versions.wpilibVersion.get()}:${classifier}@zip"
+    }
+}
+
 dependencies {
     annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
@@ -88,6 +97,15 @@ dependencies {
     // from the compile classpath. Delete when wpilib() includes them.
     implementation "org.wpilib.telemetry:telemetry-java:${wpi.versions.wpilibVersion.get()}"
     implementation "org.wpilib.tunables:tunables-java:${wpi.versions.wpilibVersion.get()}"
+
+    // Departs from the template for the same omission one layer down: libwpimath.so declares
+    // libtelemetry.so and libtunables.so as NEEDED, and GradleRIO's JNI list carries neither, so
+    // loading wpimathjni throws. Anything that discretizes a plant hits it. Delete when
+    // wpilibJniRelease includes them.
+    systemcoreDebug wpilibNatives(wpi.platforms.systemcore, true)
+    systemcoreRelease wpilibNatives(wpi.platforms.systemcore, false)
+    nativeDebug wpilibNatives(wpi.platforms.desktop, true)
+    nativeRelease wpilibNatives(wpi.platforms.desktop, false)
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -6,13 +6,23 @@ package first.robot;
 
 import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Inches;
+import static org.wpilib.units.Units.KilogramSquareMeters;
+import static org.wpilib.units.Units.Kilograms;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Pounds;
 import static org.wpilib.units.Units.Rotations;
 
+import first.robot.sim.SwerveSimConfig;
 import org.wpilib.framework.RobotBase;
 import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.system.DCMotor;
 import org.wpilib.units.measure.Angle;
 import org.wpilib.units.measure.Current;
 import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Mass;
+import org.wpilib.units.measure.MomentOfInertia;
+import org.wpilib.units.measure.Time;
 
 public final class DriveConstants {
   public static final int FRONT_LEFT_DRIVE_ID = 1;
@@ -24,6 +34,9 @@ public final class DriveConstants {
   public static final int BACK_RIGHT_DRIVE_ID = 7;
   public static final int BACK_RIGHT_STEER_ID = 8;
   public static final int GYRO_ID = 9;
+
+  // REV's documented SPARK control loop period, which is not the robot's.
+  public static final Time CONTROLLER_PERIOD = Milliseconds.of(1);
 
   // === SDS Mk5i, off the manufacturer's layout drawing =========================================
 
@@ -46,6 +59,12 @@ public final class DriveConstants {
 
   public static final Current DRIVE_CURRENT_LIMIT = Amps.of(60);
   public static final Current STEER_CURRENT_LIMIT = Amps.of(40);
+
+  // Competition weight with bumpers and battery.
+  public static final Mass ROBOT_MASS = Pounds.of(125);
+
+  // Everything the steer motor turns, about the module's steering axis. Nobody has weighed it.
+  public static final MomentOfInertia STEER_INERTIA = KilogramSquareMeters.of(0.004);
 
   public record DriveMotorGains(double kP, double kS, double kV) {}
 
@@ -108,6 +127,25 @@ public final class DriveConstants {
 
   public static ModuleGains gains() {
     return RobotBase.isSimulation() ? SIM_GAINS : REAL_GAINS;
+  }
+
+  public static SwerveSimConfig simConfig() {
+    // A quarter of the robot's mass reflected onto the wheel, not the wheel's own inertia: the
+    // drive axis has to accelerate the robot.
+    var driveInertia =
+        KilogramSquareMeters.of(
+            ROBOT_MASS.in(Kilograms) / 4 * Math.pow(WHEEL_RADIUS.in(Meters), 2));
+
+    return new SwerveSimConfig(
+        DRIVE.frontLeft().location(),
+        DRIVE.frontRight().location(),
+        DRIVE.backLeft().location(),
+        DRIVE.backRight().location(),
+        WHEEL_RADIUS,
+        new SwerveSimConfig.Axis(
+            DCMotor.getNeoVortex(1), DRIVE_REDUCTION, driveInertia, DRIVE_CURRENT_LIMIT),
+        new SwerveSimConfig.Axis(
+            DCMotor.getNeoVortex(1), STEER_REDUCTION, STEER_INERTIA, STEER_CURRENT_LIMIT));
   }
 
   private DriveConstants() {}

--- a/src/main/java/first/robot/sim/OnboardLoopSim.java
+++ b/src/main/java/first/robot/sim/OnboardLoopSim.java
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import org.wpilib.math.util.MathUtil;
+
+public final class OnboardLoopSim {
+  private final double kP;
+  private final double kD;
+  private final double kS;
+  private final double kV;
+  private final double dFilter;
+  private final boolean wrapping;
+  private final double inputRange;
+
+  private double setpoint;
+  private double lastError;
+  private double derivative;
+  private boolean started;
+
+  private OnboardLoopSim(
+      double kP, double kD, double kS, double kV, double dFilter, boolean wrapping, double range) {
+    this.kP = kP;
+    this.kD = kD;
+    this.kS = kS;
+    this.kV = kV;
+    this.dFilter = dFilter;
+    this.wrapping = wrapping;
+    this.inputRange = range;
+  }
+
+  public static OnboardLoopSim velocity(double kP, double kS, double kV) {
+    return new OnboardLoopSim(kP, 0, kS, kV, 0, false, 0);
+  }
+
+  // kV is not applied in position mode on the controller, so it is not a parameter here.
+  public static OnboardLoopSim position(
+      double kP, double kD, double dFilter, double minInput, double maxInput) {
+    return new OnboardLoopSim(kP, kD, 0, 0, dFilter, true, maxInput - minInput);
+  }
+
+  public void setSetpoint(double setpoint) {
+    this.setpoint = setpoint;
+  }
+
+  public double calculate(double measurement, double dtSeconds) {
+    double error = setpoint - measurement;
+    if (wrapping) {
+      error = MathUtil.inputModulus(error, -inputRange / 2, inputRange / 2);
+    }
+
+    double raw = started ? (error - lastError) / dtSeconds : 0;
+    // REVLib's derivative filter carries no units and no documented range, so it is modelled as
+    // the fraction of the previous derivative carried forward. Zero is an unfiltered D term.
+    derivative = dFilter * derivative + (1 - dFilter) * raw;
+    lastError = error;
+    started = true;
+
+    return kP * error + kD * derivative + kS * Math.signum(setpoint) + kV * setpoint;
+  }
+}

--- a/src/main/java/first/robot/sim/SimModuleState.java
+++ b/src/main/java/first/robot/sim/SimModuleState.java
@@ -1,0 +1,10 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import org.wpilib.math.geometry.Rotation2d;
+
+public record SimModuleState(
+    double wheelPositionRad, double wheelVelocityRadPerSec, Rotation2d azimuth, boolean slipping) {}

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -1,0 +1,138 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import static org.wpilib.units.Units.Amps;
+import static org.wpilib.units.Units.KilogramSquareMeters;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Volts;
+
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.math.system.DCMotor;
+import org.wpilib.math.system.Models;
+import org.wpilib.simulation.BatterySim;
+import org.wpilib.simulation.DCMotorSim;
+import org.wpilib.units.measure.Voltage;
+
+public final class SwerveDriveSim {
+  private static final int MODULES = 4;
+
+  private final SwerveDriveKinematics kinematics;
+  private final DCMotorSim[] drive = new DCMotorSim[MODULES];
+  private final DCMotorSim[] steer = new DCMotorSim[MODULES];
+  private final DCMotor driveMotor;
+  private final DCMotor steerMotor;
+  private final double driveCurrentLimit;
+  private final double steerCurrentLimit;
+  private final double wheelRadius;
+
+  private Pose2d pose = Pose2d.kZero;
+  private ChassisVelocities velocity = new ChassisVelocities();
+  private double batteryVolts = BatterySim.calculateDefaultBatteryLoadedVoltage();
+
+  public SwerveDriveSim(SwerveSimConfig config) {
+    kinematics = new SwerveDriveKinematics(config.moduleLocations());
+    wheelRadius = config.wheelRadius().in(Meters);
+    driveMotor = config.drive().motor();
+    steerMotor = config.steer().motor();
+    driveCurrentLimit = config.drive().currentLimit().in(Amps);
+    steerCurrentLimit = config.steer().currentLimit().in(Amps);
+    for (int i = 0; i < MODULES; i++) {
+      drive[i] = axis(config.drive());
+      steer[i] = axis(config.steer());
+    }
+  }
+
+  public SimModuleState[] update(double[] driveVolts, double[] steerVolts, double dtSeconds) {
+    for (int i = 0; i < MODULES; i++) {
+      drive[i].setInput(applied(drive[i], driveMotor, driveCurrentLimit, driveVolts[i]));
+      steer[i].setInput(applied(steer[i], steerMotor, steerCurrentLimit, steerVolts[i]));
+      drive[i].update(dtSeconds);
+      steer[i].update(dtSeconds);
+    }
+
+    // DCMotorSim.setInputVoltage clamps against RobotController's battery, which is a HAL read.
+    // The sag is modelled here instead, and reaches the motors on the next step's inputs.
+    batteryVolts = BatterySim.calculateDefaultBatteryLoadedVoltage(currents());
+
+    var states = moduleStates();
+    velocity = kinematics.toChassisVelocities(velocities(states));
+    pose = pose.plus(velocity.toTwist2d(dtSeconds).exp());
+    return states;
+  }
+
+  public SimModuleState[] moduleStates() {
+    var states = new SimModuleState[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      states[i] =
+          new SimModuleState(
+              drive[i].getAngularPosition(),
+              drive[i].getAngularVelocity(),
+              new Rotation2d(steer[i].getAngularPosition()),
+              // Always false: free space has no ground contact to break.
+              false);
+    }
+    return states;
+  }
+
+  public void resetPose(Pose2d pose) {
+    this.pose = pose;
+  }
+
+  public Pose2d truePose() {
+    return pose;
+  }
+
+  public ChassisVelocities trueVelocity() {
+    return new ChassisVelocities(velocity.vx, velocity.vy, velocity.omega);
+  }
+
+  public Voltage batteryVoltage() {
+    return Volts.of(batteryVolts);
+  }
+
+  // A single-jointed arm with no gravity term is the plain DC motor plant, and DCMotorSim's own
+  // javadoc names this factory for it.
+  private static DCMotorSim axis(SwerveSimConfig.Axis axis) {
+    return new DCMotorSim(
+        Models.singleJointedArmFromPhysicalConstants(
+            axis.motor(), axis.inertia().in(KilogramSquareMeters), axis.reduction()),
+        axis.motor());
+  }
+
+  private double applied(DCMotorSim axis, DCMotor motor, double currentLimit, double volts) {
+    // The controller enforces the current limit, not physics: free space has nothing to stop a
+    // motor drawing stall current from a stop, which collapses the battery model to zero volts.
+    double backEmf = axis.getAngularVelocity() * axis.getGearing() / motor.Kv;
+    double span = currentLimit * motor.R;
+    return Math.clamp(
+        Math.clamp(volts, backEmf - span, backEmf + span), -batteryVolts, batteryVolts);
+  }
+
+  private double[] currents() {
+    var currents = new double[MODULES * 2];
+    for (int i = 0; i < MODULES; i++) {
+      // Magnitudes: a regenerating motor charges the pack, and a simulation whose battery gains
+      // voltage under braking accelerates out of a stop better than the robot ever will.
+      currents[i] = Math.abs(drive[i].getCurrentDraw());
+      currents[MODULES + i] = Math.abs(steer[i].getCurrentDraw());
+    }
+    return currents;
+  }
+
+  private SwerveModuleVelocity[] velocities(SimModuleState[] states) {
+    var velocities = new SwerveModuleVelocity[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      velocities[i] =
+          new SwerveModuleVelocity(
+              states[i].wheelVelocityRadPerSec() * wheelRadius, states[i].azimuth());
+    }
+    return velocities;
+  }
+}

--- a/src/main/java/first/robot/sim/SwerveSimConfig.java
+++ b/src/main/java/first/robot/sim/SwerveSimConfig.java
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.system.DCMotor;
+import org.wpilib.units.measure.Current;
+import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.MomentOfInertia;
+
+public record SwerveSimConfig(
+    Translation2d frontLeft,
+    Translation2d frontRight,
+    Translation2d backLeft,
+    Translation2d backRight,
+    Distance wheelRadius,
+    Axis drive,
+    Axis steer) {
+
+  public record Axis(
+      DCMotor motor, double reduction, MomentOfInertia inertia, Current currentLimit) {}
+
+  // The order every array in this package is indexed by.
+  public Translation2d[] moduleLocations() {
+    return new Translation2d[] {frontLeft, frontRight, backLeft, backRight};
+  }
+}

--- a/src/test/java/first/robot/sim/OnboardLoopSimTest.java
+++ b/src/test/java/first/robot/sim/OnboardLoopSimTest.java
@@ -1,0 +1,49 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class OnboardLoopSimTest {
+  private static final double SUB_STEP = 0.001;
+
+  @Test
+  void aWrappedPositionLoopTakesTheShortWayRound() {
+    var loop = OnboardLoopSim.position(8, 0, 0, 0, 1);
+    loop.setSetpoint(0.05);
+
+    // 0.95 to 0.05 is a tenth of a turn forwards, not nine tenths of one backwards.
+    assertEquals(8 * 0.1, loop.calculate(0.95, SUB_STEP), 1e-9);
+  }
+
+  @Test
+  void aVelocityLoopAtItsSetpointStillWritesItsFeedforward() {
+    var loop = OnboardLoopSim.velocity(0.1, 0.15, 2.0);
+    loop.setSetpoint(3.0);
+
+    assertEquals(0.15 + 2.0 * 3.0, loop.calculate(3.0, SUB_STEP), 1e-9);
+  }
+
+  @Test
+  void theFirstCalculateHasNoDerivativeKick() {
+    var loop = OnboardLoopSim.position(0, 1, 0, 0, 1);
+    loop.setSetpoint(0.25);
+
+    assertEquals(0, loop.calculate(0, SUB_STEP), 1e-9);
+  }
+
+  @Test
+  void theDerivativeFilterCarriesTheFractionItIsGiven() {
+    var loop = OnboardLoopSim.position(0, 1, 0.5, 0, 1);
+    loop.setSetpoint(0.25);
+    loop.calculate(0.25, SUB_STEP);
+
+    // The error steps to a quarter turn over a millisecond, so the raw derivative is 250 a
+    // second and a filter of one half passes half of it.
+    assertEquals(0.5 * 250, loop.calculate(0, SUB_STEP), 1e-9);
+  }
+}

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -1,0 +1,132 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.sim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Seconds;
+import static org.wpilib.units.Units.Volts;
+
+import first.robot.Constants;
+import first.robot.DriveConstants;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.system.DCMotor;
+import org.wpilib.math.util.MathUtil;
+import org.wpilib.units.measure.Time;
+
+class SwerveDriveSimTest {
+  private static final int MODULES = 4;
+  private static final double SUB_STEP = DriveConstants.CONTROLLER_PERIOD.in(Seconds);
+  private static final int SUB_STEPS =
+      (int) Math.round(Constants.LOOP_PERIOD.in(Seconds) / SUB_STEP);
+
+  private static final double DRIVE_VOLTS = 6.0;
+  private static final Time SETTLE = Seconds.of(2);
+  private static final Time SPIN = Seconds.of(2);
+
+  private final SwerveSimConfig config = DriveConstants.simConfig();
+  private final SwerveDriveSim sim = new SwerveDriveSim(config);
+  private final double[] driveVolts = new double[MODULES];
+  private final double[] steerVolts = new double[MODULES];
+  private final OnboardLoopSim[] steerLoops = new OnboardLoopSim[MODULES];
+
+  private SimModuleState[] state;
+
+  @BeforeEach
+  void buildSteerLoops() {
+    var gains = DriveConstants.SIM_GAINS.steer();
+    for (int i = 0; i < MODULES; i++) {
+      // The wrap range is the converted analog sensor's, which is not Rotation2d's.
+      steerLoops[i] = OnboardLoopSim.position(gains.kP(), gains.kD(), gains.dFilter(), 0, 1);
+    }
+    state = sim.moduleStates();
+  }
+
+  @Test
+  void aConstantVoltageSettlesAtTheFreeSpeedThatVoltageBuys() {
+    Arrays.fill(driveVolts, DRIVE_VOLTS);
+
+    advance(Seconds.of(3));
+
+    // Terminal is where the motor draws no current, so the applied volts are all back-EMF: the
+    // rotor turns at V times Kv and the wheel at that over the reduction.
+    double expected = DRIVE_VOLTS * DCMotor.getNeoVortex(1).Kv / DriveConstants.DRIVE_REDUCTION;
+    assertEquals(
+        expected,
+        state[0].wheelVelocityRadPerSec(),
+        expected * 0.01,
+        "the wheel did not reach the free speed " + DRIVE_VOLTS + " volts buys");
+    assertEquals(
+        expected * config.wheelRadius().in(Meters),
+        sim.trueVelocity().vx,
+        expected * config.wheelRadius().in(Meters) * 0.01,
+        "the chassis is not moving at the speed its wheels are turning");
+  }
+
+  @Test
+  void pureRotationTurnsTheRobotAndDoesNotMoveIt() {
+    var kinematics = new SwerveDriveKinematics(config.moduleLocations());
+    var targets = kinematics.toSwerveModuleVelocities(new ChassisVelocities(0, 0, 1));
+    for (int i = 0; i < MODULES; i++) {
+      steerLoops[i].setSetpoint(MathUtil.inputModulus(targets[i].angle.getRotations(), 0, 1));
+    }
+
+    advance(SETTLE);
+    Arrays.fill(driveVolts, DRIVE_VOLTS);
+    advance(SPIN);
+
+    assertTrue(
+        Math.abs(sim.trueVelocity().omega) > 5, "the robot is not turning: " + sim.trueVelocity());
+    assertEquals(
+        0,
+        sim.truePose().getTranslation().getNorm(),
+        0.01,
+        "the robot translated while spinning: " + sim.truePose());
+  }
+
+  @Test
+  void theBatterySagsUnderTheCurrentItIsAskedFor() {
+    Arrays.fill(driveVolts, 12.0);
+
+    advance(Constants.LOOP_PERIOD);
+
+    assertTrue(
+        sim.batteryVoltage().lt(Volts.of(11)),
+        "accelerating four modules from a stop did not sag the battery: " + sim.batteryVoltage());
+
+    advance(Seconds.of(3));
+
+    assertEquals(
+        12.0,
+        sim.batteryVoltage().in(Volts),
+        0.5,
+        "the battery did not recover once the wheels stopped accelerating");
+  }
+
+  private void advance(Time duration) {
+    int ticks = (int) Math.round(duration.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));
+    for (int i = 0; i < ticks; i++) {
+      tick();
+    }
+  }
+
+  // One robot loop period, sub-stepped at the controller's own rate with the setpoints held
+  // across the sub-steps: what a 200 Hz robot commanding a 1 kHz loop actually looks like.
+  private void tick() {
+    for (int step = 0; step < SUB_STEPS; step++) {
+      for (int i = 0; i < MODULES; i++) {
+        // Rotation2d reads back over [-0.5, 0.5) and the analog sensor over [0, 1).
+        double azimuth = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
+        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP);
+      }
+      state = sim.update(driveVolts, steerVolts, SUB_STEP);
+    }
+  }
+}


### PR DESCRIPTION
Closes #58.

## What this is

The seam ADR 0010 draws: voltages and a timestep in, module state, true
pose and true velocity out. It goes in before the mechanism that will
drive it, so the physics is trustworthy by the time anything depends on
it.

`first.robot.sim` holds three pieces:

- **`SwerveDriveSim`** — the plant. Eight `DCMotorSim` axes built by
  `Models.singleJointedArmFromPhysicalConstants`, so the motor curve is
  WPILib's rather than ours; their velocities go through
  `SwerveDriveKinematics` and a pose exponential to a true pose.
- **`OnboardLoopSim`** — a model of one SPARK's closed loop, the loop
  that runs on the controller and therefore never runs on the robot.
  First-class and independently constructible, because the drive
  mechanism and the autonomous test both need it and only one of them
  can hold vendor objects.
- **`SwerveSimConfig`** / **`SimModuleState`** — the geometry in and the
  per-module state out.

The package imports no vendor type, no HAL and no `RobotBase`. That is
the whole membership test and it is checkable with `grep`.

## On preferring WPILib's own sim tools

Every axis is a WPILib plant, so the motor is modelled off its
nameplate rather than off a curve we invented; battery sag is
`BatterySim.calculateDefaultBatteryLoadedVoltage` fed by the summed
currents. `DCMotorSim.setInputVoltage` is deliberately not called — it
clamps against `RobotController`, which is a HAL read — so the sag is
applied here and reaches the motors on the next step's inputs.

The current limit is applied at the motor. It is the only piece of
physics here that is not free-space, and it is not optional: with
nothing to stop a stalled motor, four drive axes pull the pack to zero
volts on the first step and the battery model is noise.

## Tests

Tier 1, plain JUnit, seven assertions:

- a constant voltage settles at the free speed that voltage buys, to 1%
  of the analytic value — the number is `V·Kv/G`, not a number anybody
  tuned;
- pure rotation turns the robot and does not move it;
- the battery sags out of a stop and recovers;
- the loop model wraps the short way, writes its feedforward at zero
  error, has no first-call derivative kick, and passes the fraction the
  filter is given.

Assertions are in time. The advance-and-tick helper takes its step from
`Constants.LOOP_PERIOD` and sub-steps it at `CONTROLLER_PERIOD` with the
setpoints held, which is what reproduces 200 Hz commanding a 1 kHz loop.

## A fourth template departure

`libwpimath.so` declares `libtelemetry.so` and `libtunables.so` as
`NEEDED`, and GradleRIO's JNI list carries neither, so `wpimathjni`
threw on load and nothing that discretizes a plant could run at all —
including `simulateJava`. The two natives join the same departure the
Java artifacts already had, commented at the edit. All four classifiers
resolve, desktop and systemcore, debug and release.

## Not in this ticket

- **`/Sim/TruePose` and `/Sim/ModuleSlip` are not written here.** The
  seam is a pure function and ADR 0010 says sim state is written only in
  `simulationPeriodic()`, so both signals land with `Drive.updateSim()`
  in #59. The `slipping` field is in the signature, hardcoded false with
  the comment at the line.
- **The sub-stepped tick lives in the test helper**, which is where
  ADR 0010 puts it for `Drive.updateSim()` too. #59 and #63 will each
  write it; if the two turn out identical, lift it then.
- **No coefficient of friction, lateral stiffness or chassis MOI.**
  Free space has no consumer for them, and a constant nothing reads is
  a constant nobody checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzD9PgrkYKqQfKVjRqJjn