### PR TITLE
Follow a path, and close the loop that says it was followed

### DIFF
--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -158,7 +158,7 @@ second path to the same fact, carrying less. **[decided]**
 /Drive/Modules/FrontLeft/{DriveOutput,DriveCurrent,SteerSetpoint,SteerAngle,SteerCurrent,Temp,Faults}
 /Drive/Odometry/{EstimatedPose,OdometryOnlyPose,GyroHeading,GyroRate}
 /Drive/Following/{Setpoint,AlongTrackError,CrossTrackError,HeadingError,TimedOut}
-/Auto/{RoutineName,PlannedPath,TimeElapsed}
+/Auto/{RoutineName,PlannedPath,TimeElapsed,ZoneEntry,Complete}
 /Check/DrivePath/{Residual,ResidualDistance,ResidualRotation,Complete}
 ```
 
@@ -169,7 +169,11 @@ across the field and a wheel that slipped look identical.
 
 The `Following` and `Auto` subtrees are ADR 0011's, including why the
 error is decomposed rather than logged as x and y, and why `Setpoint`
-is one struct rather than a pose and a velocity.
+is one struct rather than a pose and a velocity. `Complete` earns its
+place there for the same reason it does under `/Check` below, and
+`ZoneEntry` is the pose a routine's pose `Trigger` fired at — the one
+thing a time marker cannot report, written where the robot was rather
+than when the clock said.
 
 `/Check` is opmode-scoped like `/Auto`, and is not a mechanism subtree:
 `DrivePathCheck` drives a closed square, so the pose it ends on is the

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-Accepted — 2026-08-26. Amended by ADR 0012, which owns the pose
+Accepted — 2026-08-26. Amended 2026-08-28 by the implementation, in two
+places: the follow timeout's margin is settled under *the follower is
+WPILib's own interface* rather than left open, and the field-centre flip
+is written per sample rather than through
+`HolonomicTrajectory.transformBy`, which turns out not to express it —
+see the fourth entry under *Traps*.
+
+Amended by ADR 0012, which owns the pose
 estimator: `Drive.getGyroHeading()` returns a `Rotation3d` rather than a
 `Rotation2d`, and the estimator beside `Drive` is
 `SwerveDrivePoseEstimator3d`. Two statements below survive the widening
@@ -215,11 +222,12 @@ with **one change**:
 ```java
 public Command followPath(String pathName) {
   return run(coroutine -> {
-        var follower = new HolonomicPathFollower(trajectories.apply(pathName), pose, FOLLOWER_GAINS);
-        coroutine.fork(driveFieldRelative(follower::next));
-        var result = coroutine.waitUntil(follower::isDone, FOLLOW_TIMEOUT);
+        var follower = new HolonomicPathFollower(trajectories.apply(pathName), pose, PATH_FOLLOWER);
+        coroutine.fork(driveFieldRelative(follower::next, follower::acceleration));
+        var result = coroutine.waitUntil(follower::isDone, follower.timeout());
         telemetry.log("Following/TimedOut", result.timedOut());
       })
+      .whenCanceled(this::stopModules)
       .named("Drive.FollowPath[" + pathName + "]");
 }
 ```
@@ -250,6 +258,21 @@ against a defender never reports `isDone`, and the untimed
 `waitUntil` is documented to *"only return once the condition is met"*
 (`:658-669`) **[source]** — so one stuck path hangs the entire
 autonomous period with no recovery. **[decided]**
+
+The clock starts inside `waitUntil` — `var timer = Timer.createStarted()`
+(`:723`) **[source]** — not at the command's start, so the value is a
+**margin over the trajectory's `duration`**, not an absolute. The margin
+is **2 s**: the worst settling time the two committed paths take past
+their own duration in simulation, rounded up. **[executed]** That figure
+is dominated by the drive lagging its velocity setpoint with `kA`
+configured zero, so it shrinks when ADR 0009 produces a `kA`.
+
+`isDone` is not the clock alone. A follower that reports done the
+instant `duration` elapses reports done for a robot held against a
+defender at the start of the path, which makes the timeout unreachable
+and hands the next command a robot nowhere near where it assumes. It is
+the clock **and** arrival inside a position and heading tolerance, both
+in the same config record as the gains. **[decided]**
 
 The three PID gains the follower uses live in a **config record next to
 the follower**, per ADR 0004 — not on `Drive`, because a second
@@ -477,14 +500,24 @@ produce it. ADR 0009 owns that.
   path that tracks perfectly on a straight run and diverges the moment
   the robot rotates.
 
-- **A `Transform2d` cannot express the blue-corner flip.**
-  `HolonomicTrajectory.transformBy(Transform2d)`
-  (`HolonomicTrajectory.java:66`) **[source]** applies a rigid
-  transform, which is what a field-centre 180° flip is. A blue-corner
-  flip is a **reflection** — `x → length − x`, heading `→ π − heading`
-  — and no rigid transform is a reflection. Reaching for `transformBy`
-  under a corner origin gives a path that is plausibly shaped, wrong,
-  and produces no error. See Open.
+- **A `Transform2d` cannot express the blue-corner flip, and
+  `transformBy` does not express the field-centre one either.** A
+  blue-corner flip is a **reflection** — `x → length − x`, heading
+  `→ π − heading` — and no rigid transform is a reflection. Reaching
+  for `transformBy` under a corner origin gives a path that is
+  plausibly shaped, wrong, and produces no error.
+
+  `HolonomicTrajectory.transformBy(Transform2d)` does not save the
+  field-centre case: it is rigid **about the trajectory's own first
+  pose** rather than about the origin —
+  `firstPose.transformBy(transform)`, then every later sample by
+  `transformedFirstPose.plus(sample.pose.minus(firstPose))`
+  (`HolonomicTrajectory.java:67-81`) **[source]** — and it carries
+  `sample.velocity` and `sample.acceleration` through **unrotated**
+  (`:72, 82-83`) **[source]**. Under a 180° flip that leaves every velocity
+  pointing the way it did before, which compiles, runs, and drives the
+  mirrored path backwards. The flip is written per sample instead. See
+  Open.
 
 - **A `kV` in `FeedForwardConfig` and a `kV·v` term in
   `arbFeedforward` double the feedforward, and nothing throws.** The
@@ -550,20 +583,13 @@ produce it. ADR 0009 owns that.
 
   | Origin | Flip is | Implementation |
   |---|---|---|
-  | **Field-centre** | 180° rotation about the origin — a **rigid transform** | `trajectory.transformBy(...)`, one call |
+  | **Field-centre** | 180° rotation about the origin — a **rigid transform** | negate x and y, turn the heading half a turn, negate the velocity and acceleration vectors; one function |
   | Blue-corner | a **reflection** (`x → length − x`, heading `→ π − heading`) | a hand-written per-sample remap; `Transform2d` cannot express it |
 
   We target field-centre. The one-function rule is what makes this
   switchable at all. *Unblocked by* the 2027 field release and its
   AprilTag map, at which point the function is re-verified against the
   real thing rather than against a report.
-
-- **The follow timeout has no value yet.** The overload is decided; the
-  duration is not. The clock starts inside `waitUntil` —
-  `var timer = Timer.createStarted()` (`Coroutine.java:723`)
-  **[source]** — not at the command's start, so it is a margin over the
-  trajectory's `duration` rather than an absolute. *Unblocked by* the first paths
-  existing, at which point the margin is a number rather than a guess.
 
 - **Whether the converter is throwaway or permanent.** If ChoreoLib's
   `Trajectory` eventually **extends** `org.wpilib.math.trajectory.Trajectory`

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -5,6 +5,7 @@
 package first.robot;
 
 import static org.wpilib.units.Units.Amps;
+import static org.wpilib.units.Units.Degrees;
 import static org.wpilib.units.Units.DegreesPerSecond;
 import static org.wpilib.units.Units.Inches;
 import static org.wpilib.units.Units.KilogramSquareMeters;
@@ -15,6 +16,7 @@ import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Pounds;
 import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Rotations;
+import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.units.Units.Volts;
 
 import first.robot.sim.SwerveSimConfig;
@@ -132,6 +134,18 @@ public final class DriveConstants {
   // A pose estimator tuned against a gyro that never wanders is tuned against a robot that does
   // not exist. Roughly a degree a minute, which is the order a Pigeon2 drifts at.
   public static final AngularVelocity GYRO_SIM_DRIFT = DegreesPerSecond.of(1.0 / 60);
+
+  // Volts per metre per second squared at the wheel, handed to the SPARK as arbFeedforward beside
+  // the velocity setpoint. Zero until SysId's dynamic test produces one, which leaves the term
+  // present and inert rather than absent.
+  public static final double DRIVE_KA = 0.0;
+
+  // Metres per second of correction per metre of error, and radians per second per radian. No path
+  // has been driven on a chassis; the gains are a starting point that a bring-up replaces, and the
+  // margin is the worst settling time the simulated paths take past their own duration, rounded up.
+  public static final HolonomicPathFollower.Config PATH_FOLLOWER =
+      new HolonomicPathFollower.Config(
+          5.0, 5.0, 5.0, Meters.of(0.05), Degrees.of(2), Seconds.of(2));
 
   public record DriveMotorGains(double kP, double kS, double kV) {}
 

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -1,0 +1,66 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import org.wpilib.driverstation.Alliance;
+import org.wpilib.driverstation.MatchState;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.trajectory.HolonomicSample;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.util.Alert;
+import org.wpilib.util.Alert.Level;
+
+public final class FieldConstants {
+  // Blue is the answer that looks right on a bench and is wrong in half of every match, so a
+  // missing alliance is said out loud rather than defaulted through.
+  private static final Alert ALLIANCE_UNKNOWN =
+      new Alert(
+          "path-alliance-unknown", "Following a path with no alliance; assuming blue", Level.HIGH);
+
+  private FieldConstants() {}
+
+  public static HolonomicTrajectory forAlliance(HolonomicTrajectory trajectory) {
+    return onRed() ? flip(trajectory) : trajectory;
+  }
+
+  // The flip is its own inverse, so the same rotation carries a measured pose back into the frame
+  // the path was drawn in. A threshold written against the drawn path is wrong on red otherwise,
+  // and wrong by never being reached rather than by being reached in the wrong place.
+  public static Pose2d asAuthored(Pose2d pose) {
+    return onRed() ? flip(pose) : pose;
+  }
+
+  // The origin is field centre, where the flip is a 180-degree rotation about it. Under the
+  // blue-corner origin the alpha-7 tree still documents, the same flip is a reflection instead,
+  // and every line below changes. Vision has to be told the same answer.
+  public static HolonomicTrajectory flip(HolonomicTrajectory trajectory) {
+    return new HolonomicTrajectory(
+        trajectory.getSamples().stream().map(FieldConstants::flip).toList());
+  }
+
+  // Not HolonomicTrajectory.transformBy: it is rigid about the trajectory's own first pose rather
+  // than about the origin, and it carries the velocities and accelerations through unrotated.
+  private static HolonomicSample flip(HolonomicSample sample) {
+    return new HolonomicSample(
+        sample.time,
+        flip(sample.pose),
+        new ChassisVelocities(-sample.velocity.vx, -sample.velocity.vy, sample.velocity.omega),
+        new ChassisAccelerations(
+            -sample.acceleration.ax, -sample.acceleration.ay, sample.acceleration.alpha));
+  }
+
+  public static Pose2d flip(Pose2d pose) {
+    return new Pose2d(-pose.getX(), -pose.getY(), pose.getRotation().rotateBy(Rotation2d.kPi));
+  }
+
+  private static boolean onRed() {
+    var alliance = MatchState.getAlliance();
+    ALLIANCE_UNKNOWN.set(alliance.isEmpty());
+    return alliance.orElse(Alliance.BLUE) == Alliance.RED;
+  }
+}

--- a/src/main/java/first/robot/HolonomicPathFollower.java
+++ b/src/main/java/first/robot/HolonomicPathFollower.java
@@ -1,0 +1,114 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Radians;
+import static org.wpilib.units.Units.Seconds;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.trajectory.HolonomicSample;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.measure.Angle;
+import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Time;
+
+public final class HolonomicPathFollower implements PathFollower {
+  public record Config(
+      double xKp,
+      double yKp,
+      double thetaKp,
+      Distance positionTolerance,
+      Angle headingTolerance,
+      Time timeoutMargin) {}
+
+  private final HolonomicTrajectory trajectory;
+  private final Supplier<Pose2d> pose;
+  private final DoubleSupplier clockSeconds;
+  private final Config config;
+  private final TelemetryTable followingLog;
+  private final double startSeconds;
+
+  private HolonomicSample setpoint;
+
+  public HolonomicPathFollower(
+      HolonomicTrajectory trajectory,
+      Supplier<Pose2d> pose,
+      DoubleSupplier clockSeconds,
+      Config config,
+      TelemetryTable followingLog) {
+    this.trajectory = trajectory;
+    this.pose = pose;
+    this.clockSeconds = clockSeconds;
+    this.config = config;
+    this.followingLog = followingLog;
+    startSeconds = clockSeconds.getAsDouble();
+    setpoint = trajectory.start();
+  }
+
+  private double elapsed() {
+    return clockSeconds.getAsDouble() - startSeconds;
+  }
+
+  @Override
+  public ChassisVelocities next() {
+    setpoint = trajectory.sampleAt(elapsed());
+
+    var current = pose.get();
+    var error = setpoint.pose.getTranslation().minus(current.getTranslation());
+    var headingError = setpoint.pose.getRotation().minus(current.getRotation());
+    log(error, headingError);
+
+    return new ChassisVelocities(
+        setpoint.velocity.vx + config.xKp() * error.getX(),
+        setpoint.velocity.vy + config.yKp() * error.getY(),
+        setpoint.velocity.omega + config.thetaKp() * headingError.getRadians());
+  }
+
+  // The sample next() left behind, so this has to be read after it within the same iteration.
+  public ChassisAccelerations acceleration() {
+    return setpoint.acceleration;
+  }
+
+  // Not time alone: a robot pinned against a defender runs the clock out where it is standing, and
+  // a follower that reports done there hands the next command a robot a metre from where it thinks.
+  @Override
+  public boolean isDone() {
+    var current = pose.get();
+    var end = trajectory.end().pose;
+    return elapsed() >= trajectory.duration
+        && end.getTranslation().getDistance(current.getTranslation())
+            <= config.positionTolerance().in(Meters)
+        && Math.abs(end.getRotation().minus(current.getRotation()).getRadians())
+            <= config.headingTolerance().in(Radians);
+  }
+
+  // The clock inside waitUntil starts when waitUntil does, so this is a margin over the path's own
+  // duration rather than an absolute deadline.
+  public Time timeout() {
+    return Seconds.of(trajectory.duration).plus(config.timeoutMargin());
+  }
+
+  public Pose2d[] plannedPath() {
+    return trajectory.getSamples().stream().map(sample -> sample.pose).toArray(Pose2d[]::new);
+  }
+
+  private void log(Translation2d error, Rotation2d headingError) {
+    // Rotated into the sample's heading frame, because raw x and y cannot tell "on the path and
+    // running late" from "on time and a metre left", and those have different causes.
+    var track = error.rotateBy(setpoint.pose.getRotation().unaryMinus());
+    followingLog.log("Setpoint", setpoint, HolonomicSample.struct);
+    followingLog.log("AlongTrackError", Meters.of(track.getX()));
+    followingLog.log("CrossTrackError", Meters.of(track.getY()));
+    followingLog.log("HeadingError", headingError.getMeasure());
+  }
+}

--- a/src/main/java/first/robot/PathFollower.java
+++ b/src/main/java/first/robot/PathFollower.java
@@ -1,0 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import org.wpilib.math.kinematics.ChassisVelocities;
+
+// next() returns FIELD-relative velocities. No type and no name says so, and a follower that
+// returns robot-relative ones compiles, runs, and tracks a straight path perfectly right up to the
+// moment the robot rotates.
+public interface PathFollower {
+  ChassisVelocities next();
+
+  boolean isDone();
+}

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -26,6 +26,8 @@ import org.wpilib.driverstation.MatchState;
 import org.wpilib.driverstation.RobotState;
 import org.wpilib.framework.OpModeRobot;
 import org.wpilib.hardware.power.PowerDistribution;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
 import org.wpilib.networktables.NetworkTableInstance;
 import org.wpilib.system.DataLogManager;
 import org.wpilib.system.Filesystem;
@@ -133,7 +135,12 @@ public class Robot extends OpModeRobot {
     drive =
         new Drive(
             DriveConstants.DRIVE,
+            this::trajectory,
+            // A method reference, not a lambda over the field: the estimator is built from the
+            // drive base two statements below this one, so the field is still blank here.
+            this::estimatedPose,
             TelemetryRegistry.getTable("/Drive"),
+            TelemetryRegistry.getTable("/Auto"),
             TelemetryRegistry.getTable("/Sim"),
             Scheduler.getDefault());
 
@@ -157,6 +164,16 @@ public class Robot extends OpModeRobot {
 
     addPeriodic(this::logAlerts, Constants.ALERT_LOG_PERIOD.in(Seconds));
     addPeriodic(this::logRadio, Constants.RADIO_LOG_PERIOD.in(Seconds));
+  }
+
+  private Pose2d estimatedPose() {
+    return poseEstimator.getEstimatedPose();
+  }
+
+  // The cache holds every path exactly as it was authored, and the flip is applied here — on a
+  // lookup, which autonomous makes once per schedule and therefore once per enable.
+  public HolonomicTrajectory trajectory(String name) {
+    return FieldConstants.forAlliance(trajectories.get(name));
   }
 
   private static PowerDistribution openPdh() {

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -24,10 +24,12 @@ import first.robot.DriveConstants;
 import first.robot.DriveConstants.DriveConfig;
 import first.robot.DriveConstants.SwerveModuleConfig;
 import first.robot.Hardware;
+import first.robot.HolonomicPathFollower;
 import first.robot.sim.OnboardLoopSim;
 import first.robot.sim.SwerveDriveSim;
 import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
@@ -39,11 +41,14 @@ import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.geometry.Rotation2d;
 import org.wpilib.math.geometry.Rotation3d;
 import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.kinematics.ChassisAccelerations;
 import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.kinematics.SwerveDriveKinematics;
 import org.wpilib.math.kinematics.SwerveModulePosition;
 import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
 import org.wpilib.simulation.RoboRioSim;
+import org.wpilib.system.Timer;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Angle;
 
@@ -57,13 +62,18 @@ public class Drive implements Mechanism {
   private final SwerveModule[] modules = new SwerveModule[MODULES];
   private final SwerveDriveKinematics kinematics;
   private final Pigeon2 gyro;
+  private final Function<String, HolonomicTrajectory> trajectories;
+  private final Supplier<Pose2d> pose;
   private final TelemetryTable chassisLog;
   private final TelemetryTable moduleLog;
   private final TelemetryTable odometryLog;
+  private final TelemetryTable followingLog;
+  private final TelemetryTable autoLog;
   private final TelemetryTable simLog;
   private final Scheduler scheduler;
 
   private ChassisVelocities desiredVelocities = new ChassisVelocities();
+  private boolean pathTimedOut;
 
   // The vendor plumbing, and the one place in this project allowed to be saturated with it.
   // Everything it drives is in first.robot.sim, which imports no vendor type at all.
@@ -77,12 +87,26 @@ public class Drive implements Mechanism {
   private Angle simYaw;
   private Rotation2d lastTrueRotation;
 
-  public Drive(DriveConfig config, TelemetryTable log, TelemetryTable simLog, Scheduler scheduler) {
+  // trajectories is a lookup into a cache somebody else filled, and pose is a read-only view of
+  // the estimate. Neither hands this class an estimator, so it still cannot reset pose and still
+  // never learns cameras exist.
+  public Drive(
+      DriveConfig config,
+      Function<String, HolonomicTrajectory> trajectories,
+      Supplier<Pose2d> pose,
+      TelemetryTable log,
+      TelemetryTable autoLog,
+      TelemetryTable simLog,
+      Scheduler scheduler) {
+    this.trajectories = trajectories;
+    this.pose = pose;
+    this.autoLog = autoLog;
     this.simLog = simLog;
     this.scheduler = scheduler;
     chassisLog = log.getTable("Chassis");
     moduleLog = log.getTable("Modules");
     odometryLog = log.getTable("Odometry");
+    followingLog = log.getTable("Following");
 
     var gains = DriveConstants.gains();
     var corners = corners(config);
@@ -158,6 +182,50 @@ public class Drive implements Mechanism {
     return fieldRelative(velocities, this::setVelocities).named("Drive.DriveFieldRelative");
   }
 
+  // The estimator's heading, not the gyro's. The two differ by whatever a resetPose introduced —
+  // Odometry3d assigns the pose and integrates gyro deltas onto it — and a follower whose error is
+  // measured against the estimate has to be converted back in that same frame. The single-argument
+  // form above stays on the gyro deliberately: a driver's forward should not jump when a vision
+  // update moves the estimate.
+  public Command driveFieldRelative(
+      Supplier<ChassisVelocities> velocities, Supplier<ChassisAccelerations> accelerations) {
+    return run(coroutine -> {
+          while (true) {
+            var heading = pose.get().getRotation();
+            var field = velocities.get();
+            setVelocities(
+                field.toRobotRelative(heading), accelerations.get().toRobotRelative(heading));
+            coroutine.yield();
+          }
+        })
+        .whenCanceled(this::stopModules)
+        .named("Drive.DriveFieldRelative");
+  }
+
+  public Command followPath(String pathName) {
+    return run(coroutine -> {
+          var follower =
+              new HolonomicPathFollower(
+                  trajectories.apply(pathName),
+                  pose,
+                  Timer::getTimestamp,
+                  DriveConstants.PATH_FOLLOWER,
+                  followingLog);
+          // A timeout left over from the previous path is indistinguishable from this one's until
+          // this one is over.
+          pathTimedOut = false;
+          followingLog.log("TimedOut", false);
+          autoLog.log("PlannedPath", follower.plannedPath(), Pose2d.struct);
+
+          coroutine.fork(driveFieldRelative(follower::next, follower::acceleration));
+          var result = coroutine.waitUntil(follower::isDone, follower.timeout());
+          pathTimedOut = result.timedOut();
+          followingLog.log("TimedOut", result.timedOut());
+        })
+        .whenCanceled(this::stopModules)
+        .named("Drive.FollowPath[" + pathName + "]");
+  }
+
   // Open loop, unlike everything else that drives: a velocity loop answers a shove by spinning the
   // wheel back to its setpoint, and a driver reads that as the robot arguing. A voltage does what
   // the stick did.
@@ -216,6 +284,17 @@ public class Drive implements Mechanism {
     }
   }
 
+  public void setVelocities(ChassisVelocities velocities, ChassisAccelerations accelerations) {
+    var states = moduleTargets(velocities);
+    // The two-argument form, always: toWheelAccelerations hardcodes omega = 0 and drops the
+    // centripetal term, which dominates during exactly the manoeuvre this feedforward is for.
+    var moduleAccelerations =
+        kinematics.toSwerveModuleAccelerations(accelerations, velocities.omega);
+    for (int i = 0; i < MODULES; i++) {
+      modules[i].setVelocity(states[i], moduleAccelerations[i]);
+    }
+  }
+
   public void setOpenLoopVelocities(ChassisVelocities velocities) {
     var states = moduleTargets(velocities);
     for (int i = 0; i < MODULES; i++) {
@@ -236,6 +315,12 @@ public class Drive implements Mechanism {
       module.stop();
     }
     desiredVelocities = new ChassisVelocities();
+  }
+
+  // followPath returns normally on a timeout rather than throwing, so a routine that awaited it
+  // cannot otherwise tell a path that finished from one that gave up a metre short.
+  public boolean lastPathTimedOut() {
+    return pathTimedOut;
   }
 
   public Rotation3d getGyroHeading() {

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -14,9 +14,11 @@ import static org.wpilib.units.Units.Volts;
 import com.revrobotics.PersistMode;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.ResetMode;
+import com.revrobotics.spark.ClosedLoopSlot;
 import com.revrobotics.spark.FeedbackSensor;
 import com.revrobotics.spark.SparkAnalogSensor;
 import com.revrobotics.spark.SparkClosedLoopController;
+import com.revrobotics.spark.SparkClosedLoopController.ArbFFUnits;
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkLowLevel.ControlType;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
@@ -29,6 +31,7 @@ import first.robot.DriveConstants.ModuleGains;
 import first.robot.DriveConstants.SwerveModuleConfig;
 import first.robot.Hardware;
 import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModuleAcceleration;
 import org.wpilib.math.kinematics.SwerveModulePosition;
 import org.wpilib.math.kinematics.SwerveModuleVelocity;
 import org.wpilib.math.util.MathUtil;
@@ -153,26 +156,51 @@ final class SwerveModule {
   }
 
   void setVelocity(SwerveModuleVelocity target) {
-    command(target, false);
+    command(resolve(target), 0, false);
+  }
+
+  void setVelocity(SwerveModuleVelocity target, SwerveModuleAcceleration acceleration) {
+    // Resolved once, so the direction the feedforward is projected onto is the same one the wheel
+    // is commanded in. Reading the sensor twice can straddle the 90-degree optimise boundary and
+    // leave the feedforward pushing against the setpoint.
+    var resolved = resolve(target);
+    command(
+        resolved, DriveConstants.DRIVE_KA * accelerationAlong(acceleration, resolved.angle), false);
   }
 
   void setOpenLoopVelocity(SwerveModuleVelocity target) {
-    command(target, true);
+    command(resolve(target), 0, true);
   }
 
-  private void command(SwerveModuleVelocity target, boolean open) {
+  private SwerveModuleVelocity resolve(SwerveModuleVelocity target) {
     var angle = getAngle();
-    desired = target.optimize(angle).cosineScale(angle);
+    return target.optimize(angle).cosineScale(angle);
+  }
+
+  private void command(SwerveModuleVelocity resolved, double arbFeedforwardVolts, boolean open) {
+    desired = resolved;
     steerSetpointRotations = toSensorRotations(desired.angle, steerOffsetRotations);
     openLoop = open;
 
     if (open) {
       driveMotor.setVoltage(openLoopVolts(desired.velocity));
     } else {
-      driveController.setSetpoint(desired.velocity, ControlType.kVelocity);
+      driveController.setSetpoint(
+          desired.velocity,
+          ControlType.kVelocity,
+          ClosedLoopSlot.kSlot0,
+          arbFeedforwardVolts,
+          ArbFFUnits.kVoltage);
     }
     steerController.setSetpoint(steerSetpointRotations, ControlType.kPosition);
     closingLoops = true;
+  }
+
+  // SwerveModuleAcceleration carries an unsigned magnitude with the direction in its angle, so the
+  // wheel's own share of it is the projection onto the direction the wheel is being driven in —
+  // negative when the wheel is braking, which the magnitude alone cannot say.
+  static double accelerationAlong(SwerveModuleAcceleration acceleration, Rotation2d wheel) {
+    return acceleration.acceleration * acceleration.angle.minus(wheel).getCos();
   }
 
   // The share of the free speed the driver asked for, spent as the same share of the rail. It is

--- a/src/main/java/first/robot/opmode/DoNothingAuto.java
+++ b/src/main/java/first/robot/opmode/DoNothingAuto.java
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.opmode;
+
+import first.robot.Robot;
+import org.wpilib.opmode.Autonomous;
+import org.wpilib.opmode.OpMode;
+
+// Binds nothing, so every mechanism runs the safe default command Robot set. The point is that the
+// operator always has something to select when the path is wrong or the field is not where the
+// robot thinks.
+@Autonomous(group = "Competition", description = "Sits still")
+public class DoNothingAuto implements OpMode {
+  public DoNothingAuto(Robot robot) {}
+}

--- a/src/main/java/first/robot/opmode/SweepLeftAuto.java
+++ b/src/main/java/first/robot/opmode/SweepLeftAuto.java
@@ -1,0 +1,97 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.opmode;
+
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Seconds;
+
+import first.robot.FieldConstants;
+import first.robot.Robot;
+import org.wpilib.command3.Command;
+import org.wpilib.command3.Trigger;
+import org.wpilib.driverstation.RobotState;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.opmode.Autonomous;
+import org.wpilib.opmode.OpMode;
+import org.wpilib.system.Timer;
+import org.wpilib.telemetry.TelemetryRegistry;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.measure.Distance;
+
+@Autonomous(group = "Competition", description = "Follows the SweepLeft path")
+public class SweepLeftAuto implements OpMode {
+  private static final String ROUTINE = "SweepLeftAuto";
+  private static final String PATH = "SweepLeft";
+
+  // Where along the path the zone starts. A pose says it and the clock does not: a robot running
+  // 300 ms late crosses the same line, and a time marker fires 300 ms short of it.
+  private static final Distance ZONE_LINE = Meters.of(4);
+
+  private final Trigger enabled = new Trigger(RobotState::isEnabled);
+  private final Trigger pastZoneLine;
+  private final TelemetryTable autoLog = TelemetryRegistry.getTable("/Auto");
+
+  public SweepLeftAuto(Robot robot) {
+    // Measured against the path as it was drawn, so the line is in the same place on both
+    // alliances. Comparing the flipped estimate to a fixed threshold is a trigger that never fires
+    // on one of them.
+    pastZoneLine =
+        new Trigger(
+            () ->
+                FieldConstants.asAuthored(robot.poseEstimator.getEstimatedPose()).getX()
+                    >= ZONE_LINE.in(Meters));
+    pastZoneLine.onTrue(markZoneEntry(robot));
+    enabled.onTrue(sweepLeft(robot));
+  }
+
+  // Both triggers were built here, so both are ours to cancel. Without this a disable leaves the
+  // previous opmode's bindings live and the next enable runs two copies of the routine.
+  @Override
+  public void close() {
+    pastZoneLine.unbind();
+    enabled.unbind();
+  }
+
+  private Command markZoneEntry(Robot robot) {
+    return Command.noRequirements(
+            coroutine ->
+                autoLog.log("ZoneEntry", robot.poseEstimator.getEstimatedPose(), Pose2d.struct))
+        .named("Auto.MarkZoneEntry");
+  }
+
+  private Command sweepLeft(Robot robot) {
+    return Command.noRequirements(
+            coroutine -> {
+              autoLog.log("RoutineName", ROUTINE);
+              // A completion left over from the previous run reads as this one's until this one
+              // is over.
+              autoLog.log("Complete", false);
+
+              // Seeded from the path the robot is about to drive, after the same alliance flip the
+              // follower will apply, so the first sample's error is where the robot was placed.
+              robot.poseEstimator.resetPose(robot.trajectory(PATH).start().pose);
+
+              coroutine.fork(elapsed());
+              coroutine.await(robot.drive.followPath(PATH));
+
+              // followPath comes back the same way whether the path finished or ran out its
+              // timeout, so this has to ask which it was rather than assume.
+              autoLog.log("Complete", !robot.drive.lastPathTimedOut());
+            })
+        .named("Auto.SweepLeft");
+  }
+
+  private Command elapsed() {
+    return Command.noRequirements(
+            coroutine -> {
+              var timer = Timer.createStarted();
+              while (true) {
+                autoLog.log("TimeElapsed", Seconds.of(timer.get()));
+                coroutine.yield();
+              }
+            })
+        .named("Auto.TimeElapsed");
+  }
+}

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -1,0 +1,99 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.trajectory.HolonomicSample;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.util.AlertDataJNI;
+
+class FieldConstantsTest {
+  private static final double TOLERANCE = 1e-9;
+
+  private static final HolonomicTrajectory PATH =
+      new HolonomicTrajectory(
+          List.of(
+              new HolonomicSample(
+                  0,
+                  new Pose2d(2, 3, Rotation2d.fromDegrees(30)),
+                  new ChassisVelocities(1, 2, 0.5),
+                  new ChassisAccelerations(3, 4, 0.75)),
+              new HolonomicSample(
+                  1,
+                  new Pose2d(4, 5, Rotation2d.fromDegrees(30)),
+                  new ChassisVelocities(1, 2, 0.5),
+                  new ChassisAccelerations(3, 4, 0.75))));
+
+  // The origin is field centre, so the flip is a rotation about it: the translation inverts, the
+  // heading turns half a turn, and the two spins keep their sign because a rotation does not
+  // mirror. A reflection — which a corner origin would need — inverts omega instead.
+  @Test
+  void theFlipIsARotationAboutTheOriginRatherThanAReflection() {
+    var flipped = FieldConstants.flip(PATH).start();
+
+    assertEquals(-2, flipped.pose.getX(), TOLERANCE);
+    assertEquals(-3, flipped.pose.getY(), TOLERANCE);
+    assertEquals(-150, flipped.pose.getRotation().getDegrees(), TOLERANCE);
+    assertEquals(-1, flipped.velocity.vx, TOLERANCE);
+    assertEquals(-2, flipped.velocity.vy, TOLERANCE);
+    assertEquals(0.5, flipped.velocity.omega, TOLERANCE);
+    assertEquals(-3, flipped.acceleration.ax, TOLERANCE);
+    assertEquals(-4, flipped.acceleration.ay, TOLERANCE);
+    assertEquals(0.75, flipped.acceleration.alpha, TOLERANCE);
+  }
+
+  @Test
+  void flippingTwiceIsTheOriginalPath() {
+    var round = FieldConstants.flip(FieldConstants.flip(PATH)).start();
+
+    assertEquals(2, round.pose.getX(), TOLERANCE);
+    assertEquals(3, round.pose.getY(), TOLERANCE);
+    assertEquals(30, round.pose.getRotation().getDegrees(), TOLERANCE);
+  }
+
+  // No Driver Station is attached under a unit test, which is the same case as a robot on a bench
+  // with nobody plugged in.
+  @Test
+  void aMissingAllianceRaisesAnAlertRatherThanFlippingOnAGuess() {
+    assertSame(
+        PATH, FieldConstants.forAlliance(PATH), "a path was flipped with no alliance to go on");
+
+    assertTrue(
+        Arrays.stream(AlertDataJNI.getAlerts())
+            .anyMatch(
+                alert ->
+                    alert.id.equals("path-alliance-unknown")
+                        && alert.activeStartTime != 0
+                        && alert.level == AlertDataJNI.LEVEL_HIGH),
+        "no high-level alert was raised for a path followed without an alliance");
+  }
+
+  // What asAuthored leans on: it has to undo exactly what the trajectory flip did, or a threshold
+  // written against the drawn path is compared against the wrong half of the field on red — and a
+  // trigger that never fires is quieter than one that fires in the wrong place.
+  @Test
+  void thePoseFlipUndoesWhatTheTrajectoryFlipDidToTheSamePose() {
+    var drawn = PATH.start().pose;
+
+    var driven = FieldConstants.flip(PATH).start().pose;
+    var back = FieldConstants.flip(driven);
+
+    assertEquals(-2, driven.getX(), TOLERANCE);
+    assertEquals(-3, driven.getY(), TOLERANCE);
+    assertEquals(drawn.getX(), back.getX(), TOLERANCE);
+    assertEquals(drawn.getY(), back.getY(), TOLERANCE);
+    assertEquals(drawn.getRotation().getDegrees(), back.getRotation().getDegrees(), TOLERANCE);
+  }
+}

--- a/src/test/java/first/robot/HolonomicPathFollowerTest.java
+++ b/src/test/java/first/robot/HolonomicPathFollowerTest.java
@@ -1,0 +1,171 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Degrees;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Seconds;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wpilib.internal.UnitTelemetry;
+import org.wpilib.math.geometry.Pose2d;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.trajectory.HolonomicSample;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.telemetry.MockTelemetryBackend;
+import org.wpilib.telemetry.TelemetryRegistry;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.Measure;
+
+class HolonomicPathFollowerTest {
+  private static final double TOLERANCE = 1e-9;
+  private static final double SPEED = 1.0;
+  private static final double LENGTH = 2.0;
+
+  private static final HolonomicPathFollower.Config CONFIG =
+      new HolonomicPathFollower.Config(
+          5.0, 5.0, 5.0, Meters.of(0.05), Degrees.of(2), Seconds.of(1));
+
+  private MockTelemetryBackend backend;
+  private TelemetryTable log;
+  private Pose2d pose = Pose2d.kZero;
+  private double now;
+
+  @BeforeEach
+  void setUp() {
+    TelemetryRegistry.registerTypeHandler(
+        Measure.class, (table, name, value) -> UnitTelemetry.log(table, name, value));
+    backend = new MockTelemetryBackend();
+    log = new TelemetryTable(backend);
+    // The mock backend retains what it is handed and HolonomicSample's fields are public, so
+    // every setpoint write warns here. The robot's backends serialise on the spot and do not.
+    TelemetryRegistry.setReportWarning((path, message) -> {});
+  }
+
+  @AfterEach
+  void tearDown() {
+    TelemetryRegistry.setReportWarning(null);
+    TelemetryRegistry.reset();
+    backend.close();
+  }
+
+  // Straight along +x at a constant speed, with the robot facing whichever way the caller asks —
+  // which is what lets one path test both the correction and the frame the errors are reported in.
+  private static HolonomicTrajectory straightAlongX(Rotation2d heading) {
+    return new HolonomicTrajectory(
+        List.of(
+            new HolonomicSample(
+                0,
+                new Pose2d(0, 0, heading),
+                new ChassisVelocities(SPEED, 0, 0),
+                new ChassisAccelerations()),
+            new HolonomicSample(
+                LENGTH / SPEED,
+                new Pose2d(LENGTH, 0, heading),
+                new ChassisVelocities(SPEED, 0, 0),
+                new ChassisAccelerations())));
+  }
+
+  private HolonomicPathFollower follower(HolonomicTrajectory trajectory) {
+    return new HolonomicPathFollower(trajectory, () -> pose, () -> now, CONFIG, log);
+  }
+
+  @Test
+  void aRobotSittingOnThePathIsHandedTheSamplesOwnVelocity() {
+    pose = new Pose2d(0, 0, Rotation2d.kZero);
+
+    var velocities = follower(straightAlongX(Rotation2d.kZero)).next();
+
+    assertEquals(SPEED, velocities.vx, TOLERANCE);
+    assertEquals(0, velocities.vy, TOLERANCE);
+    assertEquals(0, velocities.omega, TOLERANCE);
+  }
+
+  // Field-relative, and the assertion is that the correction points at the path in field terms
+  // rather than in the robot's. A robot facing +y that is a metre to the field's left needs -y.
+  @Test
+  void theCorrectionIsInFieldTermsRatherThanTheRobots() {
+    pose = new Pose2d(0, 0.1, Rotation2d.kCCW_Pi_2);
+
+    var velocities = follower(straightAlongX(Rotation2d.kCCW_Pi_2)).next();
+
+    assertEquals(SPEED, velocities.vx, TOLERANCE);
+    assertEquals(-0.5, velocities.vy, TOLERANCE);
+  }
+
+  @Test
+  void poseErrorIsReportedAlongAndAcrossTheTrackRatherThanInXAndY() {
+    // Behind the sample in field +x, with the robot facing field +y: that is a whole rotation
+    // away from being a lag, and x/y error alone cannot say so.
+    pose = new Pose2d(-0.3, 0, Rotation2d.kCCW_Pi_2);
+
+    follower(straightAlongX(Rotation2d.kCCW_Pi_2)).next();
+
+    assertEquals(0, backend.getLastValue("/AlongTrackError", Double.class), TOLERANCE);
+    assertEquals(-0.3, backend.getLastValue("/CrossTrackError", Double.class), TOLERANCE);
+  }
+
+  @Test
+  void aPathWhoseClockRanOutSomewhereElseIsNotDone() {
+    var follower = follower(straightAlongX(Rotation2d.kZero));
+    pose = new Pose2d(0.5, 0, Rotation2d.kZero);
+
+    now = LENGTH / SPEED + 1;
+
+    assertFalse(follower.isDone(), "a robot half a path short of the end reported done");
+
+    pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
+    assertTrue(follower.isDone(), "a robot at the end of a finished path did not report done");
+  }
+
+  @Test
+  void aPathThatHasNotRunItsDurationIsNotDoneEvenSittingOnTheEndPose() {
+    var follower = follower(straightAlongX(Rotation2d.kZero));
+    pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
+
+    assertFalse(follower.isDone(), "a path reported done before it had run");
+  }
+
+  @Test
+  void theTimeoutIsAMarginOverTheTrajectoryDurationRatherThanAnAbsolute() {
+    var follower = follower(straightAlongX(Rotation2d.kZero));
+
+    assertEquals(
+        LENGTH / SPEED + CONFIG.timeoutMargin().in(Seconds),
+        follower.timeout().in(Seconds),
+        TOLERANCE);
+  }
+
+  @Test
+  void theAccelerationHandedOnIsTheSamplesOwnRatherThanADerivative() {
+    var accelerating =
+        new HolonomicTrajectory(
+            List.of(
+                new HolonomicSample(
+                    0,
+                    Pose2d.kZero,
+                    new ChassisVelocities(),
+                    new ChassisAccelerations(2.5, 0, 0.75)),
+                new HolonomicSample(
+                    1,
+                    new Pose2d(1.25, 0, Rotation2d.kZero),
+                    new ChassisVelocities(2.5, 0, 0.75),
+                    new ChassisAccelerations(2.5, 0, 0.75))));
+    var follower = follower(accelerating);
+
+    follower.next();
+
+    assertEquals(2.5, follower.acceleration().ax, TOLERANCE);
+    assertEquals(0.75, follower.acceleration().alpha, TOLERANCE);
+  }
+}

--- a/src/test/java/first/robot/mechanisms/PathFollowingTest.java
+++ b/src/test/java/first/robot/mechanisms/PathFollowingTest.java
@@ -1,0 +1,170 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.Seconds;
+
+import first.robot.Constants;
+import first.robot.DriveConstants;
+import first.robot.HolonomicPathFollower;
+import first.robot.TrajectoryLoader;
+import first.robot.sim.OnboardLoopSim;
+import first.robot.sim.SwerveDriveSim;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wpilib.internal.UnitTelemetry;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
+import org.wpilib.math.kinematics.SwerveModuleVelocity;
+import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.math.util.MathUtil;
+import org.wpilib.system.Filesystem;
+import org.wpilib.telemetry.MockTelemetryBackend;
+import org.wpilib.telemetry.TelemetryRegistry;
+import org.wpilib.telemetry.TelemetryTable;
+import org.wpilib.units.Measure;
+import org.wpilib.units.measure.Distance;
+import org.wpilib.units.measure.Time;
+
+// The whole autonomous loop, with no HAL and no vendor type in it: follower to field-relative
+// velocities to kinematics to module voltages to the plant to a pose and back into the follower.
+// The cross-track number asserted here is the one the field diagnostic reports, so a regression
+// looks the same in CI as it does on a field.
+class PathFollowingTest {
+  private static final int MODULES = 4;
+  private static final double LOOP = Constants.LOOP_PERIOD.in(Seconds);
+  private static final double SUB_STEP = DriveConstants.CONTROLLER_PERIOD.in(Seconds);
+  private static final int SUB_STEPS = (int) Math.round(LOOP / SUB_STEP);
+
+  private final SwerveDriveKinematics kinematics =
+      new SwerveDriveKinematics(DriveConstants.simConfig().moduleLocations());
+  private final SwerveDriveSim physics = new SwerveDriveSim(DriveConstants.simConfig());
+  private final OnboardLoopSim[] driveLoops = new OnboardLoopSim[MODULES];
+  private final OnboardLoopSim[] steerLoops = new OnboardLoopSim[MODULES];
+
+  private MockTelemetryBackend backend;
+  private TelemetryTable log;
+  private double now;
+
+  @BeforeEach
+  void setUp() {
+    var gains = DriveConstants.SIM_GAINS;
+    for (int i = 0; i < MODULES; i++) {
+      driveLoops[i] =
+          OnboardLoopSim.velocity(gains.drive().kP(), gains.drive().kS(), gains.drive().kV());
+      steerLoops[i] =
+          OnboardLoopSim.position(
+              gains.steer().kP(), gains.steer().kD(), gains.steer().dFilter(), 0, 1);
+    }
+
+    TelemetryRegistry.registerTypeHandler(
+        Measure.class, (table, name, value) -> UnitTelemetry.log(table, name, value));
+    backend = new MockTelemetryBackend();
+    log = new TelemetryTable(backend);
+    // The mock backend retains what it is handed and HolonomicSample's fields are public, so every
+    // setpoint write warns here. The robot's backends serialise on the spot and do not.
+    TelemetryRegistry.setReportWarning((path, message) -> {});
+  }
+
+  @AfterEach
+  void tearDown() {
+    TelemetryRegistry.setReportWarning(null);
+    TelemetryRegistry.reset();
+    backend.close();
+  }
+
+  // Straight and square to the field, so every metre of error is a metre of lag and the cross-track
+  // number measures only what it claims to.
+  @Test
+  void aStraightPathIsDrivenWithinAWheelsWidthOfItself() {
+    drive("StraightAhead", Meters.of(0.05), Seconds.of(1.5));
+  }
+
+  // Heading and translation change together, which is where a robot-relative follower and a dropped
+  // centripetal term both show up. The threshold is loose because the drive lags its velocity
+  // setpoint by a plant time constant with no acceleration feedforward to cancel it, and on a curve
+  // that lag is read as cross-track. It tightens when characterisation produces a kA.
+  @Test
+  void aPathThatTurnsWhileItTranslatesIsDrivenTheSameWay() {
+    drive("SweepLeft", Meters.of(0.8), Seconds.of(2));
+  }
+
+  private void drive(String pathName, Distance maxCrossTrack, Time margin) {
+    var trajectory = load(pathName);
+    physics.resetPose(trajectory.start().pose);
+
+    var follower =
+        new HolonomicPathFollower(
+            trajectory, physics::truePose, () -> now, DriveConstants.PATH_FOLLOWER, log);
+
+    double worstCrossTrack = 0;
+    double deadline = trajectory.duration + margin.in(Seconds);
+    while (!follower.isDone() && now < deadline) {
+      step(follower);
+      now += LOOP;
+      worstCrossTrack =
+          Math.max(
+              worstCrossTrack, Math.abs(backend.getLastValue("/CrossTrackError", Double.class)));
+    }
+
+    assertTrue(
+        follower.isDone(),
+        pathName + " was still not done " + now + " s in, against a deadline of " + deadline);
+    assertTrue(
+        worstCrossTrack <= maxCrossTrack.in(Meters),
+        pathName + " ran " + worstCrossTrack + " m off the path at its worst");
+  }
+
+  // Everything Drive does between a follower and the plant, with the SPARK-side loops modelled at
+  // their own rate rather than at the robot's.
+  private void step(HolonomicPathFollower follower) {
+    var heading = physics.truePose().getRotation();
+    var field = follower.next();
+    var robotRelative = field.toRobotRelative(heading);
+    var accelerations = follower.acceleration().toRobotRelative(heading);
+
+    var targets =
+        SwerveDriveKinematics.desaturateWheelVelocities(
+            kinematics.toSwerveModuleVelocities(robotRelative.discretize(LOOP)),
+            DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
+    // The two-argument form: the one-argument overload hardcodes omega = 0 and drops the
+    // centripetal term, which is most of the acceleration on the path that turns.
+    var moduleAccelerations =
+        kinematics.toSwerveModuleAccelerations(accelerations, robotRelative.omega);
+
+    var state = physics.moduleStates();
+    var desired = new SwerveModuleVelocity[MODULES];
+    var feedforward = new double[MODULES];
+    for (int i = 0; i < MODULES; i++) {
+      var azimuth = state[i].azimuth();
+      desired[i] = targets[i].optimize(azimuth).cosineScale(azimuth);
+      feedforward[i] =
+          DriveConstants.DRIVE_KA
+              * SwerveModule.accelerationAlong(moduleAccelerations[i], desired[i].angle);
+      driveLoops[i].setSetpoint(desired[i].velocity);
+      steerLoops[i].setSetpoint(MathUtil.inputModulus(desired[i].angle.getRotations(), 0, 1));
+    }
+
+    var driveVolts = new double[MODULES];
+    var steerVolts = new double[MODULES];
+    for (int substep = 0; substep < SUB_STEPS; substep++) {
+      for (int i = 0; i < MODULES; i++) {
+        double wheelSpeed =
+            state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters);
+        double sensor = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
+        driveVolts[i] = driveLoops[i].calculate(wheelSpeed, SUB_STEP) + feedforward[i];
+        steerVolts[i] = steerLoops[i].calculate(sensor, SUB_STEP);
+      }
+      state = physics.update(driveVolts, steerVolts, SUB_STEP);
+    }
+  }
+
+  private static HolonomicTrajectory load(String pathName) {
+    return new TrajectoryLoader(Filesystem.getDeployDirectory().toPath()).get(pathName);
+  }
+}

--- a/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
+++ b/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import first.robot.DriveConstants;
 import org.junit.jupiter.api.Test;
 import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModuleAcceleration;
 
 class SwerveModuleTest {
   private static final double TOLERANCE = 1e-9;
@@ -46,5 +47,22 @@ class SwerveModuleTest {
         1.0,
         DriveConstants.STEER_SENSOR_SPAN.magnitude() * DriveConstants.STEER_POSITION_FACTOR,
         TOLERANCE);
+  }
+
+  // The kinematics hand back an unsigned magnitude and a direction, so a module driving the other
+  // way is braking and its share has to come back negative.
+  @Test
+  void aWheelDrivenAgainstTheAccelerationBrakesAgainstIt() {
+    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.kZero);
+
+    assertEquals(4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kZero), TOLERANCE);
+    assertEquals(-4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kPi), TOLERANCE);
+  }
+
+  @Test
+  void aWheelTurnedAcrossTheAccelerationTakesNoneOfIt() {
+    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.kZero);
+
+    assertEquals(0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kCCW_Pi_2), TOLERANCE);
   }
 }


### PR DESCRIPTION
Closes #63.

The robot follows a Choreo path, and the whole loop closes in a plain
JUnit test — follower to field-relative velocities to kinematics to
module voltages to the plant to a pose and back into the follower, with
no HAL and no vendor type in it.

## What is here

- **`PathFollower`** — WPILib's own two-method stub, implemented. The
  interface does not say which frame `next()` is in and neither does any
  type, so it is written at the interface.
- **`HolonomicPathFollower`** — samples the trajectory, adds a P
  correction per axis to the sample's own feedforward velocity, and
  hands on `sample.acceleration` undifferentiated. Takes a trajectory
  lookup and a read-only pose supplier, not the estimator: `Drive` still
  cannot reset pose and still never learns cameras exist.
- **`FieldConstants`** — the one function that flips a path for red,
  raising a `HIGH` alert rather than defaulting when no alliance has
  arrived.
- **`DoNothingAuto`, `SweepLeftAuto`** — the safe pick, and a routine
  composed from coroutines with a pose trigger.

## Three things worth a reviewer's attention

**`isDone` is not the clock alone.** A robot held against a defender
runs the clock out where it is standing. A follower that reports done
there makes the timeout unreachable — it never fires, because `isDone`
got there first — and hands the next command a robot a metre from where
it assumes. It is the clock *and* arrival inside a tolerance.

**The accelerations overload converts in the estimator's frame, not the
gyro's.** `Odometry3d.resetPose` assigns the pose and integrates gyro
*deltas* onto it, so the two are decoupled the moment anything seeds a
starting pose — and a follower whose error is measured against the
estimate has to be converted back in that same frame. The
single-argument form stays on the gyro deliberately: a driver's forward
should not jump when a vision update moves the estimate.

**`transformBy` cannot express the alliance flip**, so it is written per
sample. It is rigid about the trajectory's own first pose rather than
about the origin, and it carries velocities and accelerations through
unrotated — which under a 180° flip drives the mirrored path backwards,
compiling and running the whole way. ADR 0011 said to use it; that claim
is corrected in this PR.

## Numbers, and why one of them is loose

Tier 1 asserts max cross-track error and completion within duration plus
a margin. `StraightAhead` holds 0.05 m; `SweepLeft` gets 0.8 m, and the
looseness is real rather than slack: with `kA` configured zero the drive
lags its velocity setpoint by a plant time constant, and on a curve that
lag is read as cross-track. The follow timeout's 2 s margin comes from
the same measurement. Both tighten when characterisation produces a
`kA`, and neither was reached by adjusting a sim gain until a test
passed.

## Docs

ADR 0011's *Open* item on the follow timeout is resolved into the
Decision, its `transformBy` claim is corrected in *Traps*, and ADR 0005
gains the `/Auto` signals this writes.

## Known, and not fixed here

The flip assumes the field-centre origin ADR 0011 targets, but the
committed paths are in corner-origin coordinates, so **red autonomous
drives off the field today**. The code implements the decided
architecture and the paths are #75's placeholders — ADR 0011 already
says every path is regenerated when the field map lands — but it is real
and it is tracked separately, alongside #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzD9PgrkYKqQfKVjRqJjn
