### PR TITLE
Know where the robot is, and let a driver take it there

### DIFF
--- a/docs/adr/0007-can-topology-and-frames.md
+++ b/docs/adr/0007-can-topology-and-frames.md
@@ -257,8 +257,11 @@ is exactly what would let somebody stop noticing that.
   goes through default to **50 Hz** on CAN 2.0
   (`com/ctre/phoenix6/hardware/core/CorePigeon2.java:667-680`), and
   `getAngularVelocityZWorld()` defaults to **10 Hz** (`:1625-1639`).
-  **[source]** ADR 0012 raises both to loop rate; this ADR budgets the
-  two frames that costs. Because our bus runs classic framing, the CAN
+  **[source]** ADR 0012 raises the heading and the rate to loop rate;
+  this ADR budgets the two frames that costs. The heading is read off
+  **yaw, pitch and roll** rather than the quaternion — ADR 0012 owns
+  why — so it is three signals in one frame rather than four in one.
+  **[unverified — that yaw, pitch and roll share one status frame]** Because our bus runs classic framing, the CAN
   2.0 column is the one that applies — the FD column's 100 Hz is not
   available to us and never will be while SPARKs share the bus.
 
@@ -449,8 +452,7 @@ them resolvable here.
   Priced in the Decision as a conditional row.
 
 - **"Pigeon2 yaw, 5 ms, ~200" → two frames, 400.** #28 wrote that
-  before pose estimation was decided. ADR 0012 reads `getRotation3d()`,
-  which refreshes the four quaternion signals, **and**
+  before pose estimation was decided. ADR 0012 reads the heading **and**
   `getAngularVelocityZWorld()`, and raises both to loop rate. Those are
   two different frames — their CAN 2.0 defaults differ, 50 Hz against
   10 Hz (`CorePigeon2.java:667-680, 1625-1639`) **[source]** — so two

--- a/docs/adr/0008-closed-loop-on-the-spark.md
+++ b/docs/adr/0008-closed-loop-on-the-spark.md
@@ -5,6 +5,12 @@
 Accepted — 2026-08-26. Superseded in part by ADR 0011: `kA` returns at
 drivebase level, riding `arbFeedforward` on the path-following path only.
 
+Amended 2026-08-28. *Writes a setpoint, never a voltage* holds for
+everything the software drives and no longer for the driver: **teleop
+drives the wheels open loop, on a voltage**. Steer is untouched, and so
+is every path-following and autonomous velocity. See *Teleop drives open
+loop*.
+
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
 `v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. REVLib
@@ -54,9 +60,56 @@ encoder**, with position wrapping enabled. **Drive velocity** closes on
 the SPARK against the **primary encoder**, with `kS` + `kV` + `kP`.
 **[decided]**
 
-Robot-side code **writes a setpoint, never a voltage**. Once per loop a
-module hands the SPARK an angle and a speed; the controller does the
-rest at 1 kHz. Nothing in `Drive` computes a motor output.
+Robot-side code **writes a setpoint, never a voltage** — with one
+exception, the driver's own wheel speed, which the next section owns.
+Once per loop a module hands the SPARK an angle and a speed; the
+controller does the rest at 1 kHz. Nothing in `Drive` computes a gain
+against a measurement.
+
+### Teleop drives open loop, and the driver's stick is asymptotically linear
+
+The **driver's** wheel speed is written as a voltage —
+`SparkBase.setVoltage(double)` — and not as a velocity setpoint.
+**[decided]** Every other velocity in the project, path following
+included, still closes the loop described above.
+
+A velocity loop answers a shove by spinning the wheel back to its
+setpoint, and answers a wheel that is being dragged by pushing harder.
+A driver reads both as the robot arguing with them. Open loop, the
+stick is the wheel: the same stick position is the same wheel speed
+whatever the carpet is doing, and there is no gain to be mistuned in
+the one mode where a mistuned gain is a match. **[field — 604,
+*Thumbs on the Sticks*, FIRST Mentor Conference 2025]**
+
+It is a **voltage rather than a throttle** because a SPARK holds a
+commanded voltage against bus sag: a stick position means the same
+wheel speed on a flat battery as on a fresh one. The mapping is the
+free-speed relationship inverted — the share of `MAX_VELOCITY` the
+driver asked for, spent as that share of the rail — so it carries no
+gain and duplicates no term that lives in `FeedForwardConfig`.
+
+**The stick curve is asymptotically linear with a deadband, not linear
+and not squared.** **[decided]** Square and cubic curves buy low-speed
+resolution and are too sensitive at the speeds a driver spends most of
+a match at; a linear rescale leaves a flat zone whose edge the driver
+cannot feel. The curve used eases out of zero over a width and then
+converges onto the straight line, so there is one line for muscle
+memory rather than a new one each season. **[field — 604, slide 17]**
+
+```java
+(axis - width * Math.tanh(axis / width)) / (1 - width * Math.tanh(1 / width))
+```
+
+with a hard zero below `DRIVER_DEADBAND`, which is **narrower than the
+curve's width** and lands where the curve is already worth about a
+fifth of a percent — so the step is one nobody can feel, and a resting
+stick still commands exactly nothing. That last part is not cosmetic: a
+small non-zero ω steers all four modules to a rotation angle and holds
+them there.
+
+Both constants are **provisional and are meant to stay put once set**.
+Consistency across seasons is the whole argument; rewriting the drive
+curve every year is what the argument is against.
 
 ### Steer closes on the analog absolute encoder
 
@@ -462,6 +515,17 @@ does not exist — the Flex's analog input reaches the supply rail.
 *Do not re-raise* unless steer noise is measured to matter and
 `dFilter` is measured not to fix it.
 
+### Closing the driver's velocity loop, for consistency with autonomous
+
+One control path is simpler to describe than two, and the drive `kS`
+and `kV` are configured either way because autonomous needs them. It is
+rejected on what a driver feels rather than on what the code looks
+like: the loop's corrections are indistinguishable from the robot
+disobeying, and they arrive exactly when a driver is fighting for
+position. **[field]** The cost is that the teleop path never exercises
+the drive velocity loop, so a `kV` that is wrong is found in autonomous
+or in characterisation and not by driving — which ADR 0009 already owns.
+
 ### `arbFeedforward` as the home for `kS` and `kV`
 
 It works — the term is applied in Volts, after the control mode and
@@ -491,6 +555,12 @@ restated here because a controller mid-tune is exactly when someone
 reaches for the GUI.
 
 ## Source
+
+The teleop amendment — open-loop voltage for the driver's wheel speed
+and the asymptotically-linear stick curve — is
+[#60](https://github.com/Drew-Robotics/2027beta/issues/60), on 604's
+*Thumbs on the Sticks* (Eugene Fang, FIRST Mentor Conference 2025),
+whose slide 17 carries the scaling argument.
 
 Decided in
 [#29](https://github.com/Drew-Robotics/2027beta/issues/29), which

--- a/docs/adr/0012-pose-estimation-and-vision.md
+++ b/docs/adr/0012-pose-estimation-and-vision.md
@@ -6,6 +6,13 @@ Accepted — 2026-08-26. The *Open* item asking whether the bus can pay
 for five 200 Hz Pigeon signals is answered by ADR 0007, which budgets
 the two frames they ride, and now sits under *Consequences*.
 
+Amended 2026-08-28, on two things found while building it. The heading
+is read off yaw, pitch and roll rather than `getRotation3d()`, because
+nothing drives the quaternion in simulation — see *3d wherever
+possible*. And `odometryUpdate` stamps the odometry buffer itself,
+because `update()` keys it on a clock the vision seam does not use —
+see *Traps*.
+
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
 `v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. Phoenix 6
@@ -135,12 +142,24 @@ is not.
 
 Four consequences, all of them mechanical:
 
-- **`Drive.getGyroHeading()` returns `Rotation3d`** — an amendment to
-  ADR 0011, which had it as `Rotation2d`. ⚠️ #20 flagged this as
-  assuming a full 3d rotation from the Pigeon2 and could not check.
-  **It is there**: `Pigeon2.getRotation3d()` returns
+- **`Drive.getGyroHeading()` returns `Rotation3d`**, built as
+  `new Rotation3d(roll, pitch, yaw)` over the Pigeon's own three angle
+  signals — an amendment to ADR 0011, which had it as `Rotation2d`.
+  **[decided]** The Pigeon does expose a full 3d rotation, which is
+  what #20 could not check: `Pigeon2.getRotation3d()` returns
   `new Rotation3d(getQuaternion())` (`Pigeon2.java:252-253`)
-  **[source — Phoenix 6]**, over the four quaternion signals.
+  **[source — Phoenix 6]**.
+
+  **We do not call it, because its four quaternion signals are never
+  driven in simulation.** With the HAL up and a `Pigeon2SimState` fed
+  `setRawYaw`, `setPitch` and `setRoll`, `getYaw()`, `getPitch()`,
+  `getRoll()` and `getAngularVelocityZWorld()` all read back the values
+  written, while `getQuatW/X/Y/Z()` stay at `0.0` with a status of `OK`
+  and `getRotation3d()` answers `Quaternion(1, 0, 0, 0)`. **[executed —
+  Phoenix 6 `26.50.0-alpha-1`]** Yaw, pitch and roll are the same
+  rotation on hardware and the only one that exists on a laptop, so they
+  are one code path for both. They are the heading signals the frequency
+  call below raises.
 - **`getEstimatedPose()` flattens once, internally, to `Pose2d`**, with
   `getEstimatedPose3d()` alongside it for the log. Every consumer we
   have is 2d — ADR 0011's follower, its along-track/cross-track
@@ -298,13 +317,13 @@ So the frequency is raised explicitly, with
 place ADR 0004 configures the rest of the hardware. **[decided]**
 
 **The same applies to the heading itself, and that is the more
-surprising half.** `getRotation3d()` goes through `getQuaternion()`,
-which refreshes four signals — `BaseStatusSignal.refreshAll(m_quatWGetter,
-m_quatXGetter, m_quatYGetter, m_quatZGetter)` (`Pigeon2.java:261-263`)
-**[source — Phoenix 6]** — and those default to 50 Hz on CAN 2.0 and
-100 Hz on CAN FD (`CorePigeon2.java:679-680`) **[source — Phoenix 6]**.
-Odometry at 200 Hz against a 100 Hz heading is reading every value
-twice. The signals go in the same `setUpdateFrequencyForAll` call.
+surprising half.** Pigeon signals default well below our loop — the
+quaternion signals at 50 Hz on CAN 2.0 and 100 Hz on CAN FD
+(`CorePigeon2.java:679-680`) **[source — Phoenix 6]**, and the yaw,
+pitch and roll signals the heading is built from at their own defaults
+**[unverified — not read at this Phoenix version]**. Odometry at 200 Hz
+against a 100 Hz heading is reading every value twice. The heading
+signals go in the same `setUpdateFrequencyForAll` call as the rate.
 
 ⚠️ **No source ticket raised the heading signal's rate** — #27 asked
 only about `AngularVelocityZWorld`. This half was surfaced by reading
@@ -451,14 +470,13 @@ older spellings appears anywhere.
   getting it wrong; it does not change who decides it, and it is still
   unresolved upstream. See Open.
 
-- **The CAN frame budget grows by five signals at 200 Hz** — the yaw
-  rate and the four quaternion components. That is a real cost against a
-  bus that already carries eight SPARKs and the Pigeon's constant
-  diagnostic overhead, and it lands on ADR 0007, **which pays for it**:
-  five signals are **two frames**, because `getRotation3d()`'s four
-  quaternion signals share one and the yaw rate is the other, and 0007
-  budgets both at 5 ms for **400 frames/s**. **[unverified —
-  arithmetic; ADR 0007 owns the budget]**
+- **The CAN frame budget grows by the heading and the yaw rate at
+  200 Hz.** That is a real cost against a bus that already carries eight
+  SPARKs and the Pigeon's constant diagnostic overhead, and it lands on
+  ADR 0007, **which pays for it**: the heading signals share one frame
+  and the yaw rate is the other, and 0007 budgets both at 5 ms for
+  **400 frames/s**. **[unverified — arithmetic, and the grouping of yaw,
+  pitch and roll into one status frame; ADR 0007 owns the budget]**
 
 - **No simulated vision source and no wiring test.** A sim source feeding
   ADR 0010's true pose back noisily would mostly test
@@ -494,8 +512,23 @@ older spellings appears anywhere.
   timestamp *and* the yaw-rate buffer's keys, or `subMap` returns empty
   and every frame fails closed instead.
 
+  ⚠️ **`update()` would not have keyed the buffer on that clock**, which
+  is why `odometryUpdate` calls
+  `updateWithTime(Timer.getMonotonicTimestamp(), ...)` on both estimators
+  instead. **[decided]** `PoseEstimator3d.update()` passes
+  `MathSharedStore.getTimestamp()` (`PoseEstimator3d.java:381`)
+  **[source]**, and `RobotBase` points `MathShared.getTimestamp()` at
+  `Timer.getTimestamp()`
+  (`wpilibj/src/main/java/org/wpilib/framework/RobotBase.java:72-89`)
+  **[source]** — the modifiable one, not the monotonic one this trap
+  requires. The two are the same number until somebody calls
+  `RobotController.setTimeSource`. Stamping the update ourselves makes
+  the rule above a property of the code rather than a coincidence
+  between two libraries, and one clock read feeds both estimators, so
+  they cannot be keyed apart either.
+
   `/Drive/Vision/Age` is the diagnostic that makes this findable in one
-  glance.
+  glance, and it is computed against the same clock.
 
 - **The ~1 m sanity gate is recommended by javadoc, is not implemented,
   and must not be added.**
@@ -636,6 +669,17 @@ older spellings appears anywhere.
   symptom to notice, which is why `setUpdateFrequencyForAll` is not
   optional and why the fallback under Open is a matching sample rate
   rather than a silent default.
+
+- **`Pigeon2.getRotation3d()` compiles, is the obvious call, and is
+  identity for ever in simulation.** The evidence is under *Decision*.
+  What it looks like is a robot whose odometry translates and never
+  turns, and whose field-relative driving never rotates its frame —
+  under `simulateJava`, which is the only place most of this project is
+  ever run. Nothing throws, and every quaternion signal reports `OK`
+  while reading `0.0`. Read the heading off yaw, pitch and roll.
+  *Re-raise* when a Phoenix release drives the quaternion in
+  simulation, at which point the two are interchangeable and the
+  simpler call wins.
 
 - **Do not synthesise yaw rate by differencing `getGyroHeading()`.** It
   compiles and it is one line, which is the whole danger; Decision owns

--- a/src/main/java/first/robot/Constants.java
+++ b/src/main/java/first/robot/Constants.java
@@ -21,6 +21,8 @@ public final class Constants {
   // Every device is on this one bus. REVLib wants its .value, Phoenix wants CANBus.systemcore(n).
   public static final CANBus CAN_BUS = CANBus.CAN_S0;
 
+  public static final int DRIVER_PORT = 0;
+
   public static final Time RADIO_LOG_PERIOD = Seconds.of(5);
   public static final Time RADIO_TIMEOUT = Milliseconds.of(500);
 

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -112,9 +112,18 @@ public final class DriveConstants {
   public static final AngularVelocity MAX_ANGULAR_VELOCITY =
       RadiansPerSecond.of(MAX_VELOCITY.in(MetersPerSecond) / DRIVE_RADIUS.in(Meters));
 
-  // A stick that never quite returns to centre is the normal state of a used controller, and
-  // field-relative driving turns that offset into a robot that walks away from its driver.
-  public static final double DRIVER_DEADBAND = 0.1;
+  // The offset a used controller sits at with nobody touching it. Below this the command is
+  // exactly zero, because even a small omega steers all four modules to a rotation angle.
+  public static final double DRIVER_DEADBAND = 0.05;
+
+  // The width of the soft region in the stick curve. A linear rescale leaves a flat zone whose
+  // edge the driver cannot feel; easing out of zero over this much travel and then converging on
+  // the straight line keeps one line for muscle memory to learn.
+  public static final double DRIVER_CURVE_WIDTH = 0.15;
+
+  // A SPARK told to apply a voltage holds it against battery sag, so the driver's stick means the
+  // same wheel speed at the end of a match as at the start.
+  public static final Voltage NOMINAL_VOLTAGE = Volts.of(12);
 
   // The pose estimator's trust in the wheels as standard deviations over [x, y, z, theta], so
   // larger is less trust. WPILib's own defaults, until a bring-up drives a known distance and

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -6,7 +6,6 @@ package first.robot;
 
 import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.DegreesPerSecond;
-import static org.wpilib.units.Units.Hertz;
 import static org.wpilib.units.Units.Inches;
 import static org.wpilib.units.Units.KilogramSquareMeters;
 import static org.wpilib.units.Units.Kilograms;
@@ -14,18 +13,22 @@ import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Pounds;
+import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Rotations;
 import static org.wpilib.units.Units.Volts;
 
 import first.robot.sim.SwerveSimConfig;
 import org.wpilib.framework.RobotBase;
 import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.linalg.Matrix;
+import org.wpilib.math.linalg.VecBuilder;
+import org.wpilib.math.numbers.N1;
+import org.wpilib.math.numbers.N4;
 import org.wpilib.math.system.DCMotor;
 import org.wpilib.units.measure.Angle;
 import org.wpilib.units.measure.AngularVelocity;
 import org.wpilib.units.measure.Current;
 import org.wpilib.units.measure.Distance;
-import org.wpilib.units.measure.Frequency;
 import org.wpilib.units.measure.LinearVelocity;
 import org.wpilib.units.measure.Mass;
 import org.wpilib.units.measure.MomentOfInertia;
@@ -100,12 +103,27 @@ public final class DriveConstants {
       MetersPerSecond.of(
           DCMotor.getNeoVortex(1).freeSpeed / DRIVE_REDUCTION * WHEEL_RADIUS.in(Meters));
 
+  // Half the diagonal between opposite modules: the radius the corner wheels travel on in a spin.
+  private static final Distance DRIVE_RADIUS =
+      Meters.of(Math.hypot(TRACK_WIDTH.in(Meters), WHEELBASE.in(Meters)) / 2);
+
+  // The spin that puts the corner modules at MAX_VELOCITY. Asking for this and a translation at
+  // once oversaturates the wheels, which desaturateWheelVelocities then scales back together.
+  public static final AngularVelocity MAX_ANGULAR_VELOCITY =
+      RadiansPerSecond.of(MAX_VELOCITY.in(MetersPerSecond) / DRIVE_RADIUS.in(Meters));
+
+  // A stick that never quite returns to centre is the normal state of a used controller, and
+  // field-relative driving turns that offset into a robot that walks away from its driver.
+  public static final double DRIVER_DEADBAND = 0.1;
+
+  // The pose estimator's trust in the wheels as standard deviations over [x, y, z, theta], so
+  // larger is less trust. WPILib's own defaults, until a bring-up drives a known distance and
+  // measures the drift.
+  public static final Matrix<N4, N1> STATE_STD_DEVS = VecBuilder.fill(0.1, 0.1, 0.1, 0.1);
+
   // A pose estimator tuned against a gyro that never wanders is tuned against a robot that does
   // not exist. Roughly a degree a minute, which is the order a Pigeon2 drifts at.
   public static final AngularVelocity GYRO_SIM_DRIFT = DegreesPerSecond.of(1.0 / 60);
-  // The documented ceiling for a Phoenix signal. CTRE simulates CAN latency, and a lagged gyro
-  // makes odometry look broken for a reason that is not our code.
-  public static final Frequency GYRO_SIM_UPDATE_RATE = Hertz.of(1000);
 
   public record DriveMotorGains(double kP, double kS, double kV) {}
 

--- a/src/main/java/first/robot/PoseEstimator.java
+++ b/src/main/java/first/robot/PoseEstimator.java
@@ -1,0 +1,110 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.wpilib.units.Units.Seconds;
+
+import org.wpilib.math.estimator.SwerveDrivePoseEstimator3d;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Pose3d;
+import org.wpilib.math.geometry.Rotation3d;
+import org.wpilib.math.geometry.Transform3d;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModulePosition;
+import org.wpilib.math.linalg.Matrix;
+import org.wpilib.math.linalg.VecBuilder;
+import org.wpilib.math.numbers.N1;
+import org.wpilib.math.numbers.N4;
+import org.wpilib.system.Timer;
+import org.wpilib.telemetry.TelemetryTable;
+
+public final class PoseEstimator {
+  // Never read: visionUpdate sets the vision deviations on every call, before the estimator uses
+  // them. An infinite sigma is a gain of exactly zero, which is what a measurement that somehow
+  // arrived without one deserves.
+  private static final Matrix<N4, N1> UNSET_VISION_STD_DEVS =
+      VecBuilder.fill(
+          Double.POSITIVE_INFINITY,
+          Double.POSITIVE_INFINITY,
+          Double.POSITIVE_INFINITY,
+          Double.POSITIVE_INFINITY);
+
+  private final SwerveDrivePoseEstimator3d fused;
+  private final SwerveDrivePoseEstimator3d odometryOnly;
+  private final TelemetryTable odometryLog;
+  private final TelemetryTable visionLog;
+
+  public PoseEstimator(
+      SwerveDriveKinematics kinematics,
+      Rotation3d gyroHeading,
+      SwerveModulePosition[] modulePositions,
+      TelemetryTable log) {
+    odometryLog = log.getTable("Odometry");
+    visionLog = log.getTable("Vision");
+    fused = estimator(kinematics, gyroHeading, modulePositions);
+    odometryOnly = estimator(kinematics, gyroHeading, modulePositions);
+  }
+
+  private static SwerveDrivePoseEstimator3d estimator(
+      SwerveDriveKinematics kinematics,
+      Rotation3d gyroHeading,
+      SwerveModulePosition[] modulePositions) {
+    return new SwerveDrivePoseEstimator3d(
+        kinematics,
+        gyroHeading,
+        modulePositions,
+        Pose3d.kZero,
+        DriveConstants.STATE_STD_DEVS,
+        UNSET_VISION_STD_DEVS);
+  }
+
+  public void odometryUpdate(Rotation3d gyroHeading, SwerveModulePosition... modulePositions) {
+    // Stamped here rather than left to update(), which keys its buffer on a clock whose time base
+    // something else is allowed to replace. Vision hands us instants on this one, and a buffer
+    // keyed on a different clock drops every measurement without a word. One read, so the two
+    // estimators are also keyed identically.
+    double now = Timer.getMonotonicTimestamp();
+    fused.updateWithTime(now, gyroHeading, modulePositions);
+    odometryOnly.updateWithTime(now, gyroHeading, modulePositions);
+  }
+
+  public void visionUpdate(Pose3d measurement, double timestamp, Matrix<N4, N1> stdDevs) {
+    // Logged before the measurement lands, so the residual is the disagreement the estimator was
+    // handed rather than what the Kalman gain left of it.
+    visionLog.log("Measurement", measurement, Pose3d.struct);
+    fused
+        .sampleAt(timestamp)
+        .ifPresent(at -> visionLog.log("Residual", measurement.minus(at), Transform3d.struct));
+    visionLog.log("Age", Seconds.of(Timer.getMonotonicTimestamp() - timestamp));
+    visionLog.log("StdDevs", stdDevs.getData());
+
+    fused.addVisionMeasurement(measurement, timestamp, stdDevs);
+  }
+
+  public void resetPose(Pose2d pose) {
+    // Both, always. Reset one and the gap between them stops being wheel error and becomes wheel
+    // error plus this offset, with nothing in the log to say which.
+    var widened = new Pose3d(pose);
+    fused.resetPose(widened);
+    odometryOnly.resetPose(widened);
+  }
+
+  public Pose2d getEstimatedPose() {
+    return fused.getEstimatedPosition().toPose2d();
+  }
+
+  public Pose3d getEstimatedPose3d() {
+    return fused.getEstimatedPosition();
+  }
+
+  public Pose3d getOdometryOnlyPose() {
+    return odometryOnly.getEstimatedPosition();
+  }
+
+  public void log() {
+    odometryLog.log("EstimatedPose", getEstimatedPose3d(), Pose3d.struct);
+    odometryLog.log("OdometryOnlyPose", getOdometryOnlyPose(), Pose3d.struct);
+  }
+}

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import org.wpilib.backend.DataLogTelemetryBackend;
 import org.wpilib.backend.NetworkTablesTelemetryBackend;
 import org.wpilib.command3.Scheduler;
+import org.wpilib.command3.button.CommandGamepad;
 import org.wpilib.driverstation.DriverStation;
 import org.wpilib.driverstation.MatchState;
 import org.wpilib.driverstation.RobotState;
@@ -46,6 +47,8 @@ import org.wpilib.util.AlertDataJNI.AlertInfo;
  */
 public class Robot extends OpModeRobot {
   public final Drive drive;
+  public final PoseEstimator poseEstimator;
+  public final CommandGamepad driver = new CommandGamepad(Constants.DRIVER_PORT);
 
   private final TelemetryTable robotLog;
   private final TelemetryTable canLog;
@@ -128,6 +131,15 @@ public class Robot extends OpModeRobot {
             TelemetryRegistry.getTable("/Sim"),
             Scheduler.getDefault());
 
+    // Seeded from the hardware rather than from zeroes, so the first odometry update measures a
+    // step the wheels actually took.
+    poseEstimator =
+        new PoseEstimator(
+            drive.getKinematics(),
+            drive.getGyroHeading(),
+            drive.getModulePositions(),
+            TelemetryRegistry.getTable("/Drive"));
+
     // The safe state of the whole robot is one block a reviewer can read, rather than something
     // they have to know idle() would have defaulted to.
     drive.setDefaultCommand(drive.idle());
@@ -194,6 +206,11 @@ public class Robot extends OpModeRobot {
     allianceUnknown.set(RobotState.isDSAttached() && alliance.isEmpty());
 
     drive.log();
+
+    // Before the scheduler, and the order is load-bearing: every command that runs below reads a
+    // pose built from this iteration's module positions rather than the previous one's.
+    poseEstimator.odometryUpdate(drive.getGyroHeading(), drive.getModulePositions());
+    poseEstimator.log();
 
     // Nothing in OpModeRobot runs the Commands v3 scheduler, so a mechanism whose scheduler is
     // never run has a default command that never starts and commands that never execute.

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -11,6 +11,7 @@ import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.units.Units.Volts;
 
+import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.configs.Pigeon2Configuration;
@@ -29,14 +30,19 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
+import org.wpilib.command3.NeedsNameBuilderStage;
 import org.wpilib.command3.Scheduler;
+import org.wpilib.command3.button.CommandGamepad;
 import org.wpilib.framework.RobotBase;
 import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.geometry.Rotation3d;
 import org.wpilib.math.geometry.Translation2d;
 import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModulePosition;
 import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.math.util.MathUtil;
 import org.wpilib.simulation.RoboRioSim;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Angle;
@@ -53,6 +59,7 @@ public class Drive implements Mechanism {
   private final Pigeon2 gyro;
   private final TelemetryTable chassisLog;
   private final TelemetryTable moduleLog;
+  private final TelemetryTable odometryLog;
   private final TelemetryTable simLog;
   private final Scheduler scheduler;
 
@@ -75,6 +82,7 @@ public class Drive implements Mechanism {
     this.scheduler = scheduler;
     chassisLog = log.getTable("Chassis");
     moduleLog = log.getTable("Modules");
+    odometryLog = log.getTable("Odometry");
 
     var gains = DriveConstants.gains();
     var corners = corners(config);
@@ -88,6 +96,18 @@ public class Drive implements Mechanism {
     gyro = new Pigeon2(config.gyroId(), CANBus.systemcore(Constants.CAN_BUS.value));
     Hardware.configurePhoenix(
         "SwerveGyro", () -> gyro.getConfigurator().apply(new Pigeon2Configuration()));
+    // Every one of these publishes below the loop rate at its Phoenix default — the yaw rate at
+    // 10 Hz — so odometry unraised reads the same frame several times over and counts the repeats
+    // as new information.
+    Hardware.configurePhoenix(
+        "SwerveGyroSignals",
+        () ->
+            BaseStatusSignal.setUpdateFrequencyForAll(
+                Constants.LOOP_PERIOD.asFrequency(),
+                gyro.getYaw(),
+                gyro.getPitch(),
+                gyro.getRoll(),
+                gyro.getAngularVelocityZWorld()));
 
     if (RobotBase.isSimulation()) {
       physics = new SwerveDriveSim(DriveConstants.simConfig());
@@ -95,7 +115,6 @@ public class Drive implements Mechanism {
       simDrift = Radians.zero();
       simYaw = Radians.zero();
       lastTrueRotation = physics.truePose().getRotation();
-      retry(() -> gyro.getYaw().setUpdateFrequency(DriveConstants.GYRO_SIM_UPDATE_RATE));
       for (int i = 0; i < MODULES; i++) {
         driveLoops[i] =
             OnboardLoopSim.velocity(gains.drive().kP(), gains.drive().kS(), gains.drive().kV());
@@ -132,25 +151,52 @@ public class Drive implements Mechanism {
   }
 
   public Command driveRobotRelative(Supplier<ChassisVelocities> velocities) {
+    return robotRelative(velocities).named("Drive.DriveRobotRelative");
+  }
+
+  public Command driveFieldRelative(Supplier<ChassisVelocities> velocities) {
+    return fieldRelative(velocities).named("Drive.DriveFieldRelative");
+  }
+
+  public Command driverControl(CommandGamepad driver) {
+    return fieldRelative(() -> driverVelocities(driver)).named("Drive.DriverControl");
+  }
+
+  public Command driverControlRobotRelative(CommandGamepad driver) {
+    return robotRelative(() -> driverVelocities(driver)).named("Drive.DriverControlRobotRelative");
+  }
+
+  private NeedsNameBuilderStage robotRelative(Supplier<ChassisVelocities> velocities) {
     return run(coroutine -> {
           while (true) {
             setVelocities(velocities.get());
             coroutine.yield();
           }
         })
-        .whenCanceled(this::stopModules)
-        .named("Drive.DriveRobotRelative");
+        .whenCanceled(this::stopModules);
   }
 
-  public Command driveFieldRelative(Supplier<ChassisVelocities> velocities) {
+  private NeedsNameBuilderStage fieldRelative(Supplier<ChassisVelocities> velocities) {
     return run(coroutine -> {
           while (true) {
-            setVelocities(velocities.get().toRobotRelative(getHeading()));
+            setVelocities(velocities.get().toRobotRelative(getGyroHeading().toRotation2d()));
             coroutine.yield();
           }
         })
-        .whenCanceled(this::stopModules)
-        .named("Drive.DriveFieldRelative");
+        .whenCanceled(this::stopModules);
+  }
+
+  // Away from the driver station is +x and to the driver's left is +y, and both stick axes read
+  // the other way round.
+  private static ChassisVelocities driverVelocities(CommandGamepad driver) {
+    return new ChassisVelocities(
+        DriveConstants.MAX_VELOCITY.times(stick(-driver.getLeftY())),
+        DriveConstants.MAX_VELOCITY.times(stick(-driver.getLeftX())),
+        DriveConstants.MAX_ANGULAR_VELOCITY.times(stick(-driver.getRightX())));
+  }
+
+  private static double stick(double axis) {
+    return MathUtil.applyDeadband(axis, DriveConstants.DRIVER_DEADBAND);
   }
 
   public void setVelocities(ChassisVelocities velocities) {
@@ -172,10 +218,24 @@ public class Drive implements Mechanism {
     desiredVelocities = new ChassisVelocities();
   }
 
-  public Rotation2d getHeading() {
-    // The yaw signal still publishes at its Phoenix default, which is below the loop rate, so
-    // this reads one frame stale during a fast spin until the pose estimator raises it.
-    return new Rotation2d(gyro.getYaw().getValue());
+  public Rotation3d getGyroHeading() {
+    // Not Pigeon2.getRotation3d(): through 26.50.0-alpha-1 nothing drives the four quaternion
+    // signals it reads in simulation, so it answers identity there for ever. Yaw, pitch and roll
+    // are driven, and are the same three numbers.
+    return new Rotation3d(
+        gyro.getRoll().getValue(), gyro.getPitch().getValue(), gyro.getYaw().getValue());
+  }
+
+  public SwerveModulePosition[] getModulePositions() {
+    var positions = new SwerveModulePosition[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      positions[i] = modules[i].getPosition();
+    }
+    return positions;
+  }
+
+  public SwerveDriveKinematics getKinematics() {
+    return kinematics;
   }
 
   public ChassisVelocities getVelocities() {
@@ -191,6 +251,8 @@ public class Drive implements Mechanism {
     // reads, and a corner/index mismatch is only visible if both are written.
     moduleLog.log("DesiredStates", desiredStates(), SwerveModuleVelocity.struct);
     moduleLog.log("MeasuredStates", measured, SwerveModuleVelocity.struct);
+    odometryLog.log("GyroHeading", getGyroHeading(), Rotation3d.struct);
+    odometryLog.log("GyroRate", gyro.getAngularVelocityZWorld().getValue());
     for (var module : modules) {
       module.log();
     }

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -27,6 +27,7 @@ import first.robot.Hardware;
 import first.robot.sim.OnboardLoopSim;
 import first.robot.sim.SwerveDriveSim;
 import java.util.Arrays;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
@@ -42,7 +43,6 @@ import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.kinematics.SwerveDriveKinematics;
 import org.wpilib.math.kinematics.SwerveModulePosition;
 import org.wpilib.math.kinematics.SwerveModuleVelocity;
-import org.wpilib.math.util.MathUtil;
 import org.wpilib.simulation.RoboRioSim;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Angle;
@@ -151,35 +151,37 @@ public class Drive implements Mechanism {
   }
 
   public Command driveRobotRelative(Supplier<ChassisVelocities> velocities) {
-    return robotRelative(velocities).named("Drive.DriveRobotRelative");
+    return robotRelative(velocities, this::setVelocities).named("Drive.DriveRobotRelative");
   }
 
   public Command driveFieldRelative(Supplier<ChassisVelocities> velocities) {
-    return fieldRelative(velocities).named("Drive.DriveFieldRelative");
+    return fieldRelative(velocities, this::setVelocities).named("Drive.DriveFieldRelative");
   }
 
+  // Open loop, unlike everything else that drives: a velocity loop answers a shove by spinning the
+  // wheel back to its setpoint, and a driver reads that as the robot arguing. A voltage does what
+  // the stick did.
   public Command driverControl(CommandGamepad driver) {
-    return fieldRelative(() -> driverVelocities(driver)).named("Drive.DriverControl");
+    return fieldRelative(() -> driverVelocities(driver), this::setOpenLoopVelocities)
+        .named("Drive.DriverControl");
   }
 
-  public Command driverControlRobotRelative(CommandGamepad driver) {
-    return robotRelative(() -> driverVelocities(driver)).named("Drive.DriverControlRobotRelative");
-  }
-
-  private NeedsNameBuilderStage robotRelative(Supplier<ChassisVelocities> velocities) {
+  private NeedsNameBuilderStage robotRelative(
+      Supplier<ChassisVelocities> velocities, Consumer<ChassisVelocities> output) {
     return run(coroutine -> {
           while (true) {
-            setVelocities(velocities.get());
+            output.accept(velocities.get());
             coroutine.yield();
           }
         })
         .whenCanceled(this::stopModules);
   }
 
-  private NeedsNameBuilderStage fieldRelative(Supplier<ChassisVelocities> velocities) {
+  private NeedsNameBuilderStage fieldRelative(
+      Supplier<ChassisVelocities> velocities, Consumer<ChassisVelocities> output) {
     return run(coroutine -> {
           while (true) {
-            setVelocities(velocities.get().toRobotRelative(getGyroHeading().toRotation2d()));
+            output.accept(velocities.get().toRobotRelative(getGyroHeading().toRotation2d()));
             coroutine.yield();
           }
         })
@@ -195,20 +197,38 @@ public class Drive implements Mechanism {
         DriveConstants.MAX_ANGULAR_VELOCITY.times(stick(-driver.getRightX())));
   }
 
-  private static double stick(double axis) {
-    return MathUtil.applyDeadband(axis, DriveConstants.DRIVER_DEADBAND);
+  // Asymptotically linear: the curve eases out of zero over the width and then converges onto the
+  // straight line, so there is one line for muscle memory to learn rather than a flat zone whose
+  // edge the driver has to find. The hard zero is narrower than the easing and lands where the
+  // curve is already worth about a fifth of a percent, so it is a step nobody can feel.
+  static double stick(double axis) {
+    if (Math.abs(axis) < DriveConstants.DRIVER_DEADBAND) {
+      return 0;
+    }
+    double width = DriveConstants.DRIVER_CURVE_WIDTH;
+    return (axis - width * Math.tanh(axis / width)) / (1 - width * Math.tanh(1 / width));
   }
 
   public void setVelocities(ChassisVelocities velocities) {
-    desiredVelocities = velocities;
-    var target = velocities.discretize(Constants.LOOP_PERIOD.in(Seconds));
-    var states =
-        SwerveDriveKinematics.desaturateWheelVelocities(
-            kinematics.toSwerveModuleVelocities(target),
-            DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
+    var states = moduleTargets(velocities);
     for (int i = 0; i < MODULES; i++) {
       modules[i].setVelocity(states[i]);
     }
+  }
+
+  public void setOpenLoopVelocities(ChassisVelocities velocities) {
+    var states = moduleTargets(velocities);
+    for (int i = 0; i < MODULES; i++) {
+      modules[i].setOpenLoopVelocity(states[i]);
+    }
+  }
+
+  private SwerveModuleVelocity[] moduleTargets(ChassisVelocities velocities) {
+    desiredVelocities = velocities;
+    var target = velocities.discretize(Constants.LOOP_PERIOD.in(Seconds));
+    return SwerveDriveKinematics.desaturateWheelVelocities(
+        kinematics.toSwerveModuleVelocities(target),
+        DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
   }
 
   public void stopModules() {
@@ -285,9 +305,18 @@ public class Drive implements Mechanism {
         double wheelSpeed =
             state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters);
         double sensor = modules[i].toSensorRotations(state[i].azimuth());
-        boolean closing = modules[i].isClosingLoops();
-        driveVolts[i] = closing ? driveLoops[i].calculate(wheelSpeed, SUB_STEP) : 0;
-        steerVolts[i] = closing ? steerLoops[i].calculate(sensor, SUB_STEP) : 0;
+        if (!modules[i].isClosingLoops()) {
+          driveVolts[i] = 0;
+          steerVolts[i] = 0;
+        } else {
+          // An open-loop module was written a voltage, so there is no loop here to model: the
+          // number the SPARK was handed is the number the plant gets.
+          driveVolts[i] =
+              modules[i].isOpenLoop()
+                  ? SwerveModule.openLoopVolts(modules[i].getDriveSetpoint())
+                  : driveLoops[i].calculate(wheelSpeed, SUB_STEP);
+          steerVolts[i] = steerLoops[i].calculate(sensor, SUB_STEP);
+        }
       }
       state = physics.update(driveVolts, steerVolts, SUB_STEP);
     }

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -6,8 +6,10 @@ package first.robot.mechanisms;
 
 import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Celsius;
+import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Rotations;
+import static org.wpilib.units.Units.Volts;
 
 import com.revrobotics.PersistMode;
 import com.revrobotics.RelativeEncoder;
@@ -46,6 +48,7 @@ final class SwerveModule {
   private SwerveModuleVelocity desired = new SwerveModuleVelocity();
   private double steerSetpointRotations;
   private boolean closingLoops;
+  private boolean openLoop;
 
   SwerveModule(SwerveModuleConfig config, ModuleGains gains, TelemetryTable log) {
     name = config.name();
@@ -150,13 +153,35 @@ final class SwerveModule {
   }
 
   void setVelocity(SwerveModuleVelocity target) {
+    command(target, false);
+  }
+
+  void setOpenLoopVelocity(SwerveModuleVelocity target) {
+    command(target, true);
+  }
+
+  private void command(SwerveModuleVelocity target, boolean open) {
     var angle = getAngle();
     desired = target.optimize(angle).cosineScale(angle);
     steerSetpointRotations = toSensorRotations(desired.angle, steerOffsetRotations);
+    openLoop = open;
 
-    driveController.setSetpoint(desired.velocity, ControlType.kVelocity);
+    if (open) {
+      driveMotor.setVoltage(openLoopVolts(desired.velocity));
+    } else {
+      driveController.setSetpoint(desired.velocity, ControlType.kVelocity);
+    }
     steerController.setSetpoint(steerSetpointRotations, ControlType.kPosition);
     closingLoops = true;
+  }
+
+  // The share of the free speed the driver asked for, spent as the same share of the rail. It is
+  // the free-speed relationship inverted, which is what makes a stick position mean a wheel speed
+  // without a loop measuring anything.
+  static double openLoopVolts(double velocity) {
+    return DriveConstants.NOMINAL_VOLTAGE.in(Volts)
+        * velocity
+        / DriveConstants.MAX_VELOCITY.in(MetersPerSecond);
   }
 
   void stop() {
@@ -213,6 +238,10 @@ final class SwerveModule {
 
   boolean isClosingLoops() {
     return closingLoops;
+  }
+
+  boolean isOpenLoop() {
+    return openLoop;
   }
 
   double getDriveSetpoint() {

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -27,6 +27,7 @@ import first.robot.DriveConstants.ModuleGains;
 import first.robot.DriveConstants.SwerveModuleConfig;
 import first.robot.Hardware;
 import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModulePosition;
 import org.wpilib.math.kinematics.SwerveModuleVelocity;
 import org.wpilib.math.util.MathUtil;
 import org.wpilib.telemetry.TelemetryTable;
@@ -176,6 +177,10 @@ final class SwerveModule {
 
   SwerveModuleVelocity getVelocity() {
     return new SwerveModuleVelocity(driveEncoder.getVelocity().get(), getAngle());
+  }
+
+  SwerveModulePosition getPosition() {
+    return new SwerveModulePosition(driveEncoder.getPosition().get(), getAngle());
   }
 
   SwerveModuleVelocity getDesiredVelocity() {

--- a/src/main/java/first/robot/opmode/DefaultTeleop.java
+++ b/src/main/java/first/robot/opmode/DefaultTeleop.java
@@ -12,9 +12,5 @@ import org.wpilib.opmode.Teleop;
 public class DefaultTeleop implements OpMode {
   public DefaultTeleop(Robot robot) {
     robot.drive.setDefaultCommand(robot.drive.driverControl(robot.driver));
-
-    // Field-relative has no answer for a heading the driver has stopped believing. Holding the
-    // bumper drives the chassis frame directly; releasing it goes back.
-    robot.driver.leftBumper().whileTrue(robot.drive.driverControlRobotRelative(robot.driver));
   }
 }

--- a/src/main/java/first/robot/opmode/DefaultTeleop.java
+++ b/src/main/java/first/robot/opmode/DefaultTeleop.java
@@ -1,0 +1,20 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.opmode;
+
+import first.robot.Robot;
+import org.wpilib.opmode.OpMode;
+import org.wpilib.opmode.Teleop;
+
+@Teleop
+public class DefaultTeleop implements OpMode {
+  public DefaultTeleop(Robot robot) {
+    robot.drive.setDefaultCommand(robot.drive.driverControl(robot.driver));
+
+    // Field-relative has no answer for a heading the driver has stopped believing. Holding the
+    // bumper drives the chassis frame directly; releasing it goes back.
+    robot.driver.leftBumper().whileTrue(robot.drive.driverControlRobotRelative(robot.driver));
+  }
+}

--- a/src/test/java/first/robot/InjectedSchedulerTest.java
+++ b/src/test/java/first/robot/InjectedSchedulerTest.java
@@ -5,12 +5,14 @@
 package first.robot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wpilib.units.Units.Microseconds;
 import static org.wpilib.units.Units.Milliseconds;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.SchedulerEvent;
+import org.wpilib.command3.Trigger;
 import org.wpilib.system.RobotController;
 import org.wpilib.system.Timer;
 import org.wpilib.units.measure.Time;
@@ -83,6 +86,37 @@ class InjectedSchedulerTest {
     assertTrue(
         Scheduler.getDefault().getRunningCommands().isEmpty(),
         "it reached the process-wide scheduler");
+  }
+
+  // The one assertion in this project written in cycles rather than in time. An edge is a
+  // statement about scheduler cycles at any loop rate, and rewriting it as a duration would make
+  // it wrong.
+  @Test
+  void anEdgeTriggerIsHighForExactlyOneCycleSoWhileTrueCancelsImmediately() {
+    var edgeBound = new Stopwatch(scheduler);
+    var levelBound = new Stopwatch(scheduler);
+    var edgeCommand = edgeBound.holdFor(HOLD);
+    var levelCommand = levelBound.holdFor(HOLD);
+    var pressed = new AtomicBoolean();
+    var button = new Trigger(scheduler, pressed::get);
+    button.onTrue(levelCommand);
+    button.risingEdge().whileTrue(edgeCommand);
+
+    advance();
+    pressed.set(true);
+    advance();
+
+    assertTrue(
+        scheduler.isScheduledOrRunning(edgeCommand), "the rising edge never started its command");
+
+    advance();
+
+    assertFalse(
+        scheduler.isScheduledOrRunning(edgeCommand),
+        "the edge was still high a cycle after it rose, so whileTrue would be safe on it");
+    assertTrue(
+        scheduler.isScheduledOrRunning(levelCommand),
+        "the signal itself went low, so the cancellation was not the edge's doing");
   }
 
   private void advance() {

--- a/src/test/java/first/robot/PoseEstimatorTest.java
+++ b/src/test/java/first/robot/PoseEstimatorTest.java
@@ -1,0 +1,214 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Centimeters;
+import static org.wpilib.units.Units.Degrees;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Seconds;
+
+import first.robot.sim.OnboardLoopSim;
+import first.robot.sim.SimModuleState;
+import first.robot.sim.SwerveDriveSim;
+import first.robot.sim.SwerveSimConfig;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wpilib.internal.UnitTelemetry;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Pose3d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.geometry.Rotation3d;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModulePosition;
+import org.wpilib.math.linalg.VecBuilder;
+import org.wpilib.math.util.MathUtil;
+import org.wpilib.system.Timer;
+import org.wpilib.telemetry.MockTelemetryBackend;
+import org.wpilib.telemetry.TelemetryRegistry;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.Measure;
+import org.wpilib.units.measure.Angle;
+import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Time;
+
+class PoseEstimatorTest {
+  private static final int MODULES = 4;
+  private static final double SUB_STEP = DriveConstants.CONTROLLER_PERIOD.in(Seconds);
+  private static final int SUB_STEPS =
+      (int) Math.round(Constants.LOOP_PERIOD.in(Seconds) / SUB_STEP);
+
+  private static final double DRIVE_VOLTS = 6.0;
+  private static final Time SETTLE = Seconds.of(1);
+  private static final Time TRAVEL = Seconds.of(2);
+
+  // Two integrators over the same kinematics disagree only by their step: the model runs at the
+  // controller period and odometry exponentiates one twist per robot loop.
+  private static final Distance TRANSLATION_TOLERANCE = Centimeters.of(2);
+  private static final Angle ROTATION_TOLERANCE = Degrees.of(1);
+
+  private final SwerveSimConfig config = DriveConstants.simConfig();
+  private final SwerveDriveSim sim = new SwerveDriveSim(config);
+  private final SwerveDriveKinematics kinematics =
+      new SwerveDriveKinematics(config.moduleLocations());
+  private final double[] driveVolts = new double[MODULES];
+  private final double[] steerVolts = new double[MODULES];
+  private final OnboardLoopSim[] steerLoops = new OnboardLoopSim[MODULES];
+
+  private MockTelemetryBackend backend;
+  private PoseEstimator estimator;
+  private SimModuleState[] state;
+
+  @BeforeEach
+  void buildEstimator() {
+    // RobotBase's constructor is what registers this handler, and no Tier 1 test builds one.
+    TelemetryRegistry.registerTypeHandler(
+        Measure.class, (table, name, value) -> UnitTelemetry.log(table, name, value));
+    backend = new MockTelemetryBackend();
+
+    var gains = DriveConstants.SIM_GAINS.steer();
+    for (int i = 0; i < MODULES; i++) {
+      // The wrap range is the converted analog sensor's, which is not Rotation2d's.
+      steerLoops[i] = OnboardLoopSim.position(gains.kP(), gains.kD(), gains.dFilter(), 0, 1);
+    }
+    state = sim.moduleStates();
+
+    estimator =
+        new PoseEstimator(
+            kinematics, gyroHeading(), modulePositions(), new TelemetryTable(backend));
+  }
+
+  @AfterEach
+  void clearRegistry() {
+    TelemetryRegistry.reset();
+    backend.close();
+  }
+
+  @Test
+  void theOdometryOnlyPoseTracksTheSimulationsTruePoseThroughATranslation() {
+    // An eighth of a turn off the frame's axis, so the run displaces both axes rather than one.
+    steerTo(0.125);
+    advance(SETTLE);
+    Arrays.fill(driveVolts, DRIVE_VOLTS);
+    advance(TRAVEL);
+
+    var truePose = sim.truePose();
+    assertTrue(truePose.getTranslation().getNorm() > 1, "the robot barely moved: " + truePose);
+    assertTracks(truePose);
+  }
+
+  @Test
+  void theOdometryOnlyPoseTracksTheSimulationsTruePoseThroughASpin() {
+    var targets = kinematics.toSwerveModuleVelocities(new ChassisVelocities(0, 0, 1));
+    for (int i = 0; i < MODULES; i++) {
+      steerLoops[i].setSetpoint(MathUtil.inputModulus(targets[i].angle.getRotations(), 0, 1));
+    }
+    advance(SETTLE);
+    Arrays.fill(driveVolts, DRIVE_VOLTS);
+    advance(TRAVEL);
+
+    // Asserted on the rate rather than the heading: the spin passes a full turn, and a wrapped
+    // heading can read as barely moved.
+    assertTrue(
+        Math.abs(sim.trueVelocity().omega) > 5, "the robot is not turning: " + sim.trueVelocity());
+    assertTracks(sim.truePose());
+  }
+
+  @Test
+  void resettingThePoseMovesBothEstimatorsTogether() {
+    var seed = new Pose2d(3, 4, Rotation2d.fromDegrees(90));
+
+    estimator.resetPose(seed);
+
+    assertPose(seed, estimator.getEstimatedPose(), "the fused estimate did not reset");
+    assertPose(
+        seed,
+        estimator.getOdometryOnlyPose().toPose2d(),
+        "the odometry-only estimate did not reset");
+  }
+
+  @Test
+  void aVisionMeasurementMovesOnlyTheFusedEstimate() {
+    advance(SETTLE);
+    double captured = Timer.getMonotonicTimestamp();
+    advance(SETTLE);
+
+    estimator.visionUpdate(
+        new Pose3d(new Pose2d(1, 0, Rotation2d.kZero)),
+        captured,
+        VecBuilder.fill(0.1, 0.1, 0.1, 0.1));
+
+    assertEquals(
+        0,
+        estimator.getOdometryOnlyPose().getX(),
+        1e-9,
+        "the odometry-only estimate was told about vision");
+    assertTrue(
+        estimator.getEstimatedPose().getX() > 0.1,
+        "the fused estimate ignored the measurement: " + estimator.getEstimatedPose());
+  }
+
+  private void assertTracks(Pose2d truePose) {
+    var odometry = estimator.getOdometryOnlyPose().toPose2d();
+    assertPose(truePose, odometry, "odometry lost the simulation");
+  }
+
+  private static void assertPose(Pose2d expected, Pose2d actual, String message) {
+    assertEquals(
+        expected.getX(), actual.getX(), TRANSLATION_TOLERANCE.in(Meters), message + ", in x");
+    assertEquals(
+        expected.getY(), actual.getY(), TRANSLATION_TOLERANCE.in(Meters), message + ", in y");
+    assertEquals(
+        expected.getRotation().getDegrees(),
+        actual.getRotation().getDegrees(),
+        ROTATION_TOLERANCE.in(Degrees),
+        message + ", in heading");
+  }
+
+  private void steerTo(double sensorRotations) {
+    for (var loop : steerLoops) {
+      loop.setSetpoint(sensorRotations);
+    }
+  }
+
+  private void advance(Time duration) {
+    int ticks = (int) Math.round(duration.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));
+    for (int i = 0; i < ticks; i++) {
+      tick();
+      estimator.odometryUpdate(gyroHeading(), modulePositions());
+    }
+  }
+
+  private void tick() {
+    for (int step = 0; step < SUB_STEPS; step++) {
+      for (int i = 0; i < MODULES; i++) {
+        // Rotation2d reads back over [-0.5, 0.5) and the analog sensor over [0, 1).
+        double azimuth = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
+        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP);
+      }
+      state = sim.update(driveVolts, steerVolts, SUB_STEP);
+    }
+  }
+
+  // What the Pigeon reports on a flat floor: the model's own heading, widened.
+  private Rotation3d gyroHeading() {
+    return new Rotation3d(sim.truePose().getRotation());
+  }
+
+  private SwerveModulePosition[] modulePositions() {
+    var positions = new SwerveModulePosition[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      positions[i] =
+          new SwerveModulePosition(
+              state[i].wheelPositionRad() * DriveConstants.WHEEL_RADIUS.in(Meters),
+              state[i].azimuth());
+    }
+    return positions;
+  }
+}

--- a/src/test/java/first/robot/mechanisms/DriverInputTest.java
+++ b/src/test/java/first/robot/mechanisms/DriverInputTest.java
@@ -1,0 +1,65 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.Volts;
+
+import first.robot.DriveConstants;
+import org.junit.jupiter.api.Test;
+
+class DriverInputTest {
+  private static final double DEADBAND = DriveConstants.DRIVER_DEADBAND;
+
+  @Test
+  void aRestingStickCommandsExactlyNothing() {
+    assertEquals(0, Drive.stick(0));
+    assertEquals(0, Drive.stick(DEADBAND * 0.99));
+    assertEquals(0, Drive.stick(-DEADBAND * 0.99));
+  }
+
+  @Test
+  void fullTravelIsFullOutputAndTheCurveIsOdd() {
+    assertEquals(1, Drive.stick(1), 1e-9);
+    assertEquals(-1, Drive.stick(-1), 1e-9);
+    assertEquals(-Drive.stick(0.42), Drive.stick(-0.42), 1e-9);
+  }
+
+  @Test
+  void theStepAtTheDeadbandIsSmallerThanTheDriverCanFeel() {
+    // What a linear rescale spends here is the deadband itself, and the whole reason for the
+    // curve is that the driver cannot feel where that edge is.
+    assertTrue(
+        Drive.stick(DEADBAND * 1.001) < 0.01,
+        "the curve steps to " + Drive.stick(DEADBAND * 1.001) + " at the deadband");
+  }
+
+  @Test
+  void theCurveIsSoftBelowTheStraightLineAndConvergesOntoIt() {
+    // Soft where a driver is placing the robot, and indistinguishable from linear where they are
+    // crossing the field.
+    assertTrue(Drive.stick(0.2) < 0.2 / 2, "the curve is not soft at a fifth of travel");
+    assertTrue(Drive.stick(0.9) > 0.9 * 0.9, "the curve has not converged by nine tenths");
+
+    double previous = 0;
+    for (double axis = DEADBAND; axis <= 1; axis += 0.01) {
+      double output = Drive.stick(axis);
+      assertTrue(output >= previous, "the curve went backwards at " + axis);
+      previous = output;
+    }
+  }
+
+  @Test
+  void theTopWheelSpeedIsTheWholeRail() {
+    assertEquals(
+        DriveConstants.NOMINAL_VOLTAGE.in(Volts),
+        SwerveModule.openLoopVolts(DriveConstants.MAX_VELOCITY.in(MetersPerSecond)),
+        1e-9,
+        "the fastest the wheel goes is not the whole battery");
+    assertEquals(0, SwerveModule.openLoopVolts(0), 1e-9);
+  }
+}


### PR DESCRIPTION
Closes #60 — the end of the tracer bullet, minus the one criterion REVLib still blocks.

## What landed

- **`PoseEstimator`**, a plain class beside `Drive` on `Robot`. Two `SwerveDrivePoseEstimator3d` instances, same gyro rotation and same module positions into both, vision into one, and `resetPose` resets both.
- **3d throughout, flattened once** in `getEstimatedPose()`. `resetPose(Pose2d)` widens inside.
- **`visionUpdate(Pose3d, double, Matrix<N4, N1>)`** — mandatory std devs, and nothing calls it. No flag, no alert, no branch for vision-absent.
- **Odometry before the scheduler** in `robotPeriodic()`, with the comment saying why.
- **`Drive.getGyroHeading()` / `getModulePositions()` / `getKinematics()`**, plus `SwerveModule.getPosition()`.
- **`/Drive/Odometry/{EstimatedPose,OdometryOnlyPose,GyroHeading,GyroRate}`** and **`/Drive/Vision/{Measurement,Residual,Age,StdDevs}`** — the whole subtree ADR 0005 and ADR 0012 name.
- **`DefaultTeleop`** — a default-command override and one binding, both through `CommandGamepad`.
- **Tier 1** — odometry-only pose tracks the model's true pose through a translation and a spin; a vision measurement moves the fused estimate only; both estimators reset together; and a rising edge is high for exactly one scheduler cycle.

## Two ADR amendments, both found by building it

**1. `Pigeon2.getRotation3d()` is identity for ever in simulation.** With the HAL up and a `Pigeon2SimState` fed `setRawYaw`, `setPitch` and `setRoll`, `getYaw()`, `getPitch()`, `getRoll()` and `getAngularVelocityZWorld()` all read back the values written, while `getQuatW/X/Y/Z()` stay at `0.0` with a status of `OK`. Phoenix drives the Euler angles and not the quaternion, so `getRotation3d()` answers `Quaternion(1, 0, 0, 0)` no matter what the robot does. **[executed — Phoenix 6 `26.50.0-alpha-1`]**

`getGyroHeading()` is therefore `new Rotation3d(roll, pitch, yaw)`. Same rotation on hardware, and the only one that exists on a laptop. The `setUpdateFrequencyForAll` call raises those three and the yaw rate to the loop rate, unconditionally — ADR 0007's two-frame budget line is unchanged in intent, and its assumption that yaw, pitch and roll share one status frame is tagged `[unverified]` rather than asserted.

**2. `PoseEstimator3d.update()` keys its buffer on the wrong clock.** It passes `MathSharedStore.getTimestamp()`, which `RobotBase` points at `Timer.getTimestamp()` — the modifiable clock, not the `getMonotonicTimestamp()` ADR 0012's own trap tells a season to stamp vision with. Identical until somebody calls `setTimeSource`. `odometryUpdate` now calls `updateWithTime(Timer.getMonotonicTimestamp(), ...)`, so the trap's rule is structural, and one clock read feeds both estimators.

Both are written into ADR 0012 (and the heading half into ADR 0007). Veto either and the code follows.

## Departures worth a second look

- **`Drive` owns the stick-to-velocity mapping** and so imports `CommandGamepad`. That is the flagship's shape, and it is what keeps the opmode to bindings and a default-command override. The alternative puts a private helper in the opmode, which reads like a worse fit for *"bindings, a default-command override and nothing else"*.
- **A left-bumper robot-relative override.** Nothing asked for a second driving mode. The criterion asks for a trigger only one opmode cares about, and this is the only honest binding available before autonomous exists. One line to cut if you would rather not have it.
- **The simulation-only 1 kHz raise on the yaw signal is deleted.** It existed because nothing set a real-robot rate; now something does, at the loop rate ADR 0012 and ADR 0007 decide. Its original comment worried about simulated CAN latency — that becomes checkable the day `simulateJava` runs again, and is not checkable today.
- **`DRIVER_DEADBAND` and `MAX_ANGULAR_VELOCITY` are new provisional constants.** Both are starting values a bring-up replaces.

## Not met

**Drivable under `simulateJava`.** Constructing a SPARK still terminates the JVM:

```
libREVLibWpi.so: undefined symbol: _ZN3fmt3v127vformatB5cxx11ENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE
```

Confirmed again on this branch — the program boots, opens its log, and dies in `Drive`'s constructor. `Drive.getGyroHeading()`, `Drive.getModulePositions()` and `SwerveModule.getPosition()` are written and unrun for the same reason; the Tier 1 assertions go through `SwerveDriveSim` and need none of them. Evidence and plan impact are on #59 and #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzD9PgrkYKqQfKVjRqJjn


---

## Follow-up: teleop drives open loop, and the stick curve is 604's

Two changes on review feedback, both in `fb6a2d5`.

**The left-bumper robot-relative override is deleted.** `DefaultTeleop` is now a default-command override and nothing else.

**Teleop writes the drive wheels a voltage, not a velocity setpoint** — an amendment to ADR 0008's *writes a setpoint, never a voltage*, for the one path a human is closing the loop on. A velocity loop answers a shove by spinning the wheel back to its setpoint and a drag by pushing harder, and a driver reads both as the robot arguing. Steer is untouched, and every velocity the software commands — path following included — still closes on the SPARK.

Voltage rather than throttle because a SPARK holds a commanded voltage against bus sag, so a stick position means the same wheel speed on a flat battery as on a fresh one. The mapping is the free-speed relationship inverted, so it carries no gain and duplicates nothing in `FeedForwardConfig`.

**The stick curve is asymptotically linear with a deadband**, per *Thumbs on the Sticks* slide 17 — not a linear rescale, which leaves a flat zone whose edge the driver cannot feel, and not square or cubic, which are too sensitive at the speeds a driver spends a match at.

```
 stick   linear rescale   asympt. linear
  0.04            0.000            0.000
  0.05            0.000            0.002
  0.10            0.053            0.015
  0.20            0.158            0.082
  0.50            0.474            0.412
  0.90            0.895            0.882
  1.00            1.000            1.000
```

The hard zero sits at `DRIVER_DEADBAND = 0.05`, narrower than `DRIVER_CURVE_WIDTH = 0.15`, so it lands where the curve is already worth two parts in a thousand — a step nobody can feel, and a resting stick still commands exactly nothing. That last part is not cosmetic: a small omega steers all four modules to a rotation angle and holds them there.

`Drive.stick` and `SwerveModule.openLoopVolts` are static, so Tier 1 asserts on both without a SPARK — 29 tests now.

**This is a third decision-level change in one PR**, on a different ADR from the other two. If you would rather it landed on its own ticket against ADR 0008, say so and I will split it out.
