### PR TITLE
Put the path in the frame the flip already worked in

### DIFF
--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -9,6 +9,16 @@ is written per sample rather than through
 `HolonomicTrajectory.transformBy`, which turns out not to express it —
 see the fourth entry under *Traps*.
 
+Amended again 2026-08-28 by #78, which closed the origin question and
+found this ADR wrong in two places while doing it. Field centre is
+confirmed as the destination and every artifact that ships today is
+still corner-origin, so **the load converts the frame** — see
+*Trajectories arrive in the robot's frame*, which replaces *Trajectories
+cache raw*. And the *Traps* entry on `Transform2d` described the
+blue-corner flip as a reflection, which is the wrong flip for a
+rotationally symmetric field and is not what ChoreoLib does; corrected
+there.
+
 Amended by ADR 0012, which owns the pose
 estimator: `Drive.getGyroHeading()` returns a `Rotation3d` rather than a
 `Rotation2d`, and the estimator beside `Drive` is
@@ -300,14 +310,28 @@ wheel slipped, a time marker fires in the wrong place and a pose
 trigger does not. Splits stop being necessary once each segment is its
 own file.
 
-### Trajectories cache raw; the alliance flip happens at follower construction
+### Trajectories arrive in the robot's frame; the alliance flip happens at follower construction
 
-The cache holds the trajectory **exactly as authored**. The flip is
-applied when the `PathFollower` is constructed. **[decided]**
+The cache holds the trajectory **in the robot's own coordinate frame,
+converted once at load**, and holds nothing about which alliance it is
+for. The flip is applied when the `PathFollower` is constructed.
+**[decided]**
 
-Flipping at load is wrong: a cached trajectory would be bound to
-whatever alliance was set the first time the file was read, so
-switching alliance for a test would need a restart. The follower, by
+The conversion is the origin and nothing else. Choreo emits blue-corner
+coordinates and the robot works in field centre, so `TrajectoryLoader`
+subtracts half the field's length and width from every sample pose as
+it reshapes the file. It is a translation, so the heading, the velocity
+and the acceleration all carry through untouched — which is what makes
+it safe to do at load, where the flip is not. Field centre is where
+2027 is going **[source]**, and when it arrives the two constants go to
+zero and the conversion deletes.
+
+Flipping at load is wrong, and the difference between the two is not
+one of taste. A frame is a property of the file; an alliance is a
+property of the match, and it is not known when the file is read. A
+cached flip would bind the trajectory to whatever alliance was set the
+first time it was read, so switching alliance for a test would need a
+restart. The follower, by
 contrast, is constructed inside `followPath`'s `run(coroutine -> …)`
 body, which re-runs **every time the command is scheduled**. Change
 alliance in the sim GUI → disable → enable → correct flip.
@@ -422,10 +446,11 @@ produce it. ADR 0009 owns that.
   WPILib-shaped JSON directly, which upstream's stated intent makes
   plausible.
 
-- **Every path gets regenerated when the 2027 field map lands.** The
-  `.traj` schema is version 3 today and a coordinate-origin change
-  would almost certainly bump it. Plan on it rather than being
-  surprised by it. The `.chor` is the source of truth; a regenerated
+- **Every path gets regenerated when the 2027 field map lands, and the
+  frame conversion deletes with them.** The `.traj` schema is version 3
+  today and a coordinate-origin change would almost certainly bump it —
+  which is the signal, since `TrajectoryLoader` already refuses any
+  other version. Plan on it rather than being surprised by it. The `.chor` is the source of truth; a regenerated
   `.traj` should be a reviewable diff, which is why both file kinds are
   committed.
 
@@ -500,12 +525,18 @@ produce it. ADR 0009 owns that.
   path that tracks perfectly on a straight run and diverges the moment
   the robot rotates.
 
-- **A `Transform2d` cannot express the blue-corner flip, and
-  `transformBy` does not express the field-centre one either.** A
-  blue-corner flip is a **reflection** — `x → length − x`, heading
-  `→ π − heading` — and no rigid transform is a reflection. Reaching
-  for `transformBy` under a corner origin gives a path that is
-  plausibly shaped, wrong, and produces no error.
+- **`transformBy` does not express the flip, and the corner-origin form
+  of it is a rotation rather than a reflection.** Written about a
+  corner the flip is `x → length − x`, `y → width − y`, heading
+  `→ θ + π` — the same rotation as the field-centre form, about a point
+  that is not the origin. A **reflection** (`x → length − x`, heading
+  `→ π − heading`) is a different flip, correct only for a
+  mirror-symmetric field, and it is not what the 2026 field or
+  ChoreoLib use — `Flipper.FRC_CURRENT` is `rotatedAround(FIELD_LENGTH,
+  FIELD_WIDTH)` **[source]**. Reaching for the reflection gives a path
+  that is plausibly shaped, wrong, and produces no error. We do not
+  write either corner form: the frame is converted at load and the flip
+  stays the field-centre one.
 
   `HolonomicTrajectory.transformBy(Transform2d)` does not save the
   field-centre case: it is rigid **about the trajectory's own first
@@ -563,33 +594,37 @@ produce it. ADR 0009 owns that.
 
 ## Open
 
-- **The field origin is unresolved, and two consumers depend on it.**
-  The map owner reports that 2027 moves the origin to field centre.
-  **The alpha-7 tree does not reflect that**: the `fields` module still
-  documents *"the origin at the bottom-right corner of the blue
-  alliance wall"* (`fields/src/main/java/org/wpilib/fields/Field.java:32-33`)
-  and `OriginPosition` offers only `BLUE_ALLIANCE_WALL_RIGHT_SIDE` and
-  `RED_ALLIANCE_WALL_RIGHT_SIDE` (`:43-48`). **[source]** #6 recorded
-  the Choreo maintainer gating the change on the 2027 field AprilTag
-  map, which has not shipped. **[unverified]**
+- **When the field origin moves, and whether it moves under the 2026
+  layouts too.** *That* it moves is settled: field centre is where 2027
+  is going, from Peter Johnson in the WPILib Discord on 2026-04-11.
+  **[source — #78]** Nothing that ships today is in it — the `fields`
+  module still documents *"the origin at the bottom-right corner of the
+  blue alliance wall"*
+  (`fields/src/main/java/org/wpilib/fields/Field.java:32-33`),
+  `OriginPosition` offers only `BLUE_ALLIANCE_WALL_RIGHT_SIDE` and
+  `RED_ALLIANCE_WALL_RIGHT_SIDE` (`:43-48`) **[source]**, and Choreo's
+  editor still nails its canvas to a corner **[source — #78]**.
 
-  The two consumers are **the trajectory flip** (this ADR) and
-  **vision** (ADR 0012), and they must agree — a tag layout in one
-  origin and a path in the other is a robot that drives confidently to
-  the wrong half of the field.
+  Nothing on the public tracker records the change: no issue, no PR, no
+  milestone entry, no docs branch. **That is silence, not doubt** —
+  re-running the search and reading it as absence is how #78 first got
+  this backwards.
 
-  The consequence for the flip is concrete, and field-centre is
-  strictly simpler:
+  So the robot works in field centre now and converts what it reads,
+  and this is no longer a decision waiting on an event. What is left is
+  timing, and one live hazard: **whether the 2026 layouts are
+  retroactively converted** was asked in the same exchange and answered
+  *"probably a good idea? I think?"*, with nothing since.
+  **[unverified]** The field JSON declares no origin at all, so a
+  retroactive conversion moves every tag by half a field with no schema
+  bump behind it and an offset applied twice looks like a robot that is
+  merely confident. `.traj` at least has the version-3 check
+  `TrajectoryLoader` already fails on; the layout has nothing. ADR 0012
+  owns the check that catches it.
 
-  | Origin | Flip is | Implementation |
-  |---|---|---|
-  | **Field-centre** | 180° rotation about the origin — a **rigid transform** | negate x and y, turn the heading half a turn, negate the velocity and acceleration vectors; one function |
-  | Blue-corner | a **reflection** (`x → length − x`, heading `→ π − heading`) | a hand-written per-sample remap; `Transform2d` cannot express it |
-
-  We target field-centre. The one-function rule is what makes this
-  switchable at all. *Unblocked by* the 2027 field release and its
-  AprilTag map, at which point the function is re-verified against the
-  real thing rather than against a report.
+  *Unblocked by* the 2027 field release and its AprilTag map, at which
+  point both conversions go to zero and the flip is re-verified against
+  the real field rather than against a frame we translated into.
 
 - **Whether the converter is throwaway or permanent.** If ChoreoLib's
   `Trajectory` eventually **extends** `org.wpilib.math.trajectory.Trajectory`

--- a/docs/adr/0012-pose-estimation-and-vision.md
+++ b/docs/adr/0012-pose-estimation-and-vision.md
@@ -13,6 +13,11 @@ possible*. And `odometryUpdate` stamps the odometry buffer itself,
 because `update()` keys it on a clock the vision seam does not use —
 see *Traps*.
 
+Amended again 2026-08-28 by #78, which settled the field origin. The
+robot works in field centre, so the seam's contract now names the frame
+a measurement arrives in — see *The seam is one method on a class that
+already exists upstream*.
+
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
 `v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. Phoenix 6
@@ -79,6 +84,36 @@ interface, no `VisionMeasurement` record, no vision type of any kind. A
 season's vision class holds a reference to `PoseEstimator` and calls
 that method. Unplugging vision next September is **deleting that
 class**, and the drive base never knew it existed. **[decided]**
+
+**The measurement arrives in field centre**, which is the frame the
+robot works in and the one ADR 0011's trajectories are converted into
+at load. That is the whole of the contract the drive base can state,
+and stating it is what keeps the two consumers of the origin in
+agreement without either knowing about the other. **[decided]**
+
+Producing a measurement in that frame is the vision class's job, and
+today it is a conversion rather than a read: everything published is
+still blue-corner. A class solving poses on the robot from WPILib's own
+layout gets there with
+`Field.setOrigin(new Pose3d(new Translation3d(length / 2, width / 2, 0), Rotation3d.kZero))`
+— `getTagPose` returns `tag.getPose().relativeTo(m_origin)`
+(`fields/src/main/java/org/wpilib/fields/Field.java:394`) **[source]**,
+so the stock layout needs no forked copy and no hand-edited tag poses.
+`OriginPosition`'s two members are named presets over that same setter
+(`:349-357`) **[source]** and neither of them is field centre.
+
+⚠️ **The layout declares no origin, so it cannot tell you which frame
+it is already in.** Its keys are `name`, `season`, `game`,
+`field-image`, `field-dimensions`, `program`, `field-tags`
+(`fields/src/main/native/resources/org/wpilib/fields/frc/2026-rebuilt-welded.json`)
+**[source]** — a revision published in field centre would move every tag
+by half a field with nothing in the schema to announce it, and an offset
+applied twice reads as a robot that is merely confident. The signs are
+the tell: **every tag has x ≥ 0 in a corner-frame layout and roughly
+half are negative in a centre-frame one.** A vision class that reads a
+layout checks that before trusting it, and fails rather than adapting.
+Nothing in the drive base does this, because nothing in the drive base
+reads a layout.
 
 `Drive` is untouched by this. It exposes `getGyroHeading()` and
 `getModulePositions()` for pose, exactly as ADR 0011 left it, and
@@ -460,15 +495,14 @@ older spellings appears anywhere.
   disabled is free, lands in the season's class, and drives the identical
   ratio.
 
-- **ADR 0011's field-origin question now has two consumers.** Vision
-  measurements are field-absolute, so a tag layout in one origin and a
-  trajectory in the other is a robot that drives confidently to the wrong
-  half of the field. Under a blue-corner origin,
-  `Field.setOrigin(OriginPosition)`
-  (`fields/src/main/java/org/wpilib/fields/Field.java:349`) **[source]**
-  and ADR 0011's trajectory flip must agree. That raises the cost of
-  getting it wrong; it does not change who decides it, and it is still
-  unresolved upstream. See Open.
+- **ADR 0011's field-origin question has two consumers, and one
+  answer.** Vision measurements are field-absolute, so a tag layout in
+  one origin and a trajectory in the other is a robot that drives
+  confidently to the wrong half of the field. Both are now converted
+  into field centre on the way in — the trajectory at load, the layout
+  at `setOrigin` — so they agree by construction rather than by two
+  places being kept in step. The seam names the frame; producing a
+  measurement in it is the vision class's job.
 
 - **The CAN frame budget grows by the heading and the yaw rate at
   200 Hz.** That is a real cost against a bus that already carries eight
@@ -690,17 +724,16 @@ older spellings appears anywhere.
 
 ## Open
 
-- **The field origin is unresolved, and this ADR is its second
-  consumer.** ADR 0011 records it in full: the map owner reports 2027
-  moves the origin to field centre, and the alpha-7 tree does not
-  reflect that — `Field`'s class doc still describes *"the origin at the
-  bottom-right corner of the blue alliance wall"*
-  (`Field.java:32-33`) and `OriginPosition` offers only
-  `BLUE_ALLIANCE_WALL_RIGHT_SIDE` and `RED_ALLIANCE_WALL_RIGHT_SIDE`
-  (`:45-47`) **[source]**. **[unverified]** For vision the consequence
-  is `Field.setOrigin(...)`; for autonomous it is the trajectory flip;
-  and the two must agree or vision and the path disagree by a mirror.
-  *Unblocked by* the 2027 field release and its AprilTag map.
+- **Whether a 2026 layout arrives already converted.** ADR 0011 records
+  the origin question in full and #78 closed it: field centre is where
+  2027 is going **[source]**, nothing shipped is in it yet, and this ADR
+  converts on the way in. What is open is whether the **2026** layouts
+  get retroactively converted — asked of WPILib in the same exchange and
+  answered *"probably a good idea? I think?"*, with nothing since.
+  **[unverified]** *Unblocked by* the 2027 field release, or by a 2026
+  layout revision landing first. A vision class reading WPILib's layout
+  on the robot is the thing that would notice, and the seam section says
+  how.
 
 - **Whether 200 Hz is enough.** The field precedent is 254's 250 Hz
   history, and our loop is 200 Hz. The gap is small and nobody has shown

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -22,7 +22,22 @@ public final class FieldConstants {
       new Alert(
           "path-alliance-unknown", "Following a path with no alliance; assuming blue", Level.HIGH);
 
+  // Choreo draws in the blue-alliance-corner frame and WPILib publishes its tag layouts in it; the
+  // robot works in field centre, which is where 2027 is going. The dimensions are the 2026 field's
+  // because that is the field the paths were drawn against, and both halves go to zero when the
+  // origin moves.
+  private static final double HALF_LENGTH = 16.541 / 2;
+  private static final double HALF_WIDTH = 8.0692 / 2;
+
   private FieldConstants() {}
+
+  public static double fromCornerX(double x) {
+    return x - HALF_LENGTH;
+  }
+
+  public static double fromCornerY(double y) {
+    return y - HALF_WIDTH;
+  }
 
   public static HolonomicTrajectory forAlliance(HolonomicTrajectory trajectory) {
     return onRed() ? flip(trajectory) : trajectory;
@@ -35,9 +50,9 @@ public final class FieldConstants {
     return onRed() ? flip(pose) : pose;
   }
 
-  // The origin is field centre, where the flip is a 180-degree rotation about it. Under the
-  // blue-corner origin the alpha-7 tree still documents, the same flip is a reflection instead,
-  // and every line below changes. Vision has to be told the same answer.
+  // The origin is field centre, where the flip is a 180-degree rotation about it. Anything drawn
+  // against a corner comes through fromCornerX and fromCornerY first; vision is told the same
+  // answer through Field.setOrigin.
   public static HolonomicTrajectory flip(HolonomicTrajectory trajectory) {
     return new HolonomicTrajectory(
         trajectory.getSamples().stream().map(FieldConstants::flip).toList());

--- a/src/main/java/first/robot/TrajectoryLoader.java
+++ b/src/main/java/first/robot/TrajectoryLoader.java
@@ -122,11 +122,16 @@ public final class TrajectoryLoader {
   }
 
   // Both formats state the velocity and the acceleration in the field frame, so the whole mapping
-  // is a reshaping and there is no rotation anywhere in it.
+  // is a reshaping and a translation, and there is no rotation anywhere in it. The translation is
+  // the origin: Choreo emits corner coordinates and everything downstream is field centre, which
+  // leaves the heading and both vectors alone.
   private static HolonomicSample convert(ChoreoSample sample) {
     return new HolonomicSample(
         sample.t(),
-        new Pose2d(sample.x(), sample.y(), new Rotation2d(sample.heading())),
+        new Pose2d(
+            FieldConstants.fromCornerX(sample.x()),
+            FieldConstants.fromCornerY(sample.y()),
+            new Rotation2d(sample.heading())),
         new ChassisVelocities(sample.vx(), sample.vy(), sample.omega()),
         new ChassisAccelerations(sample.ax(), sample.ay(), sample.alpha()));
   }

--- a/src/main/java/first/robot/opmode/SweepLeftAuto.java
+++ b/src/main/java/first/robot/opmode/SweepLeftAuto.java
@@ -26,8 +26,9 @@ public class SweepLeftAuto implements OpMode {
   private static final String PATH = "SweepLeft";
 
   // Where along the path the zone starts. A pose says it and the clock does not: a robot running
-  // 300 ms late crosses the same line, and a time marker fires 300 ms short of it.
-  private static final Distance ZONE_LINE = Meters.of(4);
+  // 300 ms late crosses the same line, and a time marker fires 300 ms short of it. Read off the
+  // path in Choreo, so it arrives in corner coordinates like the path does.
+  private static final Distance ZONE_LINE = Meters.of(FieldConstants.fromCornerX(4));
 
   private final Trigger enabled = new Trigger(RobotState::isEnabled);
   private final Trigger pastZoneLine;

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -21,6 +21,7 @@ import org.wpilib.util.AlertDataJNI;
 
 class FieldConstantsTest {
   private static final double TOLERANCE = 1e-9;
+  private static final Rotation2d ANGLE = Rotation2d.fromDegrees(30);
 
   private static final HolonomicTrajectory PATH =
       new HolonomicTrajectory(
@@ -52,6 +53,27 @@ class FieldConstantsTest {
     assertEquals(-3, flipped.acceleration.ax, TOLERANCE);
     assertEquals(-4, flipped.acceleration.ay, TOLERANCE);
     assertEquals(0.75, flipped.acceleration.alpha, TOLERANCE);
+  }
+
+  // The centre origin is what makes the flip a rotation, so the two conversions have to put the
+  // field's own edges symmetrically about zero. A wrong dimension shows up here and nowhere else
+  // until a path is flipped off the field.
+  @Test
+  void theCornerConversionPutsTheFieldSymmetricallyAboutTheOrigin() {
+    assertEquals(-FieldConstants.fromCornerX(16.541), FieldConstants.fromCornerX(0), TOLERANCE);
+    assertEquals(-FieldConstants.fromCornerY(8.0692), FieldConstants.fromCornerY(0), TOLERANCE);
+  }
+
+  // A corner-frame pose and its rotation about the field's centre both land in the converted
+  // frame as a pair the flip carries between, which is the whole reason the conversion exists.
+  @Test
+  void aCornerFramePoseFlipsToTheRotationOfItselfAboutTheFieldCentre() {
+    var drawn = new Pose2d(FieldConstants.fromCornerX(2), FieldConstants.fromCornerY(2), ANGLE);
+
+    var flipped = FieldConstants.flip(drawn);
+
+    assertEquals(FieldConstants.fromCornerX(16.541 - 2), flipped.getX(), TOLERANCE);
+    assertEquals(FieldConstants.fromCornerY(8.0692 - 2), flipped.getY(), TOLERANCE);
   }
 
   @Test

--- a/src/test/java/first/robot/TrajectoryLoaderTest.java
+++ b/src/test/java/first/robot/TrajectoryLoaderTest.java
@@ -57,8 +57,8 @@ class TrajectoryLoaderTest {
 
     var sample = trajectory.start();
     assertEquals(0.0, sample.time, EPSILON);
-    assertEquals(1.0, sample.pose.getX(), EPSILON);
-    assertEquals(2.0, sample.pose.getY(), EPSILON);
+    assertEquals(FieldConstants.fromCornerX(1.0), sample.pose.getX(), EPSILON);
+    assertEquals(FieldConstants.fromCornerY(2.0), sample.pose.getY(), EPSILON);
     assertEquals(0.5, sample.pose.getRotation().getRadians(), EPSILON);
     assertEquals(3.0, sample.velocity.vx, EPSILON);
     assertEquals(4.0, sample.velocity.vy, EPSILON);
@@ -130,6 +130,41 @@ class TrajectoryLoaderTest {
     var thrown = assertThrows(NoSuchElementException.class, () -> loader.get("Absent"));
     assertTrue(thrown.getMessage().contains("Absent"), thrown.getMessage());
     assertTrue(thrown.getMessage().contains("Path"), thrown.getMessage());
+  }
+
+  // Choreo's frame is the corner and the robot's is the centre, so the load is the one place the
+  // two meet. The heading and both vectors are left alone because a translation does not turn them.
+  @Test
+  void theCornerFrameChoreoEmitsBecomesTheFieldCentreOneTheRobotUses(@TempDir Path deploy)
+      throws IOException {
+    var sample = loaderOver(deploy, "Path", file(3, "Swerve", SAMPLES)).get("Path").start();
+
+    assertEquals(1.0 - 16.541 / 2, sample.pose.getX(), EPSILON);
+    assertEquals(2.0 - 8.0692 / 2, sample.pose.getY(), EPSILON);
+    assertEquals(0.5, sample.pose.getRotation().getRadians(), EPSILON);
+    assertEquals(3.0, sample.velocity.vx, EPSILON);
+    assertEquals(4.0, sample.velocity.vy, EPSILON);
+    assertEquals(5.0, sample.acceleration.ax, EPSILON);
+    assertEquals(6.0, sample.acceleration.ay, EPSILON);
+  }
+
+  // The failure this conversion exists to kill. The flip is a rotation about the origin, so a path
+  // left in Choreo's corner frame rotates into the quadrant behind the field and takes the
+  // estimator seed with it, throwing nothing on the way.
+  @Test
+  void aCommittedPathIsStillOnTheFieldAfterTheAllianceFlip() {
+    var loader = new TrajectoryLoader(Path.of("src", "main", "deploy"));
+
+    for (var name : new String[] {"StraightAhead", "SweepLeft"}) {
+      for (var sample : FieldConstants.flip(loader.get(name)).getSamples()) {
+        assertTrue(
+            Math.abs(sample.pose.getX()) <= 16.541 / 2,
+            () -> name + " flips to x " + sample.pose.getX());
+        assertTrue(
+            Math.abs(sample.pose.getY()) <= 8.0692 / 2,
+            () -> name + " flips to y " + sample.pose.getY());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
The follow-on work from #78. Fixes red autonomous, and corrects the two ADRs the research found wrong.

## The bug

`FieldConstants.flip` is a rotation about the origin, and the origin is field centre — ADR 0011's decision, and what the code implements. The paths committed in #75 are Choreo's output, and **Choreo draws from the blue alliance corner**. Nothing reconciled the two.

So on red, `SweepLeft` rotated to x −2.0…−5.5, y −2.0…−5.5 — off the field, behind the driver station. `SweepLeftAuto` seeded the estimator there and drove at it. Nothing threw anywhere along the way.

## The fix: convert where the file is read

Field centre is where 2027 is going and nothing shipped is in it yet, so the frame is reconciled at the boundary. `TrajectoryLoader` subtracts half the field from each sample pose as it reshapes a `.traj` — a **translation**, so the heading, the velocity and the acceleration all carry through untouched.

That is what makes it safe to do at load, where the alliance flip is not: **a frame is a property of the file; an alliance is a property of the match**, and the match is not known when the file is read. The flip stays at follower construction, unchanged.

`FieldConstants` gains `fromCornerX`/`fromCornerY` and the two dimensions. Both go to zero when the origin moves, and the conversion deletes.

The zone line in `SweepLeftAuto` moves with it — it was read off the path in Choreo, so it is a corner-frame number. Left behind, it would sit 8.27 m past anywhere the robot goes and simply never fire.

## Where the paths land now

```
                 loaded                          flipped (red)              half-field
StraightAhead    x [-6.271,-3.271] y [-0.035]    x [3.271,6.271] y [0.035]  8.271 x 4.035
SweepLeft        x [-6.271,-2.771] y [-2.035,1.465]  x [2.771,6.271] y [-1.465,2.035]
```

Both alliances, every sample, inside the field.

## Tests

`aCommittedPathIsStillOnTheFieldAfterTheAllianceFlip` is the one that matters — both committed paths, flipped, every sample bounded by the half-field. **Verified failing on the old loader**: `SweepLeft flips to y -4.06398` against a half-width of 4.0346.

Also `theCornerFrameChoreoEmitsBecomesTheFieldCentreOneTheRobotUses` (the translation is applied and nothing else is), and two in `FieldConstantsTest` — that the conversion puts the field's own edges symmetrically about zero, which is where a wrong dimension shows up, and that a corner-frame pose flips to the rotation of itself about the field centre.

`PathFollowingTest` is unaffected: it drives the paths in a free-space sim seeded from their own first sample, so it never saw absolute coordinates.

## ADR 0011 — wrong in two places

- **Its blue-corner row described a reflection** (`x → L − x`, heading `→ π − heading`) and concluded the corner origin costs a hand-written per-sample remap. That is the wrong flip for a rotationally symmetric field and is not what ChoreoLib does — `Flipper.FRC_CURRENT` is `rotatedAround(...)`. It is part of why field-centre looked strictly simpler than it is. Corrected in *Traps*.
- **"Trajectories cache raw" no longer holds.** The cache holds the robot's frame, converted once at load. The section is retitled and rewritten, with the frame-vs-alliance distinction as the reason the two happen in different places.
- The origin *Open* item is rewritten: field centre is `[source]` now, the public tracker's silence is recorded **as silence** so it is not re-read as doubt, and what remains open is timing plus the retroactive-conversion hazard.

## ADR 0012 — the frame, not a class to enforce it

ADR 0012 deliberately keeps **no vision type in this repo**, so a new decision section would have contradicted it. Instead the seam's contract names the frame: `visionUpdate` takes a measurement in field centre, and producing one is the vision class's job.

Written down there for whoever brings vision: `Field.setOrigin(Pose3d)` gets there from the stock layout with no fork and no hand-edited tag poses (`OriginPosition`'s two members are presets over the same setter, and neither is field centre) — and the trap that **the layout declares no origin at all**, so a revision published in centre coordinates moves every tag half a field with nothing in the schema to announce it. The tell is the signs: every tag has x ≥ 0 in a corner-frame layout, roughly half are negative in a centre-frame one. Check before trusting; fail rather than adapt. Nothing in the drive base does it, because nothing in the drive base reads a layout.

## Still open

Whether AdvantageScope's field view can be told about a centre origin. A robot at the blue wall now logs `x = −8.27`, and ADR 0011 writes the trajectory at start specifically for that view. Not established here, and worth ten minutes with a log.

Follows #78 / #79.