### PR TITLE
Turn the wheels, and model the loop that turns them

### DIFF
--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -14,7 +14,6 @@ import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Pounds;
-import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Rotations;
 import static org.wpilib.units.Units.Volts;
 
@@ -100,10 +99,6 @@ public final class DriveConstants {
   public static final LinearVelocity MAX_VELOCITY =
       MetersPerSecond.of(
           DCMotor.getNeoVortex(1).freeSpeed / DRIVE_REDUCTION * WHEEL_RADIUS.in(Meters));
-  public static final AngularVelocity MAX_TURN_RATE =
-      RadiansPerSecond.of(
-          MAX_VELOCITY.in(MetersPerSecond)
-              / Math.hypot(TRACK_WIDTH.in(Meters) / 2, WHEELBASE.in(Meters) / 2));
 
   // A pose estimator tuned against a gyro that never wanders is tuned against a robot that does
   // not exist. Roughly a degree a minute, which is the order a Pigeon2 drifts at.

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -5,24 +5,33 @@
 package first.robot;
 
 import static org.wpilib.units.Units.Amps;
+import static org.wpilib.units.Units.DegreesPerSecond;
+import static org.wpilib.units.Units.Hertz;
 import static org.wpilib.units.Units.Inches;
 import static org.wpilib.units.Units.KilogramSquareMeters;
 import static org.wpilib.units.Units.Kilograms;
 import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Pounds;
+import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Rotations;
+import static org.wpilib.units.Units.Volts;
 
 import first.robot.sim.SwerveSimConfig;
 import org.wpilib.framework.RobotBase;
 import org.wpilib.math.geometry.Translation2d;
 import org.wpilib.math.system.DCMotor;
 import org.wpilib.units.measure.Angle;
+import org.wpilib.units.measure.AngularVelocity;
 import org.wpilib.units.measure.Current;
 import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Frequency;
+import org.wpilib.units.measure.LinearVelocity;
 import org.wpilib.units.measure.Mass;
 import org.wpilib.units.measure.MomentOfInertia;
 import org.wpilib.units.measure.Time;
+import org.wpilib.units.measure.Voltage;
 
 public final class DriveConstants {
   public static final int FRONT_LEFT_DRIVE_ID = 1;
@@ -37,6 +46,13 @@ public final class DriveConstants {
 
   // REV's documented SPARK control loop period, which is not the robot's.
   public static final Time CONTROLLER_PERIOD = Milliseconds.of(1);
+
+  // Module angle and wheel travel are what odometry consumes, so they ride at the loop period.
+  // Everything else is a diagnostic and rides slower. Raising one period raises its whole frame
+  // group, because the setters keep the smaller of the requested and the already-set value.
+  public static final Time ODOMETRY_FRAME_PERIOD = Constants.LOOP_PERIOD;
+  public static final Time FAULT_FRAME_PERIOD = Milliseconds.of(50);
+  public static final Time DIAGNOSTIC_FRAME_PERIOD = Milliseconds.of(100);
 
   // === SDS Mk5i, off the manufacturer's layout drawing =========================================
 
@@ -65,6 +81,36 @@ public final class DriveConstants {
 
   // Everything the steer motor turns, about the module's steering axis. Nobody has weighed it.
   public static final MomentOfInertia STEER_INERTIA = KilogramSquareMeters.of(0.004);
+
+  // The drive encoder counts motor rotations; conversion puts every drive quantity in metres, so
+  // kV is Volts per metre per second and a setpoint is a wheel speed.
+  public static final double DRIVE_POSITION_FACTOR =
+      2 * Math.PI * WHEEL_RADIUS.in(Meters) / DRIVE_REDUCTION;
+  // The primary encoder reports velocity in RPM, not rotations per second.
+  public static final double DRIVE_VELOCITY_FACTOR = DRIVE_POSITION_FACTOR / 60;
+
+  // The Thrifty analog is ratiometric and swings the full supply rail over one turn of the
+  // module, and the Flex's analog input reads to that same rail, so the two cancel.
+  public static final Voltage STEER_SENSOR_SPAN = Volts.of(5);
+  // Volts to module rotations, which puts the sensor in [0, 1) and fixes the wrap range with it.
+  public static final double STEER_POSITION_FACTOR = 1 / STEER_SENSOR_SPAN.in(Volts);
+  public static final double STEER_VELOCITY_FACTOR = STEER_POSITION_FACTOR;
+
+  // The nameplate free speed at this reduction, not a measurement of a chassis.
+  public static final LinearVelocity MAX_VELOCITY =
+      MetersPerSecond.of(
+          DCMotor.getNeoVortex(1).freeSpeed / DRIVE_REDUCTION * WHEEL_RADIUS.in(Meters));
+  public static final AngularVelocity MAX_TURN_RATE =
+      RadiansPerSecond.of(
+          MAX_VELOCITY.in(MetersPerSecond)
+              / Math.hypot(TRACK_WIDTH.in(Meters) / 2, WHEELBASE.in(Meters) / 2));
+
+  // A pose estimator tuned against a gyro that never wanders is tuned against a robot that does
+  // not exist. Roughly a degree a minute, which is the order a Pigeon2 drifts at.
+  public static final AngularVelocity GYRO_SIM_DRIFT = DegreesPerSecond.of(1.0 / 60);
+  // The documented ceiling for a Phoenix signal. CTRE simulates CAN latency, and a lagged gyro
+  // makes odometry look broken for a reason that is not our code.
+  public static final Frequency GYRO_SIM_UPDATE_RATE = Hertz.of(1000);
 
   public record DriveMotorGains(double kP, double kS, double kV) {}
 

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -10,6 +10,7 @@ import static org.wpilib.units.Units.Microseconds;
 import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Seconds;
 
+import first.robot.mechanisms.Drive;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.wpilib.backend.DataLogTelemetryBackend;
 import org.wpilib.backend.NetworkTablesTelemetryBackend;
+import org.wpilib.command3.Scheduler;
 import org.wpilib.driverstation.DriverStation;
 import org.wpilib.driverstation.MatchState;
 import org.wpilib.driverstation.RobotState;
@@ -43,6 +45,8 @@ import org.wpilib.util.AlertDataJNI.AlertInfo;
  * project.
  */
 public class Robot extends OpModeRobot {
+  public final Drive drive;
+
   private final TelemetryTable robotLog;
   private final TelemetryTable canLog;
   private final TelemetryTable alertLog;
@@ -117,6 +121,17 @@ public class Robot extends OpModeRobot {
           .set(true);
     }
 
+    drive =
+        new Drive(
+            DriveConstants.DRIVE,
+            TelemetryRegistry.getTable("/Drive"),
+            TelemetryRegistry.getTable("/Sim"),
+            Scheduler.getDefault());
+
+    // The safe state of the whole robot is one block a reviewer can read, rather than something
+    // they have to know idle() would have defaulted to.
+    drive.setDefaultCommand(drive.idle());
+
     lastWakeUs = RobotController.getMonotonicTime();
     // The first sendAsync costs ~8 ms while the client starts its machinery, which is over the
     // whole loop period. Paid here, where nothing is timing anything.
@@ -178,12 +193,24 @@ public class Robot extends OpModeRobot {
     // decision on the robot is about to be made against a guess.
     allianceUnknown.set(RobotState.isDSAttached() && alliance.isEmpty());
 
+    drive.log();
+
     var can = RobotController.getCANStatus(Constants.CAN_BUS);
     canLog.log("Utilization", can.percentBusUtilization);
     canLog.log("ReceiveErrors", can.receiveErrorCount);
     canLog.log("TransmitErrors", can.transmitErrorCount);
     canLog.log("BusOff", can.busOffCount);
     canLog.log("TxFull", can.txFullCount);
+  }
+
+  @Override
+  public void simulationInit() {
+    drive.simulationInit();
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    drive.updateSim();
   }
 
   /** This function is called exactly once when the DS first connects. */

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -195,6 +195,10 @@ public class Robot extends OpModeRobot {
 
     drive.log();
 
+    // Nothing in OpModeRobot runs the Commands v3 scheduler, so a mechanism whose scheduler is
+    // never run has a default command that never starts and commands that never execute.
+    Scheduler.getDefault().run();
+
     var can = RobotController.getCANStatus(Constants.CAN_BUS);
     canLog.log("Utilization", can.percentBusUtilization);
     canLog.log("ReceiveErrors", can.receiveErrorCount);

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -67,6 +67,8 @@ public class Drive implements Mechanism {
   private final SparkAnalogSensorSim[] steerSensorSims = new SparkAnalogSensorSim[MODULES];
   private final Pigeon2SimState gyroSim;
   private Angle simDrift;
+  private Angle simYaw;
+  private Rotation2d lastTrueRotation;
 
   public Drive(DriveConfig config, TelemetryTable log, TelemetryTable simLog, Scheduler scheduler) {
     this.simLog = simLog;
@@ -91,6 +93,8 @@ public class Drive implements Mechanism {
       physics = new SwerveDriveSim(DriveConstants.simConfig());
       gyroSim = gyro.getSimState();
       simDrift = Radians.zero();
+      simYaw = Radians.zero();
+      lastTrueRotation = physics.truePose().getRotation();
       retry(() -> gyro.getYaw().setUpdateFrequency(DriveConstants.GYRO_SIM_UPDATE_RATE));
       for (int i = 0; i < MODULES; i++) {
         driveLoops[i] =
@@ -169,6 +173,8 @@ public class Drive implements Mechanism {
   }
 
   public Rotation2d getHeading() {
+    // The yaw signal still publishes at its Phoenix default, which is below the loop rate, so
+    // this reads one frame stale during a fast spin until the pose estimator raises it.
     return new Rotation2d(gyro.getYaw().getValue());
   }
 
@@ -191,6 +197,8 @@ public class Drive implements Mechanism {
   }
 
   public void simulationInit() {
+    simYaw = Radians.zero();
+    lastTrueRotation = physics.truePose().getRotation();
     // setYaw's offset is integrated on top of whatever setRawYaw writes, by design, so zeroing
     // one leaves the other's offset in every reading with nothing in the log to show it.
     retry(() -> gyroSim.setRawYaw(0));
@@ -234,8 +242,14 @@ public class Drive implements Mechanism {
 
     RoboRioSim.setVInVoltage(physics.batteryVoltage().in(Volts));
 
+    // The Pigeon integrates what setRawYaw is handed, so it has to be a continuous angle. A
+    // Rotation2d is wrapped, and handing it one steps a whole turn at the boundary, which the
+    // emulated yaw then takes as real rotation the robot never did.
+    var trueRotation = physics.truePose().getRotation();
+    simYaw = simYaw.plus(trueRotation.minus(lastTrueRotation).getMeasure());
+    lastTrueRotation = trueRotation;
     simDrift = simDrift.plus(DriveConstants.GYRO_SIM_DRIFT.times(Constants.LOOP_PERIOD));
-    retry(() -> gyroSim.setRawYaw(physics.truePose().getRotation().getMeasure().plus(simDrift)));
+    retry(() -> gyroSim.setRawYaw(simYaw.plus(simDrift)));
     retry(() -> gyroSim.setAngularVelocityZ(RadiansPerSecond.of(physics.trueVelocity().omega)));
 
     simLog.log("TruePose", physics.truePose(), Pose2d.struct);

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -1,0 +1,272 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.Radians;
+import static org.wpilib.units.Units.RadiansPerSecond;
+import static org.wpilib.units.Units.Seconds;
+import static org.wpilib.units.Units.Volts;
+
+import com.ctre.phoenix6.CANBus;
+import com.ctre.phoenix6.StatusCode;
+import com.ctre.phoenix6.configs.Pigeon2Configuration;
+import com.ctre.phoenix6.hardware.Pigeon2;
+import com.ctre.phoenix6.sim.Pigeon2SimState;
+import com.revrobotics.sim.SparkAnalogSensorSim;
+import com.revrobotics.sim.SparkRelativeEncoderSim;
+import first.robot.Constants;
+import first.robot.DriveConstants;
+import first.robot.DriveConstants.DriveConfig;
+import first.robot.DriveConstants.SwerveModuleConfig;
+import first.robot.Hardware;
+import first.robot.sim.OnboardLoopSim;
+import first.robot.sim.SwerveDriveSim;
+import java.util.Arrays;
+import java.util.function.Supplier;
+import org.wpilib.command3.Command;
+import org.wpilib.command3.Mechanism;
+import org.wpilib.command3.Scheduler;
+import org.wpilib.framework.RobotBase;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.simulation.RoboRioSim;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.measure.Angle;
+
+public class Drive implements Mechanism {
+  private static final int MODULES = 4;
+  private static final double SUB_STEP = DriveConstants.CONTROLLER_PERIOD.in(Seconds);
+  private static final int SUB_STEPS =
+      (int) Math.round(Constants.LOOP_PERIOD.in(Seconds) / SUB_STEP);
+  private static final int PHOENIX_ATTEMPTS = 5;
+
+  private final SwerveModule[] modules = new SwerveModule[MODULES];
+  private final SwerveDriveKinematics kinematics;
+  private final Pigeon2 gyro;
+  private final TelemetryTable chassisLog;
+  private final TelemetryTable moduleLog;
+  private final TelemetryTable simLog;
+  private final Scheduler scheduler;
+
+  private ChassisVelocities desiredVelocities = new ChassisVelocities();
+
+  // The vendor plumbing, and the one place in this project allowed to be saturated with it.
+  // Everything it drives is in first.robot.sim, which imports no vendor type at all.
+  private final SwerveDriveSim physics;
+  private final OnboardLoopSim[] driveLoops = new OnboardLoopSim[MODULES];
+  private final OnboardLoopSim[] steerLoops = new OnboardLoopSim[MODULES];
+  private final SparkRelativeEncoderSim[] driveEncoderSims = new SparkRelativeEncoderSim[MODULES];
+  private final SparkAnalogSensorSim[] steerSensorSims = new SparkAnalogSensorSim[MODULES];
+  private final Pigeon2SimState gyroSim;
+  private Angle simDrift;
+
+  public Drive(DriveConfig config, TelemetryTable log, TelemetryTable simLog, Scheduler scheduler) {
+    this.simLog = simLog;
+    this.scheduler = scheduler;
+    chassisLog = log.getTable("Chassis");
+    moduleLog = log.getTable("Modules");
+
+    var gains = DriveConstants.gains();
+    var corners = corners(config);
+    for (int i = 0; i < MODULES; i++) {
+      modules[i] = new SwerveModule(corners[i], gains, moduleLog.getTable(corners[i].name()));
+    }
+    kinematics =
+        new SwerveDriveKinematics(
+            Arrays.stream(corners).map(SwerveModuleConfig::location).toArray(Translation2d[]::new));
+
+    gyro = new Pigeon2(config.gyroId(), CANBus.systemcore(Constants.CAN_BUS.value));
+    Hardware.configurePhoenix(
+        "SwerveGyro", () -> gyro.getConfigurator().apply(new Pigeon2Configuration()));
+
+    if (RobotBase.isSimulation()) {
+      physics = new SwerveDriveSim(DriveConstants.simConfig());
+      gyroSim = gyro.getSimState();
+      simDrift = Radians.zero();
+      retry(() -> gyro.getYaw().setUpdateFrequency(DriveConstants.GYRO_SIM_UPDATE_RATE));
+      for (int i = 0; i < MODULES; i++) {
+        driveLoops[i] =
+            OnboardLoopSim.velocity(gains.drive().kP(), gains.drive().kS(), gains.drive().kV());
+        steerLoops[i] =
+            OnboardLoopSim.position(
+                gains.steer().kP(), gains.steer().kD(), gains.steer().dFilter(), 0, 1);
+        // Built below the SPARK it names: a sensor sim whose device does not resolve drops every
+        // write, and the mechanism's encoders then read zero forever with nothing thrown.
+        driveEncoderSims[i] = new SparkRelativeEncoderSim(modules[i].getDriveMotor());
+        steerSensorSims[i] = new SparkAnalogSensorSim(modules[i].getSteerMotor());
+      }
+    } else {
+      physics = null;
+      gyroSim = null;
+    }
+  }
+
+  private static SwerveModuleConfig[] corners(DriveConfig config) {
+    return new SwerveModuleConfig[] {
+      config.frontLeft(), config.frontRight(), config.backLeft(), config.backRight()
+    };
+  }
+
+  @Override
+  public Scheduler getRegisteredScheduler() {
+    return scheduler;
+  }
+
+  @Override
+  public Command idle() {
+    return runRepeatedly(this::stopModules)
+        .withPriority(Command.LOWEST_PRIORITY)
+        .named("Drive.Idle");
+  }
+
+  public Command driveRobotRelative(Supplier<ChassisVelocities> velocities) {
+    return run(coroutine -> {
+          while (true) {
+            setVelocities(velocities.get());
+            coroutine.yield();
+          }
+        })
+        .whenCanceled(this::stopModules)
+        .named("Drive.DriveRobotRelative");
+  }
+
+  public Command driveFieldRelative(Supplier<ChassisVelocities> velocities) {
+    return run(coroutine -> {
+          while (true) {
+            setVelocities(velocities.get().toRobotRelative(getHeading()));
+            coroutine.yield();
+          }
+        })
+        .whenCanceled(this::stopModules)
+        .named("Drive.DriveFieldRelative");
+  }
+
+  public void setVelocities(ChassisVelocities velocities) {
+    desiredVelocities = velocities;
+    var target = velocities.discretize(Constants.LOOP_PERIOD.in(Seconds));
+    var states =
+        SwerveDriveKinematics.desaturateWheelVelocities(
+            kinematics.toSwerveModuleVelocities(target),
+            DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
+    for (int i = 0; i < MODULES; i++) {
+      modules[i].setVelocity(states[i]);
+    }
+  }
+
+  public void stopModules() {
+    for (var module : modules) {
+      module.stop();
+    }
+    desiredVelocities = new ChassisVelocities();
+  }
+
+  public Rotation2d getHeading() {
+    return new Rotation2d(gyro.getYaw().getValue());
+  }
+
+  public ChassisVelocities getVelocities() {
+    return kinematics.toChassisVelocities(measuredStates());
+  }
+
+  public void log() {
+    chassisLog.log("DesiredVelocities", desiredVelocities, ChassisVelocities.struct);
+    chassisLog.log("MeasuredVelocities", getVelocities(), ChassisVelocities.struct);
+    // The array form is what the visualiser consumes and the named subtables are what a human
+    // reads, and a corner/index mismatch is only visible if both are written.
+    moduleLog.log("DesiredStates", desiredStates(), SwerveModuleVelocity.struct);
+    moduleLog.log("MeasuredStates", measuredStates(), SwerveModuleVelocity.struct);
+    for (var module : modules) {
+      module.log();
+    }
+  }
+
+  public void simulationInit() {
+    // setYaw's offset is integrated on top of whatever setRawYaw writes, by design, so zeroing
+    // one leaves the other's offset in every reading with nothing in the log to show it.
+    retry(() -> gyroSim.setRawYaw(0));
+    retry(() -> gyro.setYaw(0));
+  }
+
+  public void updateSim() {
+    retry(() -> gyroSim.setSupplyVoltage(physics.batteryVoltage()));
+
+    var driveVolts = new double[MODULES];
+    var steerVolts = new double[MODULES];
+    var state = physics.moduleStates();
+    for (int i = 0; i < MODULES; i++) {
+      driveLoops[i].setSetpoint(modules[i].getDriveSetpoint());
+      steerLoops[i].setSetpoint(modules[i].getSteerSetpoint());
+    }
+
+    // The setpoints are held constant across the sub-steps, which is what reproduces a 200 Hz
+    // robot commanding a 1 kHz controller rather than pretending they run at the same rate.
+    for (int step = 0; step < SUB_STEPS; step++) {
+      for (int i = 0; i < MODULES; i++) {
+        double wheelSpeed =
+            state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters);
+        double sensor = modules[i].toSensorRotations(state[i].azimuth());
+        boolean closing = modules[i].isClosingLoops();
+        driveVolts[i] = closing ? driveLoops[i].calculate(wheelSpeed, SUB_STEP) : 0;
+        steerVolts[i] = closing ? steerLoops[i].calculate(sensor, SUB_STEP) : 0;
+      }
+      state = physics.update(driveVolts, steerVolts, SUB_STEP);
+    }
+
+    for (int i = 0; i < MODULES; i++) {
+      // setPosition takes the value after the conversion factor, so these are the metres and the
+      // rotations the mechanism will read back, not raw encoder units.
+      driveEncoderSims[i].setPosition(
+          state[i].wheelPositionRad() * DriveConstants.WHEEL_RADIUS.in(Meters));
+      driveEncoderSims[i].setVelocity(
+          state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters));
+      steerSensorSims[i].setPosition(modules[i].toSensorRotations(state[i].azimuth()));
+    }
+
+    RoboRioSim.setVInVoltage(physics.batteryVoltage().in(Volts));
+
+    simDrift = simDrift.plus(DriveConstants.GYRO_SIM_DRIFT.times(Constants.LOOP_PERIOD));
+    retry(() -> gyroSim.setRawYaw(physics.truePose().getRotation().getMeasure().plus(simDrift)));
+    retry(() -> gyroSim.setAngularVelocityZ(RadiansPerSecond.of(physics.trueVelocity().omega)));
+
+    simLog.log("TruePose", physics.truePose(), Pose2d.struct);
+    boolean[] slip = new boolean[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      slip[i] = state[i].slipping();
+    }
+    simLog.log("ModuleSlip", slip);
+  }
+
+  private SwerveModuleVelocity[] desiredStates() {
+    var states = new SwerveModuleVelocity[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      states[i] = modules[i].getDesiredVelocity();
+    }
+    return states;
+  }
+
+  private SwerveModuleVelocity[] measuredStates() {
+    var states = new SwerveModuleVelocity[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      states[i] = modules[i].getVelocity();
+    }
+    return states;
+  }
+
+  // A simulation write is not a config write, so it never raises an alert: constructing one every
+  // loop under a fixed id throws on the duplicate.
+  private static void retry(Supplier<StatusCode> write) {
+    for (int attempt = 1; attempt <= PHOENIX_ATTEMPTS; attempt++) {
+      if (write.get().isOK()) {
+        return;
+      }
+    }
+  }
+}

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -177,12 +177,14 @@ public class Drive implements Mechanism {
   }
 
   public void log() {
+    var measured = measuredStates();
     chassisLog.log("DesiredVelocities", desiredVelocities, ChassisVelocities.struct);
-    chassisLog.log("MeasuredVelocities", getVelocities(), ChassisVelocities.struct);
+    chassisLog.log(
+        "MeasuredVelocities", kinematics.toChassisVelocities(measured), ChassisVelocities.struct);
     // The array form is what the visualiser consumes and the named subtables are what a human
     // reads, and a corner/index mismatch is only visible if both are written.
     moduleLog.log("DesiredStates", desiredStates(), SwerveModuleVelocity.struct);
-    moduleLog.log("MeasuredStates", measuredStates(), SwerveModuleVelocity.struct);
+    moduleLog.log("MeasuredStates", measured, SwerveModuleVelocity.struct);
     for (var module : modules) {
       module.log();
     }

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -164,6 +164,9 @@ final class SwerveModule {
     driveMotor.stopMotor();
     steerMotor.stopMotor();
     desired = new SwerveModuleVelocity(0, getAngle());
+    // The logged setpoint's whole job is to tell a setpoint the SPARK never received from one it
+    // cannot reach, and a stale angle against a coasting module reads as the second.
+    steerSetpointRotations = toSensorRotations(desired.angle, steerOffsetRotations);
     closingLoops = false;
   }
 

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -1,0 +1,232 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.wpilib.units.Units.Amps;
+import static org.wpilib.units.Units.Celsius;
+import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Rotations;
+
+import com.revrobotics.PersistMode;
+import com.revrobotics.RelativeEncoder;
+import com.revrobotics.ResetMode;
+import com.revrobotics.spark.FeedbackSensor;
+import com.revrobotics.spark.SparkAnalogSensor;
+import com.revrobotics.spark.SparkClosedLoopController;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkLowLevel.ControlType;
+import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.config.FeedForwardConfig;
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+import com.revrobotics.spark.config.SparkFlexConfig;
+import first.robot.Constants;
+import first.robot.DriveConstants;
+import first.robot.DriveConstants.ModuleGains;
+import first.robot.DriveConstants.SwerveModuleConfig;
+import first.robot.Hardware;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.math.util.MathUtil;
+import org.wpilib.telemetry.TelemetryTable;
+
+final class SwerveModule {
+  private final String name;
+  private final SparkFlex driveMotor;
+  private final SparkFlex steerMotor;
+  private final RelativeEncoder driveEncoder;
+  private final SparkAnalogSensor steerSensor;
+  private final SparkClosedLoopController driveController;
+  private final SparkClosedLoopController steerController;
+  private final double steerOffsetRotations;
+  private final TelemetryTable moduleLog;
+
+  private SwerveModuleVelocity desired = new SwerveModuleVelocity();
+  private double steerSetpointRotations;
+  private boolean closingLoops;
+
+  SwerveModule(SwerveModuleConfig config, ModuleGains gains, TelemetryTable log) {
+    name = config.name();
+    moduleLog = log;
+    steerOffsetRotations = config.steerZeroOffset().in(Rotations);
+
+    driveMotor = new SparkFlex(Constants.CAN_BUS.value, config.driveId(), MotorType.kBrushless);
+    steerMotor = new SparkFlex(Constants.CAN_BUS.value, config.steerId(), MotorType.kBrushless);
+    driveEncoder = driveMotor.getEncoder();
+    steerSensor = steerMotor.getAnalog();
+    driveController = driveMotor.getClosedLoopController();
+    steerController = steerMotor.getClosedLoopController();
+
+    Hardware.configureSpark(
+        "Swerve" + name + "Drive",
+        () ->
+            driveMotor.configure(
+                driveConfig(gains),
+                ResetMode.kResetSafeParameters,
+                PersistMode.kPersistParameters));
+    Hardware.configureSpark(
+        "Swerve" + name + "Steer",
+        () ->
+            steerMotor.configure(
+                steerConfig(gains),
+                ResetMode.kResetSafeParameters,
+                PersistMode.kPersistParameters));
+
+    moduleLog.keepDuplicates("DriveFaults");
+    moduleLog.keepDuplicates("SteerFaults");
+  }
+
+  private static SparkFlexConfig driveConfig(ModuleGains gains) {
+    var config = new SparkFlexConfig();
+    config
+        .idleMode(IdleMode.kBrake)
+        .smartCurrentLimit((int) DriveConstants.DRIVE_CURRENT_LIMIT.in(Amps));
+    config
+        .encoder
+        .positionConversionFactor(DriveConstants.DRIVE_POSITION_FACTOR)
+        .velocityConversionFactor(DriveConstants.DRIVE_VELOCITY_FACTOR);
+    config
+        .closedLoop
+        .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
+        .p(gains.drive().kP())
+        // kS and kV live here and nowhere else. arbFeedforward carries an already-computed
+        // voltage rather than a gain, so a term written in both places doubles and nothing throws.
+        .apply(new FeedForwardConfig().sv(gains.drive().kS(), gains.drive().kV()));
+    config
+        .signals
+        .primaryEncoderPositionPeriodMs(odometryFramePeriodMs())
+        .primaryEncoderVelocityPeriodMs(odometryFramePeriodMs());
+    diagnosticFrames(config);
+    return config;
+  }
+
+  private static SparkFlexConfig steerConfig(ModuleGains gains) {
+    var config = new SparkFlexConfig();
+    config
+        .idleMode(IdleMode.kBrake)
+        .smartCurrentLimit((int) DriveConstants.STEER_CURRENT_LIMIT.in(Amps));
+    config
+        .analogSensor
+        .positionConversionFactor(DriveConstants.STEER_POSITION_FACTOR)
+        .velocityConversionFactor(DriveConstants.STEER_VELOCITY_FACTOR);
+    config
+        .closedLoop
+        .feedbackSensor(FeedbackSensor.kAnalogSensor)
+        .pid(gains.steer().kP(), 0, gains.steer().kD())
+        .dFilter(gains.steer().dFilter())
+        // The analog runs 0 to 1 and drops to 0 every revolution with no accumulator, so a
+        // non-wrapping loop sees a one-rotation error at the boundary and applies full output.
+        .positionWrappingEnabled(true)
+        .positionWrappingInputRange(0, 1);
+    config
+        .signals
+        .analogPositionPeriodMs(odometryFramePeriodMs())
+        .analogVelocityPeriodMs(odometryFramePeriodMs())
+        .analogVoltagePeriodMs(odometryFramePeriodMs());
+    diagnosticFrames(config);
+    return config;
+  }
+
+  private static int odometryFramePeriodMs() {
+    return (int) DriveConstants.ODOMETRY_FRAME_PERIOD.in(Milliseconds);
+  }
+
+  private static void diagnosticFrames(SparkFlexConfig config) {
+    int faultMs = (int) DriveConstants.FAULT_FRAME_PERIOD.in(Milliseconds);
+    int diagnosticMs = (int) DriveConstants.DIAGNOSTIC_FRAME_PERIOD.in(Milliseconds);
+    config
+        .signals
+        .faultsPeriodMs(faultMs)
+        .warningsPeriodMs(faultMs)
+        .appliedOutputPeriodMs(diagnosticMs)
+        .busVoltagePeriodMs(diagnosticMs)
+        .outputCurrentPeriodMs(diagnosticMs)
+        .motorTemperaturePeriodMs(diagnosticMs)
+        // The controller's own copy of the setpoint separates a SPARK that never received one —
+        // it browned out and came back at default frame rates — from a SPARK that cannot reach it.
+        .setpointPeriodMs(diagnosticMs);
+  }
+
+  void setVelocity(SwerveModuleVelocity target) {
+    var angle = getAngle();
+    desired = target.optimize(angle).cosineScale(angle);
+    steerSetpointRotations = toSensorRotations(desired.angle, steerOffsetRotations);
+
+    driveController.setSetpoint(desired.velocity, ControlType.kVelocity);
+    steerController.setSetpoint(steerSetpointRotations, ControlType.kPosition);
+    closingLoops = true;
+  }
+
+  void stop() {
+    // A zero velocity setpoint would hold the wheel against a shove, which is the brake a driver
+    // cannot drive out of. Dropping the output is what leaves the robot pushable.
+    driveMotor.stopMotor();
+    steerMotor.stopMotor();
+    desired = new SwerveModuleVelocity(0, getAngle());
+    closingLoops = false;
+  }
+
+  Rotation2d getAngle() {
+    return Rotation2d.fromRotations(steerSensor.getPosition().get() - steerOffsetRotations);
+  }
+
+  SwerveModuleVelocity getVelocity() {
+    return new SwerveModuleVelocity(driveEncoder.getVelocity().get(), getAngle());
+  }
+
+  SwerveModuleVelocity getDesiredVelocity() {
+    return desired;
+  }
+
+  String getName() {
+    return name;
+  }
+
+  void log() {
+    moduleLog.log("DriveOutput", driveMotor.getAppliedOutput().get());
+    moduleLog.log("DriveCurrent", Amps.of(driveMotor.getOutputCurrent().get()));
+    moduleLog.log("DriveTemp", Celsius.of(driveMotor.getMotorTemperature().get()));
+    moduleLog.log("SteerSetpoint", Rotations.of(steerSetpointRotations));
+    moduleLog.log("SteerAngle", getAngle().getMeasure());
+    moduleLog.log("SteerCurrent", Amps.of(steerMotor.getOutputCurrent().get()));
+    moduleLog.log("SteerTemp", Celsius.of(steerMotor.getMotorTemperature().get()));
+    // REVLib's packed fault word; SparkBase.Faults names the bits at the SHA this log carries.
+    moduleLog.log("DriveFaults", driveMotor.getFaults().get().rawBits);
+    moduleLog.log("SteerFaults", steerMotor.getFaults().get().rawBits);
+  }
+
+  // Everything below is for the simulation update hook, which builds this module's sensor sims
+  // and models the loops these setpoints were written to.
+
+  SparkFlex getDriveMotor() {
+    return driveMotor;
+  }
+
+  SparkFlex getSteerMotor() {
+    return steerMotor;
+  }
+
+  boolean isClosingLoops() {
+    return closingLoops;
+  }
+
+  double getDriveSetpoint() {
+    return desired.velocity;
+  }
+
+  double getSteerSetpoint() {
+    return steerSetpointRotations;
+  }
+
+  double toSensorRotations(Rotation2d azimuth) {
+    return toSensorRotations(azimuth, steerOffsetRotations);
+  }
+
+  // getRotations() returns [-0.5, 0.5] and the converted sensor reads [0, 1): the two agree on the
+  // first half turn and differ by exactly one rotation on the second, and a value one rotation out
+  // is outside the configured wrapping range entirely, so wrapping does not rescue it.
+  static double toSensorRotations(Rotation2d azimuth, double offsetRotations) {
+    return MathUtil.inputModulus(azimuth.getRotations() + offsetRotations, 0, 1);
+  }
+}

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -179,10 +179,6 @@ final class SwerveModule {
     return desired;
   }
 
-  String getName() {
-    return name;
-  }
-
   void log() {
     moduleLog.log("DriveOutput", driveMotor.getAppliedOutput().get());
     moduleLog.log("DriveCurrent", Amps.of(driveMotor.getOutputCurrent().get()));

--- a/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
+++ b/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
@@ -1,0 +1,50 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import first.robot.DriveConstants;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.geometry.Rotation2d;
+
+class SwerveModuleTest {
+  private static final double TOLERANCE = 1e-9;
+
+  // A target the sensor would read as 0.75 arrives from getRotations() as -0.25, which is not
+  // merely wrong: it is outside the configured wrapping range, so wrapping cannot rescue it.
+  @Test
+  void theSecondHalfTurnComesBackInsideTheSensorsRange() {
+    var target = Rotation2d.fromRotations(0.75);
+
+    assertEquals(-0.25, target.getRotations(), TOLERANCE, "Rotation2d changed its range");
+    assertEquals(0.75, SwerveModule.toSensorRotations(target, 0), TOLERANCE);
+  }
+
+  @Test
+  void anOffsetPastTheBoundaryWrapsRatherThanRunningOffTheEnd() {
+    assertEquals(
+        0.1, SwerveModule.toSensorRotations(Rotation2d.fromRotations(0.4), 0.7), TOLERANCE);
+  }
+
+  @Test
+  void everyAngleLandsInsideTheConfiguredWrappingRange() {
+    for (double rotations = -1; rotations <= 1; rotations += 0.01) {
+      double folded = SwerveModule.toSensorRotations(Rotation2d.fromRotations(rotations), 0.37);
+      assertTrue(folded >= 0 && folded < 1, rotations + " rotations folded to " + folded);
+    }
+  }
+
+  // The steer loop closes on the SPARK against this sensor, so the conversion factor is fixed
+  // rather than the ratiometric division a robot-side read would do.
+  @Test
+  void theSensorSpansOneModuleRotationOverItsSupplyRail() {
+    assertEquals(
+        1.0,
+        DriveConstants.STEER_SENSOR_SPAN.magnitude() * DriveConstants.STEER_POSITION_FACTOR,
+        TOLERANCE);
+  }
+}


### PR DESCRIPTION
Closes part of #59. **One acceptance criterion cannot be met** — see the last
section; it is an upstream vendor blocker, not a shortcut.

## What lands

`SwerveModule` (package-private, not a `Mechanism` — nothing commands one alone)
and `Drive` (a `Mechanism`, taking its `Scheduler` last), plus the constants,
the gyro, the simulation update hook and the log.

**Both loops close on the controller.** The module writes a setpoint and never a
voltage: `setSetpoint(velocity, kVelocity)` on the drive SPARK against the
primary encoder, `setSetpoint(rotations, kPosition)` on the steer SPARK against
the analog absolute encoder with `positionWrappingInputRange(0, 1)`. Nothing in
`Drive` computes a motor output.

**Each feedforward term has one home.** `kS` and `kV` go into `FeedForwardConfig`
and nowhere else; `arbFeedforward` is not passed anywhere in this diff.

**The module zero lives here.** The steer setpoint is
`inputModulus(target.getRotations() + offset, 0, 1)`. That fold is a static
function with a test, because it is the one line in the ticket that compiles
fine and fails on the field: `getRotations()` reads `[-0.5, 0.5]` and the
converted sensor reads `[0, 1)`, so a target the sensor would read as `0.75`
arrives as `-0.25` — outside the configured wrapping range entirely, where
wrapping cannot rescue it.

**Idle stops the modules rather than locking them**, at `LOWEST_PRIORITY`, and
`Robot`'s constructor sets it explicitly so the robot's safe state is one
readable block. Stopping drops the output rather than commanding zero velocity:
a zero velocity setpoint holds the wheel against a shove, which is the brake a
driver cannot drive out of.

**`updateSim()` holds the vendor plumbing** and nothing else does. It drives the
onboard-loop model in five 1 ms sub-steps inside the 5 ms tick with the setpoints
held constant across them, pushes the result into `SparkRelativeEncoderSim` /
`SparkAnalogSensorSim` (built below the SPARKs they name), applies battery sag,
and writes the gyro in supply-voltage → plant → yaw order with a bounded retry.
The sensor writes are post-conversion-factor values — metres and rotations, not
raw units. `first.robot.sim` still imports no vendor type.

**The gyro** gets its yaw signal raised to 1 kHz under an `isSimulation()` guard,
a constant drift rate, and **both** yaws zeroed at `simulationInit()` —
`setYaw`'s offset is integrated on top of whatever `setRawYaw` writes, so zeroing
one leaves the other's offset in every reading with nothing in the log to show
it.

**Logging** is ADR 0005's names: `/Drive/Chassis/{Desired,Measured}Velocities`,
`/Drive/Modules/{Desired,Measured}States` as the `SwerveModuleVelocity[]` the
visualiser wants, **and** `/Drive/Modules/<Corner>/...` named for a human, so a
corner/index mismatch is visible rather than latent. `/Sim/TruePose` and
`/Sim/ModuleSlip` under the simulation guard.

Every coroutine loop is a `while`. No built-in group is used, so none needs the
comment saying why.

## Judgement calls

- **`driveFieldRelative` lands here**, not in #60. The gyro is on this mechanism,
  so the conversion is; #60 owns the gamepad and the opmode.
- **`/Drive/Odometry/{GyroHeading,GyroRate}` is not written yet.** That subtree
  lands whole with the pose estimator, and ADR 0012 widens `GyroHeading` to
  `Rotation3d` — logging it as `Rotation2d` now would be one ticket of churn.
- **`Temp` and `Faults` are split per motor** (`DriveTemp`/`SteerTemp`,
  `DriveFaults`/`SteerFaults`). ADR 0005's module list already distinguishes
  drive from steer on five of its seven names; a module has two motors and one
  aggregate hides which one is hot.

## The blocker

**`InjectedSchedulerTest` is not deleted and ADR 0006's *the divergence pays*
citation is not repointed.** The test meant to subsume them cannot run.

Constructing a SPARK terminates the JVM: REVLib `2027.0.0-alpha-6`'s
`RevLibWpiBackendDriver` needs `fmt::v12::vformat` from `libwpiutil.so`, no
WPILib development build exports it, and the only WPILib release that does ships
no `telemetry-java`. `Drive`'s constructor builds four SPARK pairs, so the test
JVM dies before its first assertion — and so does `simulateJava`, and so would a
deploy. Evidence, versions checked and plan impact are on #59 and #54.

What still runs, and passes: the `first.robot.sim` suite, and the new
`SwerveModuleTest` covering the range fold through a static function that needs
no SPARK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzD9PgrkYKqQfKVjRqJjn