### PR TITLE
Drive a closed square, and land the wiring net a SPARK still blocks

### DIFF
--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -5,7 +5,8 @@
 Accepted — 2026-08-26. Superseded in part by ADR 0011, which owns the
 `/Drive/Following` and `/Auto` signals. The *Open* item asking whether
 an alert is visible during a match is answered by #22 and now sits
-under *Consequences*.
+under *Consequences*. Amended 2026-08-28: the signal list gains
+`/Check`, the opmode-scoped root the utility checks report under.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -158,6 +159,7 @@ second path to the same fact, carrying less. **[decided]**
 /Drive/Odometry/{EstimatedPose,OdometryOnlyPose,GyroHeading,GyroRate}
 /Drive/Following/{Setpoint,AlongTrackError,CrossTrackError,HeadingError,TimedOut}
 /Auto/{RoutineName,PlannedPath,TimeElapsed}
+/Check/DrivePath/{Residual,ResidualDistance,ResidualRotation,Complete}
 ```
 
 `OdometryOnlyPose` sits beside `EstimatedPose` on purpose: with both
@@ -168,6 +170,15 @@ across the field and a wheel that slipped look identical.
 The `Following` and `Auto` subtrees are ADR 0011's, including why the
 error is decomposed rather than logged as x and y, and why `Setpoint`
 is one struct rather than a pose and a velocity.
+
+`/Check` is opmode-scoped like `/Auto`, and is not a mechanism subtree:
+`DrivePathCheck` drives a closed square, so the pose it ends on is the
+odometry error, and that number belongs to the check rather than to the
+drive. It is written off the odometry-only estimate, because a vision
+update would otherwise correct the residual away and leave the check
+reporting perfect wheels. `Complete` earns its place by separating a
+residual from a run that finished from one a disable cut in half — the
+two are the same four bytes otherwise. **[decided]**
 
 **Per mechanism**, for every mechanism we ever add: setpoint,
 measurement, applied output, current, temperature, faults, current

--- a/docs/adr/0006-commands-v3-house-style.md
+++ b/docs/adr/0006-commands-v3-house-style.md
@@ -4,7 +4,10 @@
 
 Accepted — 2026-08-26. Amended in part by ADR 0009: the `@Utility` rule
 is a supervision requirement, not an on-blocks one. Amended 2026-08-27:
-the payoff for injecting a `Scheduler` has been collected.
+the payoff for injecting a `Scheduler` has been collected. Amended
+2026-08-28: an opmode's bindings are scoped to the Driver Station's
+selection rather than to the opmode object, so an opmode that binds a
+trigger unbinds it in `close()`.
 
 Claim tags are defined in the index. `[source]` claims here were read at
 `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -284,7 +287,18 @@ scope is fixed in its constructor (`Trigger.java:112`, read back at
 (`Trigger.java:564-565` calls `BindingScope.createNarrowestScope`).
 **[source]** So a trigger held as a `Robot` field is global-scoped and
 never unbound, while a binding made on it inside an opmode constructor is
-opmode-scoped and is still torn down when the opmode exits.
+opmode-scoped.
+
+**Opmode-scoped means the operator's selection, not the opmode object.**
+`ForOpmode.active()` compares against `RobotState.getOpModeId()` — what
+is picked on the Driver Station (`BindingScope.java:70-74`).
+**[source]** Selecting something else ends the scope and the bindings
+go. *Disabling* does not: `OpModeRobot` closes the opmode and forces a
+rebuild on the enabled→disabled edge while leaving the selection alone
+(`OpModeRobot.java:659-665`, `:744-766`). **[source]** So **an opmode
+that binds a trigger overrides `close()` and unbinds it**, or every
+re-enable leaves the previous run's binding live beside the new one —
+see *Traps*.
 
 **`CommandGamepad`, not `CommandXboxController`.** Both upstream
 references use the layout-neutral form — `faceUp()`, `rightBumper()`
@@ -408,10 +422,46 @@ the compile-time net **[decided]** — see Traps.
   reintroduces exactly the coupling the injected `Scheduler` was taken to
   remove — and it does it in a class that otherwise looks correct.
 
+- **A disable rebuilds the opmode and leaves its bindings behind.** The
+  binding scope is the Driver Station's *selection*
+  (`BindingScope.java:70-74`), and `OpModeRobot` destroys and rebuilds
+  the opmode object on the enabled→disabled edge without changing it
+  (`OpModeRobot.java:659-665`). **[source]** None of the three sweeps
+  fire, because all three test that same still-active scope:
+  `Trigger.clearStaleBindings` (`Trigger.java:438`, called from `poll`
+  at `:393`), `Scheduler.cancelStaleBindings` (`Scheduler.java:825`) and
+  `Scheduler.unbindStaleTriggers` (`:836`). **[source]** The second
+  enable therefore runs the first run's binding *and* the rebuilt one.
+  On `DrivePathCheck` that is two copies of the same square interrupting
+  each other a leg per loop, finishing in a tenth of the time, and both
+  writing a near-zero residual that reads as perfect odometry. The fix
+  is `close() { trigger.unbind(); }`, which cancels the bound commands
+  and clears the bindings (`Trigger.java:537-546`). **[source]** Read
+  out of the sources named, not run: the REVLib native blocks
+  constructing a `Robot`, so no opmode in this project has executed.
+
 - **Names are mandatory, so an unnamed command is a compile error, not a
   bad log.** This is a trap only in the sense that it surprises: the
   builder stages are the enforcement, and there is no way to opt out for
   a quick test.
+
+## Open
+
+- **A shared `Robot`-field trigger has no per-opmode teardown.**
+  `Trigger.unbind()` clears *every* binding on the trigger
+  (`Trigger.java:537-546`) **[source]**, and there is no per-binding
+  removal API, so an opmode cannot drop its own binding without taking
+  every other opmode's with it. The trigger behind
+  `CommandGamepad.faceUp()` is cached per button and per event loop
+  (`CommandGenericHID.java:147-151`) **[source]**, so it is shared by
+  construction: the first `driver.faceUp().onTrue(...)` written in an
+  opmode inherits the duplicate-on-re-enable trap above with nothing to
+  override. Nothing in this repo binds a shared trigger in an opmode
+  yet — `DefaultTeleop` only sets a default command — so this is a hole
+  ahead of us rather than a live defect. **Unblocked by** the first
+  opmode that needs one, which forces the choice: upstream grows
+  per-binding removal, or the house style rules that an opmode binds
+  only triggers it constructed itself.
 
 ## Rejected
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,8 +48,8 @@ worth different amounts when one of them turns out to be wrong.
 | [0002](0002-loop-rate-and-jvm.md) | 200 Hz loop, no JVM tuning, no loop-count assumptions | **Accepted** — 2026-08-26 |
 | [0003](0003-project-and-package-structure.md) | Project and package structure | **Accepted** — 2026-08-26 |
 | [0004](0004-config-as-code.md) | Config-as-code | **Accepted** — 2026-08-26 |
-| [0005](0005-telemetry-and-log-schema.md) | Telemetry and the log | **Accepted** — 2026-08-26 |
-| [0006](0006-commands-v3-house-style.md) | Commands v3 house style | **Accepted** — 2026-08-26 |
+| [0005](0005-telemetry-and-log-schema.md) | Telemetry and the log | **Accepted** — 2026-08-28 |
+| [0006](0006-commands-v3-house-style.md) | Commands v3 house style | **Accepted** — 2026-08-28 |
 | [0007](0007-can-topology-and-frames.md) | CAN bus topology and frame allocation | **Accepted** — 2026-08-26 |
 | [0008](0008-closed-loop-on-the-spark.md) | Closed loop on the SPARK | **Accepted** — 2026-08-26 |
 | [0009](0009-characterisation-and-tuning.md) | Characterisation and tuning | **Accepted** — 2026-08-26 |

--- a/docs/commands-v3-house-style.md
+++ b/docs/commands-v3-house-style.md
@@ -297,8 +297,9 @@ failure in §12 that takes a whole routine down without an exception.
 ## 10. Opmodes hold bindings, and nothing else
 
 An opmode is a class the Driver Station constructs when the operator
-selects it, and closes when they select something else. Its constructor
-contains only:
+selects it, and closes when they select something else — **and also
+every time the robot is disabled**, which rebuilds it on the next loop.
+§11 is about what that costs. Its constructor contains only:
 
 - trigger bindings,
 - default-command overrides for this mode,
@@ -313,9 +314,16 @@ public class SweepAuto implements OpMode {
     enabled.onTrue(sweepAndScore(robot));
   }
 
+  @Override
+  public void close() {
+    enabled.unbind();
+  }
+
   private Command sweepAndScore(Robot robot) { /* ... */ }
 }
 ```
+
+That `close()` is not optional, and §11 says why.
 
 **Never construct hardware in an opmode.** Hardware lives on `Robot` and
 is built once.
@@ -351,8 +359,41 @@ cares about is built in that opmode.
 
 That is safe even though the `Robot` field outlives the opmode: a
 trigger's *binding* — the `onTrue(...)` call — records the scope it was
-made in, so a binding made inside an opmode constructor is torn down when
-that opmode exits, even though the trigger itself lives on forever.
+made in, so a binding made inside an opmode constructor is opmode-scoped
+even though the trigger itself lives on forever.
+
+**But "opmode-scoped" means the selection on the Driver Station, not the
+opmode object** — and those are not the same lifetime. Disabling the
+robot closes your opmode and builds a fresh one on the next loop, while
+the selection sits where the operator left it. The scope never went
+inactive, so nothing swept the old binding away, and now there are two:
+
+```
+select DrivePathCheck   → opmode #1 built, binds enabled → drivePath
+enable                  → one square runs
+disable                 → opmode #1 closed, #2 built, binds again
+enable                  → TWO squares run, on top of each other
+```
+
+Two `noRequirements` commands both start; their legs then interrupt each
+other one loop at a time, the whole script burns in a tenth of a second,
+and both report an odometry residual of nearly zero — which reads as
+*perfect*. Nothing throws. This is the worst shape a bug can have.
+
+So **an opmode that binds a trigger overrides `close()` and unbinds it**:
+
+```java
+@Override
+public void close() {
+  enabled.unbind();
+}
+```
+
+`unbind()` cancels every command bound to that trigger and clears the
+bindings, which is right for a trigger the opmode built and wrong for
+one it borrowed — so this only works on a trigger the opmode constructed
+itself. Binding a shared `Robot`-field trigger inside an opmode has no
+clean teardown today; if you need one, say so before you write it.
 
 The one-argument `new Trigger(...)` is right here and wrong in a
 mechanism (§6). An opmode is only ever constructed by the robot, against

--- a/src/main/java/first/robot/opmode/DrivePathCheck.java
+++ b/src/main/java/first/robot/opmode/DrivePathCheck.java
@@ -1,0 +1,94 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.opmode;
+
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.RadiansPerSecond;
+import static org.wpilib.units.Units.Seconds;
+
+import first.robot.Robot;
+import org.wpilib.command3.Command;
+import org.wpilib.command3.Trigger;
+import org.wpilib.driverstation.RobotState;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Transform2d;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.opmode.OpMode;
+import org.wpilib.opmode.Utility;
+import org.wpilib.telemetry.TelemetryRegistry;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.measure.LinearVelocity;
+import org.wpilib.units.measure.Time;
+
+@Utility(group = "Checks", description = "Drives a closed square and reports the odometry residual")
+public class DrivePathCheck implements OpMode {
+  private static final LinearVelocity LEG_SPEED = MetersPerSecond.of(1);
+  private static final Time LEG_DURATION = Seconds.of(1.5);
+  private static final Time SETTLE = Seconds.of(0.5);
+  private static final Pose2d START = Pose2d.kZero;
+
+  // The square closes, so whatever pose the estimator reports at the end is the whole of the
+  // odometry error. Nothing here needs a ground truth, which is what makes it the same check on
+  // the floor as in simulation.
+  private static final ChassisVelocities[] SQUARE = {
+    leg(LEG_SPEED, MetersPerSecond.zero()),
+    leg(MetersPerSecond.zero(), LEG_SPEED),
+    leg(LEG_SPEED.unaryMinus(), MetersPerSecond.zero()),
+    leg(MetersPerSecond.zero(), LEG_SPEED.unaryMinus()),
+  };
+
+  private final Trigger enabled = new Trigger(RobotState::isEnabled);
+  private final TelemetryTable checkLog =
+      TelemetryRegistry.getTable("/Check").getTable("DrivePath");
+
+  public DrivePathCheck(Robot robot) {
+    enabled.onTrue(drivePath(robot));
+  }
+
+  // The scheduler unbinds a trigger when its opmode's id changes, and a disable does not change
+  // it: the framework tears this opmode down and builds a new one around a selection that stayed
+  // put. Without this, every re-enable leaves another live copy of the square racing the last.
+  @Override
+  public void close() {
+    enabled.unbind();
+  }
+
+  private static ChassisVelocities leg(LinearVelocity vx, LinearVelocity vy) {
+    return new ChassisVelocities(vx, vy, RadiansPerSecond.zero());
+  }
+
+  private Command drivePath(Robot robot) {
+    return Command.noRequirements(
+            coroutine -> {
+              robot.poseEstimator.resetPose(START);
+              // A residual left over from the previous run is indistinguishable from this run's
+              // until the run that produced it is over.
+              checkLog.log("Complete", false);
+
+              int leg = 0;
+              while (leg < SQUARE.length) {
+                var velocities = SQUARE[leg];
+                coroutine.await(
+                    robot.drive.driveRobotRelative(() -> velocities).withTimeout(LEG_DURATION));
+                leg++;
+              }
+
+              // A leg ends by cancelling its command, which drops the wheels rather than
+              // commanding zero, so the robot is still stopping when the fourth one ends. Read it
+              // there and the last leg's stopping distance reads as odometry error.
+              coroutine.wait(SETTLE);
+
+              // The odometry-only pose, not the fused one. A vision update would correct the
+              // residual away and leave this reporting perfect wheels.
+              var residual = robot.poseEstimator.getOdometryOnlyPose().toPose2d().minus(START);
+              checkLog.log("Residual", residual, Transform2d.struct);
+              checkLog.log("ResidualDistance", Meters.of(residual.getTranslation().getNorm()));
+              checkLog.log("ResidualRotation", residual.getRotation().getMeasure());
+              checkLog.log("Complete", true);
+            })
+        .named("Check.DrivePath");
+  }
+}

--- a/src/test/java/first/robot/WiringTest.java
+++ b/src/test/java/first/robot/WiringTest.java
@@ -1,0 +1,143 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Seconds;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.wpilib.hardware.hal.AllianceStationID;
+import org.wpilib.hardware.hal.OpModeOption;
+import org.wpilib.hardware.hal.RobotMode;
+import org.wpilib.simulation.DriverStationSim;
+import org.wpilib.simulation.SimHooks;
+import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Time;
+import org.wpilib.util.AlertDataJNI;
+import org.wpilib.util.AlertDataJNI.AlertInfo;
+
+// REVLib's libREVLibWpi.so needs fmt::v12::vformat, and no WPILib this project can compile against
+// exports it, so constructing a SPARK terminates the JVM with exit 127. Robot's constructor builds
+// eight of them, and the process dies before the first assertion — taking the rest of the suite in
+// the same executor with it. Delete this annotation when a SPARK can be constructed.
+@Disabled("constructing a SPARK terminates the JVM")
+@ResourceLock("timing")
+class WiringTest {
+  private static final String OPMODE = "DrivePathCheck";
+
+  // Short of the first leg, deliberately: the script drives a closed square, so a robot stepped
+  // through the whole of it ends where it started and displaces nothing.
+  private static final Time SCRIPT_SLICE = Seconds.of(1);
+
+  private static final Time SHUTDOWN = Seconds.of(5);
+
+  // Loose on purpose. Tier 1 owns every number in this project, and an assertion tight enough to
+  // say anything about the physics here would go red every time the physics changed.
+  private static final Distance MOVED = Meters.of(0.1);
+
+  @BeforeEach
+  void setUp() {
+    SimHooks.pauseTiming();
+    SimHooks.setProgramStarted(false);
+    DriverStationSim.resetData();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SimHooks.resumeTiming();
+  }
+
+  @Test
+  void theScriptedCheckDrivesTheRealRobot() throws InterruptedException {
+    // getAlerts() is process-wide and nothing clears it, so the alerts other classes raised on
+    // purpose are the starting state rather than a failure of this one.
+    var before = highAlerts();
+    var failure = new AtomicReference<Throwable>();
+    var robot = new Robot();
+    var thread = new Thread(robot::startCompetition);
+    thread.setUncaughtExceptionHandler((t, e) -> failure.set(e));
+
+    double displacement;
+    List<String> raised;
+    try {
+      thread.start();
+      SimHooks.waitForProgramStart();
+
+      // Attached with no alliance is itself a HIGH alert, so the alliance is part of standing the
+      // robot up rather than part of the scenario.
+      DriverStationSim.setDsAttached(true);
+      DriverStationSim.setAllianceStationId(AllianceStationID.BLUE_1);
+      DriverStationSim.notifyNewData();
+
+      var option = utilityOpMode();
+
+      // Selected first and enabled second, which is the order the operator does it in: the opmode
+      // is constructed on selection, and its enabled-trigger needs an edge to fire on.
+      DriverStationSim.setOpMode(option.id);
+      DriverStationSim.notifyNewData();
+      SimHooks.stepTiming(Constants.LOOP_PERIOD.in(Seconds));
+
+      DriverStationSim.setEnabled(true);
+      DriverStationSim.notifyNewData();
+      SimHooks.stepTiming(SCRIPT_SLICE.in(Seconds));
+
+      // Read before the teardown below, which closes the alerts it would otherwise be asked about.
+      displacement = robot.poseEstimator.getEstimatedPose().getTranslation().getNorm();
+      raised = new ArrayList<>(highAlerts());
+      raised.removeAll(before);
+    } finally {
+      robot.endCompetition();
+      thread.join((long) SHUTDOWN.in(Milliseconds));
+      robot.clearOpModes();
+      robot.close();
+    }
+
+    assertFalse(thread.isAlive(), "the robot loop did not exit");
+    // Before the displacement, which a robot whose thread died also fails, and less usefully.
+    assertNull(failure.get());
+    assertEquals(List.of(), raised);
+    assertTrue(
+        displacement > MOVED.in(Meters),
+        "expected displacement > " + MOVED.in(Meters) + ", was " + displacement);
+  }
+
+  private static OpModeOption utilityOpMode() {
+    var options = DriverStationSim.getOpModeOptions();
+    var option = Arrays.stream(options).filter(o -> OPMODE.equals(o.name)).findFirst().orElse(null);
+
+    assertNotNull(option, "no opmode named " + OPMODE + " in " + names(options));
+    assertEquals(RobotMode.UTILITY, option.getMode());
+    return option;
+  }
+
+  private static List<String> names(OpModeOption[] options) {
+    return Arrays.stream(options).map(o -> o.name).toList();
+  }
+
+  private static List<String> highAlerts() {
+    return Arrays.stream(AlertDataJNI.getAlerts())
+        .filter(a -> a.activeStartTime != 0 && a.level == AlertDataJNI.LEVEL_HIGH)
+        .map(WiringTest::id)
+        .toList();
+  }
+
+  private static String id(AlertInfo alert) {
+    return alert.group + "/" + alert.id;
+  }
+}


### PR DESCRIPTION
Closes part of #61. **Two of its eight criteria stay open**, and neither is this branch's to close — see *What is not met*.

## What this is

The scripted `@Utility` opmode ADR 0010 names and ADR 0013's Tier 2 drives, plus the Tier 2 test itself, disabled.

`DrivePathCheck` drives four legs at 1 m/s for 1.5 s each, composed out of `Drive.driveRobotRelative` with `noRequirements`. **The square closes**, so the pose it ends on is the whole of the odometry error and no ground truth is needed to see it — which is what makes it the same check on the floor as in simulation. It reports off the **odometry-only** estimate rather than the fused one, because a vision update would otherwise correct the residual away and leave the check reporting perfect wheels. It settles for half a second before reading: a leg ends by cancelling its command, and the fourth leg's stopping distance would otherwise be counted as error.

`/Check/DrivePath/{Residual,ResidualDistance,ResidualRotation,Complete}` is a new opmode-scoped root beside `/Auto`. ADR 0005 declared its signal list open, so this is an entry in it rather than a reversal. `Complete` separates a residual from a run that finished from one a disable cut in half; the two are otherwise the same four bytes.

## The blocker, re-checked today

Constructing a SPARK still terminates the JVM:

```
libREVLibWpi.so: undefined symbol: _ZN3fmt3v127vformat...   → exit 127
```

`libwpiutil.so` exports zero `fmt` symbols, REVLib still has exactly one 2027 publication, and `development-2027` has not moved off `358-gf90dfe8f4`. `Robot`'s constructor builds eight SPARKs, so **nothing that stands up the robot can run** — not the test, not `simulateJava`, not a deploy. That is a process death at the dynamic linker, not an exception, so it cannot be caught or contained.

`WiringTest` is therefore written whole and `@Disabled` at the class, with the symbol named at the line. Disabled rather than absent because it still compiles on every run, which is a real check against a floating `2027.+`. **Not one line of `DrivePathCheck` has executed** — the same standing `Drive.updateSim()` had in T4, where both review-caught bugs turned out to live.

## The docs change, and why it is the interesting half

Reviewing this found a defect in the **documented house pattern**, not just in the new code.

ADR 0006 claimed that a binding made in an opmode constructor "is still torn down when the opmode exits". It is torn down when the **selection** changes. `BindingScope.ForOpmode.active()` compares against `RobotState.getOpModeId()` — what the operator picked on the Driver Station (`BindingScope.java:70-74`). Disabling closes the opmode and forces a rebuild on the next loop while leaving that selection alone (`OpModeRobot.java:659-665`). The scope never goes inactive, so none of the three stale sweeps fire, and the second enable runs the first run's binding beside the new one.

On `DrivePathCheck` that is two `noRequirements` squares interrupting each other a leg per loop, the whole script burning in a tenth of a second, and **both writing a near-zero residual that reads as perfect odometry**. Nothing throws.

§10's `SweepAuto` example binds `enabled.onTrue(...)` exactly this way, so every autonomous copied from the teaching doc inherited it. Fixed by overriding `close()` to `unbind()`; recorded as a trap in ADR 0006 with the sources, taught in §11 with the sequence written out, and added to the `SweepAuto` example.

That leaves one thing genuinely open, now under an **Open** heading ADR 0006 did not have before: `unbind()` clears *every* binding on a trigger, and `CommandGamepad` caches its buttons (`CommandGenericHID.java:147-151`), so the first opmode to bind `driver.faceUp()` has no clean teardown. Nothing binds a shared trigger yet, so it is a hole ahead of us rather than a live defect.

Every claim above is read out of the sources it cites, at `cafb0cc79` — the commit ADR 0006 already pins. None of it has been run.

## What is not met

| Criterion | Status |
|---|---|
| Scripted `@Utility` opmode driving a hardcoded script, reporting odometry error | met |
| Inherits every house rule, never unattended, the same opmode a student runs | met |
| No numbers asserted at this tier | met |
| A failing sim test uploads its WPILOG | already met by #55; `logs/` is what feeds it |
| Tier 2 test constructs the real robot in process and headless | **written, cannot run** |
| Opmode discoverable by name in `getOpModeOptions()` | **written, cannot run** |
| Stepping `SimHooks` displaces the pose past a threshold | **written, cannot run** |
| Nothing throws, no `Alert` active at HIGH | **written, cannot run** |

All four are one `@Disabled` line away. **Unblocked by** REVLib republishing its native against a current WPILib development build, or WPILib restoring the `fmt` export. Neither is ours.

## Checks

`./gradlew build --continue` green: spotless, checkstyle, PMD, spotbugs and 22 Tier 1 tests pass, `WiringTest` skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzD9PgrkYKqQfKVjRqJjn
