### PR TITLE
Log the voltage the controller applied, not the one we asked for

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -343,6 +343,13 @@ The index of the ADRs themselves is
   one model over it, so they are one measurement rather than four, and
   it will not open a log that is missing one
   ([ADR 0009](docs/adr/0009-characterisation-and-tuning.md)).
+- **Applied output** — the duty cycle a SPARK reports it actually ran
+  at, which multiplied by the bus voltage is the volts that reached the
+  motor. It is not the volts that were asked for: a current limit holds
+  the output to `backEmf ± currentLimit · R`, so a step from rest
+  applies a fraction of itself. The voltage column of a characterisation
+  log is the applied one
+  ([ADR 0009](docs/adr/0009-characterisation-and-tuning.md)).
 - **Effective wheel radius** — the radius a wheel behaves as if it has,
   which is smaller than the one it was bought with and shrinks as it
   wears. Measured by spinning the robot on the spot and comparing the

--- a/docs/adr/0007-can-topology-and-frames.md
+++ b/docs/adr/0007-can-topology-and-frames.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted — 2026-08-26.
+Accepted — 2026-08-26. Amended 2026-08-29: the characterisation raise
+ADR 0009 decided is now budgeted here, beside the tuning one it is
+smaller than.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -199,6 +201,30 @@ apply the winner to four. Status9 is MAXMotion (`:819-820, 856-857`)
 A tuning session is the one time the bus is allowed to run near its
 ceiling, because it happens on a bench with nobody on the field and it
 ends when the gains are written into the repo.
+
+### Characterisation raises one of those three, not all three
+
+A characterisation run is not a tuning session and does not spend a
+tuning session's budget. The voltage column of its log is the applied
+output, which is Status0 — so **a characterisation raises Status0 alone
+to loop rate on a single named SPARK**, for **10 to 200 frames/s: +190
+to ~4110 total, 54–64%**. **[unverified — arithmetic]** It raises
+nothing else, and it is put back when the run ends.
+
+Status7 and Status8 stay at their periods because there is no closed
+loop running during a characterisation: `iAccumulation` and the setpoint
+readback would report zeros at 390 frames/s. **[decided]**
+
+`appliedOutputPeriodMs` and `busVoltagePeriodMs` are both Status0
+(`SignalsConfig.java:95-96, 115-116`) **[source]**, which is what the
+column needs — applied output is a duty cycle and the bus voltage is the
+rail it is a fraction of — and output current and motor temperature ride
+the same frame for nothing.
+
+Which controller is instrumented is a constant naming one module, and
+the routine picks the motor role: drive and rotation instrument that
+module's drive SPARK, steer its steer SPARK. ADR 0009 owns what the
+column is for.
 
 ### One project constant per physical bus, converted at each call site
 

--- a/docs/adr/0009-characterisation-and-tuning.md
+++ b/docs/adr/0009-characterisation-and-tuning.md
@@ -6,7 +6,10 @@ Accepted — 2026-08-26. Amended 2026-08-29, on implementing it: the
 analyser fits one model over all four tests combined, so *every* routine
 runs all four whatever it can use of the result — see *Traps* and the
 steer decision. The routines are also enumerated now that there are
-four of them, and a wheel-radius measurement joins them.
+four of them, and a wheel-radius measurement joins them. Amended again
+2026-08-29, on building the frame raise: the voltage column is the
+applied output rather than the request, and it is honest under a stated
+condition rather than unconditionally.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -106,9 +109,22 @@ compensation **[source]**. So the `Voltage` the routine hands out is the
 voltage the controller applies **while nothing else is limiting the
 output**, and the current limit is something else limiting the output.
 See *Traps*: the request and the application are the same number for the
-quasistatic ramp and part of the dynamic step, and the log records the
-request. Making the column unconditionally honest is
-[#81](https://github.com/Drew-Robotics/2027beta/issues/81).
+quasistatic ramp and part of the dynamic step, and they part company
+through the rest of it.
+
+**So the column is not the request.** The voltage logged is
+`getAppliedOutput() × getBusVoltage()` — the controller's own report of
+the duty cycle it ran at, multiplied back by the rail it was a fraction
+of. **[decided]** That is a number the robot reads rather than one it
+wrote, which is what the frame raise below is for.
+
+**The column is honest while the applied-output frame is at the loop
+rate, and stale by up to one frame period otherwise.** It is a status
+frame, not a readback: what `getAppliedOutput()` returns is the last
+frame that arrived, so at the 100 ms diagnostic period a 5 ms log
+repeats one sample twenty times. The raise is what makes the condition
+hold for the length of a run, and nothing outside a characterisation
+holds it.
 
 The closed loop is not running during a characterisation. Open-loop
 voltage in, velocity out, is the whole test.
@@ -223,6 +239,22 @@ on Status0 at 100 ms.
 test** — 10 to 200 frames/s, **+190 to ~4110 total** **[unverified —
 arithmetic; ADR 0007 owns the budget]** — and raises nothing else.
 
+The raise is written by the command that runs the routine, not by the
+opmode that binds it: it goes up before anything the command does and
+comes back down when the routine ends, on both the path where the body
+finishes and the path where it is cancelled. For drive and rotation the
+settle sits between the two, so the frame is at rate well before the
+first sample. **Steer has no settle**, so its raise and its first sample
+share a loop, and a steer log can open on one sample up to a frame period
+stale.
+
+`appliedOutputPeriodMs` and `busVoltagePeriodMs` are both Status0
+(`SignalsConfig.java:95-96, 115-116`) **[source]**, so the two signals the
+column is computed from ride up together, and output current and motor
+temperature come with them for no extra frame. Faults and warnings are
+Status1 (`:192-193, 230-231`) **[source]** and are not touched, so the
+restore does not quietly slow the fault frame down with it. **[decided]**
+
 That is a *different* raise from ADR 0007's tuning allowance, which
 takes Status0 + Status7 + Status8. Status7 is `iAccumulation` and
 Status8 is the setpoint readback (`SignalsConfig.java:671-672`,
@@ -230,9 +262,18 @@ Status8 is the setpoint readback (`SignalsConfig.java:671-672`,
 closed loop, so both are reporting nothing. Raising them buys a reader
 two columns of zeros at 390 frames/s.
 
-Which controller is instrumented is a constant in `Constants` naming one
-module and one motor role, exactly as ADR 0007 requires: a redeploy, not
-a dashboard setting.
+Which controller is instrumented is a constant naming one module, exactly
+as ADR 0007 requires: a redeploy, not a dashboard setting. The motor role
+is the routine's rather than a second constant — drive and rotation
+instrument that module's drive SPARK, steer its steer SPARK — because a
+routine that raised the frame on a controller it does not read would log
+a column at 100 ms and a raise at 5 ms.
+
+**The restore is a blocking `configure()` on the loop thread**, and it
+runs from the cancellation path, so a run that ends in a cancel can
+overrun its loop while the write retries. That is accepted: it happens
+once, at the end of a supervised bench test, with the mechanism already
+stopped — and deferring it is how a frame stays raised into a match.
 
 ### Feedforward stays split across two machines, and steer's is `kS` alone
 
@@ -543,8 +584,8 @@ in Traps.
   encoder settings, and they change the *measurement*, not the plant —
   see Open.
 
-- **A current-limited motor applies a voltage that rises with speed
-  while the log records the one that was asked for.** A smart current
+- **A current-limited motor applies a voltage that rises with speed, and
+  a column carrying the request would read it as flat.** A smart current
   limit holds the output to `backEmf ± currentLimit · R`; for a NEO
   Vortex at ADR 0008's 60 A that span is 3.41 V, so a 7 V step applies
   **3.41 V from rest** and only reaches 7 V at **1.82 m/s**. Constant
@@ -559,8 +600,10 @@ in Traps.
   fit whole. In that run it took `kA` from the plant's 0.4052 to a
   fitted 0.4631, **+14%** — on the one gain the dynamic test exists to
   produce and the one ADR 0011 hands to `arbFeedforward`. **[executed]**
-  The fix is to log what was applied rather than what was asked for,
-  which is the frame raise this ADR already decided; see *Open*.
+  The fix is to log what was applied rather than what was asked for. The
+  column is `getAppliedOutput() × getBusVoltage()` and the frame carrying
+  both runs at the loop rate for the length of a run, which is the
+  decision above.
 
 - **A step test begun on the move reports the time it spent stopping as
   measurement delay.** `TrimStepVoltageData` takes the velocity delay as
@@ -613,18 +656,6 @@ in Traps.
   are two routines and take two names.
 
 ## Open
-
-- **The Status0 raise this ADR decided is not built, and the voltage
-  column is the requested voltage until it is.** **[unverified]** The
-  raise was argued around on the grounds that `setVoltage` makes the
-  request and the application the same number, which holds until the
-  current limiter binds — and it binds through the lower half of every
-  dynamic step. *Unblocked by*
-  [#81](https://github.com/Drew-Robotics/2027beta/issues/81), which
-  carries the raise, the applied-output column, and the simulation
-  problem underneath it: nothing drives a SPARK's applied output in
-  simulation today, and ADR 0010 forbids `first.robot.sim` learning what
-  a SPARK is.
 
 - **How a chassis-level rotation gain reaches modules that close
   velocity on the SPARK.** **[unverified]** The rotation fit is in volts

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -6,7 +6,9 @@ Accepted — 2026-08-26. Resolves ADR 0003's `SparkSim` item, which held
 that this ADR had nothing to write until that class loaded against our
 WPILib. It still does not load, and this ADR does not use it — the
 sensor sims beside it are clean, and they are what the decision rests
-on.
+on. Amended 2026-08-29: applied output is a fourth simulated signal, and
+it is written to the device's `SimDevice` directly because the class that
+would write it is the one that does not load.
 
 The *Open* item asking whether CI runs a headless robot program is
 answered by ADR 0013 and now sits under *Consequences*.
@@ -164,6 +166,38 @@ deliberately loose and #23's `sim-hitl` is *drive around in sim*.
 integration, so `setPosition` writes the value the model already
 computed. `iterate(velocity, dt)` would integrate a second time on top
 of it, and it carries a defect besides — see Traps.
+
+### Applied output is written where `SparkSim` would write it
+
+A fourth signal joined the three above once ADR 0009's voltage column
+became the applied output rather than the request: **what the controller
+put on the motor.** Nothing writes it today —
+`SparkBase.getAppliedOutput`'s own javadoc says *"this value will not be
+updated during simulation unless `SparkSim.iterate` is called"*
+(`com/revrobotics/spark/SparkBase.java:707-708`) **[source]** — and
+`SparkSim` is the one class this ADR cannot load.
+
+Both values behind that column live on the device's own `SimDevice`:
+`SparkSim` reaches them as `"Applied Output"` and `"Bus Voltage"` on
+`SimDeviceSim("SPARK Flex [" + busId + "," + deviceId + "]")`
+(`com/revrobotics/spark/SparkSim.java:80-85`) **[source]**, which is the
+same door the sensor sims go through. **They are written directly, from
+`first.robot.mechanisms`.** **[decided]** That is eight lines against a
+class that will not load, and it is the *whole* of what `SparkSim` would
+have contributed here: the plant already integrates and the loops are
+already modelled, so nothing else in that class is wanted.
+
+The number written is the plant's applied voltage, not the mechanism's
+commanded one. `SwerveDriveSim` clamps against the current limit exactly
+where the controller does and now reports what it clamped to, so the
+simulated column has the same shape as the real one — including the flat
+stretch at the bottom of a step that ADR 0009's traps are about.
+
+`SimDeviceSim.getDouble` returns `null` for a name it cannot resolve
+(`wpilibj/src/main/java/org/wpilib/simulation/SimDeviceSim.java:117-123`)
+**[source]**, so a handle taken before its SPARK exists drops every write
+rather than throwing — the same silent no-op the sensor sims have. See
+Traps.
 
 ### The tick is 5 ms and the sub-step is 1 ms
 

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -63,6 +63,9 @@ public final class DriveConstants {
   public static final Time FAULT_FRAME_PERIOD = Milliseconds.of(50);
   public static final Time DIAGNOSTIC_FRAME_PERIOD = Milliseconds.of(100);
 
+  // What the applied-output frame runs at while a characterisation is reading a column off it.
+  public static final Time CHARACTERISATION_FRAME_PERIOD = Constants.LOOP_PERIOD;
+
   // === SDS Mk5i, off the manufacturer's layout drawing =========================================
 
   // The three ratios are the manufacturer's; which of them this robot runs is not confirmed, and

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.wpilib.command3.Command;
+import org.wpilib.command3.Coroutine;
 import org.wpilib.command3.Mechanism;
 import org.wpilib.command3.NeedsNameBuilderStage;
 import org.wpilib.command3.Scheduler;
@@ -58,6 +59,7 @@ import org.wpilib.system.Timer;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Angle;
 import org.wpilib.units.measure.Voltage;
+import org.wpilib.util.function.BooleanConsumer;
 
 public class Drive implements Mechanism {
   private static final int MODULES = 4;
@@ -95,6 +97,8 @@ public class Drive implements Mechanism {
   private final OnboardLoopSim[] steerLoops = new OnboardLoopSim[MODULES];
   private final SparkRelativeEncoderSim[] driveEncoderSims = new SparkRelativeEncoderSim[MODULES];
   private final SparkAnalogSensorSim[] steerSensorSims = new SparkAnalogSensorSim[MODULES];
+  private final SparkOutputSim[] driveOutputSims = new SparkOutputSim[MODULES];
+  private final SparkOutputSim[] steerOutputSims = new SparkOutputSim[MODULES];
   private final Pigeon2SimState gyroSim;
   private Angle simDrift;
   private Angle simYaw;
@@ -191,6 +195,8 @@ public class Drive implements Mechanism {
         // write, and the mechanism's encoders then read zero forever with nothing thrown.
         driveEncoderSims[i] = new SparkRelativeEncoderSim(modules[i].getDriveMotor());
         steerSensorSims[i] = new SparkAnalogSensorSim(modules[i].getSteerMotor());
+        driveOutputSims[i] = new SparkOutputSim(modules[i].getDriveMotor());
+        steerOutputSims[i] = new SparkOutputSim(modules[i].getSteerMotor());
       }
     } else {
       physics = null;
@@ -293,28 +299,28 @@ public class Drive implements Mechanism {
   // carried routine, whose own command keeps its upstream name — "sysid-quasistatic-forward-drive"
   // and its siblings — because the analyser's readers already know them.
   public Command driveQuasistatic(Direction direction) {
-    return settledFirst(
+    return settledDriveRun(
         this::pointForward,
         driveCharacterisation.quasistatic(direction),
         "Drive.DriveQuasistatic[" + direction + "]");
   }
 
   public Command driveDynamic(Direction direction) {
-    return settledFirst(
+    return settledDriveRun(
         this::pointForward,
         driveCharacterisation.dynamic(direction),
         "Drive.DriveDynamic[" + direction + "]");
   }
 
   public Command rotationQuasistatic(Direction direction) {
-    return settledFirst(
+    return settledDriveRun(
         this::pointAroundTheSpin,
         rotationCharacterisation.quasistatic(direction),
         "Drive.RotationQuasistatic[" + direction + "]");
   }
 
   public Command rotationDynamic(Direction direction) {
-    return settledFirst(
+    return settledDriveRun(
         this::pointAroundTheSpin,
         rotationCharacterisation.dynamic(direction),
         "Drive.RotationDynamic[" + direction + "]");
@@ -323,19 +329,47 @@ public class Drive implements Mechanism {
   // No settle, and none to make: the module starts wherever it is parked, and where it is parked
   // is not a property the measurement depends on.
   public Command steerQuasistatic(Direction direction) {
-    return steerCharacterisation.quasistatic(direction);
+    return steerRun(
+        steerCharacterisation.quasistatic(direction), "Drive.SteerQuasistatic[" + direction + "]");
   }
 
   public Command steerDynamic(Direction direction) {
-    return steerCharacterisation.dynamic(direction);
+    return steerRun(
+        steerCharacterisation.dynamic(direction), "Drive.SteerDynamic[" + direction + "]");
   }
 
-  private Command settledFirst(Runnable point, Command routine, String name) {
+  private Command settledDriveRun(Runnable point, Command routine, String name) {
+    return instrumented(
+        raised -> modules[DriveConstants.CHARACTERISED_MODULE].instrumentDrive(raised),
+        coroutine -> {
+          coroutine.await(settle(point));
+          coroutine.await(routine);
+        },
+        name);
+  }
+
+  private Command steerRun(Command routine, String name) {
+    return instrumented(
+        raised -> modules[DriveConstants.CHARACTERISED_MODULE].instrumentSteer(raised),
+        coroutine -> coroutine.await(routine),
+        name);
+  }
+
+  // The applied-output frame is a 100 ms diagnostic and it is where the voltage column comes from,
+  // so it runs at the loop rate for the length of a run and goes back afterwards. It goes up ahead
+  // of the settle rather than ahead of the ramp: a frame requested at the ramp's first sample
+  // arrives after it.
+  private static Command instrumented(
+      BooleanConsumer instrument, Consumer<Coroutine> body, String name) {
     return Command.noRequirements(
             coroutine -> {
-              coroutine.await(settle(point));
-              coroutine.await(routine);
+              instrument.accept(true);
+              body.accept(coroutine);
+              instrument.accept(false);
             })
+        // whenCanceled does not run when a body ends on its own and the line after the body does
+        // not run when it is cancelled, so the frame is put back on both paths or on neither.
+        .whenCanceled(() -> instrument.accept(false))
         .named(name);
   }
 
@@ -384,7 +418,7 @@ public class Drive implements Mechanism {
   private void logDriveRamp(SysIdRoutineLog log) {
     var module = modules[DriveConstants.CHARACTERISED_MODULE];
     log.motor(module.getName())
-        .voltage(Volts.of(module.getDriveVolts()))
+        .voltage(module.getDriveAppliedVoltage())
         .linearPosition(module.getDriveDistance())
         .linearVelocity(module.getDriveSpeed());
   }
@@ -392,7 +426,7 @@ public class Drive implements Mechanism {
   private void logSteerRamp(SysIdRoutineLog log) {
     var module = modules[DriveConstants.CHARACTERISED_MODULE];
     log.motor(module.getName())
-        .voltage(Volts.of(module.getSteerVolts()))
+        .voltage(module.getSteerAppliedVoltage())
         .angularPosition(module.getSteerRotation())
         .angularVelocity(module.getSteerRate());
   }
@@ -402,8 +436,9 @@ public class Drive implements Mechanism {
   // largest a profile may ask for — none of which a module-level test can produce. The Pigeon's
   // yaw accumulates past a turn, so the position column is continuous where a Rotation2d wraps.
   private void logRotationRamp(SysIdRoutineLog log) {
-    log.motor(modules[DriveConstants.CHARACTERISED_MODULE].getName())
-        .voltage(Volts.of(modules[DriveConstants.CHARACTERISED_MODULE].getDriveVolts()))
+    var module = modules[DriveConstants.CHARACTERISED_MODULE];
+    log.motor(module.getName())
+        .voltage(module.getDriveAppliedVoltage())
         .angularPosition(gyro.getYaw().getValue())
         .angularVelocity(gyro.getAngularVelocityZWorld().getValue());
   }
@@ -684,6 +719,7 @@ public class Drive implements Mechanism {
       state = physics.update(driveVolts, steerVolts, SUB_STEP);
     }
 
+    double busVolts = physics.batteryVoltage().in(Volts);
     for (int i = 0; i < MODULES; i++) {
       // setPosition takes the value after the conversion factor, so these are the metres and the
       // rotations the mechanism will read back, not raw encoder units.
@@ -692,9 +728,13 @@ public class Drive implements Mechanism {
       driveEncoderSims[i].setVelocity(
           state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters));
       steerSensorSims[i].setPosition(modules[i].toSensorRotations(state[i].azimuth()));
+      // The plant's applied volts, not the mechanism's commanded ones: the model clamps where the
+      // controller does, and this is the signal that reports the clamp.
+      driveOutputSims[i].set(state[i].driveAppliedVolts(), busVolts);
+      steerOutputSims[i].set(state[i].steerAppliedVolts(), busVolts);
     }
 
-    RoboRioSim.setVInVoltage(physics.batteryVoltage().in(Volts));
+    RoboRioSim.setVInVoltage(busVolts);
 
     // The Pigeon integrates what setRawYaw is handed, so it has to be a continuous angle. A
     // Rotation2d is wrapped, and handing it one steps a whole turn at the boundary, which the

--- a/src/main/java/first/robot/mechanisms/SparkOutputSim.java
+++ b/src/main/java/first/robot/mechanisms/SparkOutputSim.java
@@ -1,0 +1,42 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import com.revrobotics.spark.SparkFlex;
+import org.wpilib.hardware.hal.SimDouble;
+import org.wpilib.simulation.SimDeviceSim;
+
+// The applied output and bus voltage a SPARK reports, driven from the plant. REVLib writes both
+// only from SparkSim.iterate, and SparkSim cannot be loaded in this program: as of REVLib-java
+// 2027.0.0-alpha-6 it holds a MovingAverageFilterSim, which imports org.wpilib.math.util.Pair — a
+// class WPILib moved to org.wpilib.util.Pair. So the two values are written straight to the
+// device's SimDevice, which is where SparkSim writes them and where the sensor sims reach theirs.
+// Delete this once that import is fixed and SparkFlexSim loads.
+final class SparkOutputSim {
+  private static final String DEVICE = "SPARK Flex";
+  private static final String APPLIED_OUTPUT = "Applied Output";
+  private static final String BUS_VOLTAGE = "Bus Voltage";
+
+  private final SimDouble appliedOutput;
+  private final SimDouble busVoltage;
+
+  SparkOutputSim(SparkFlex motor) {
+    var device =
+        new SimDeviceSim(DEVICE + " [" + motor.getBusId() + "," + motor.getDeviceId() + "]");
+    appliedOutput = device.getDouble(APPLIED_OUTPUT);
+    busVoltage = device.getDouble(BUS_VOLTAGE);
+  }
+
+  void set(double volts, double busVolts) {
+    // A name the device does not carry comes back null rather than throwing, which is also what a
+    // sim built before its SPARK gets.
+    if (appliedOutput == null || busVoltage == null) {
+      return;
+    }
+    busVoltage.set(busVolts);
+    // Applied output is a duty cycle, and every reader multiplies it back by the rail.
+    appliedOutput.set(busVolts == 0 ? 0 : volts / busVolts);
+  }
+}

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -245,6 +245,43 @@ final class SwerveModule {
     closingLoops = true;
   }
 
+  // Applied output and bus voltage share Status0 with output current and motor temperature, so
+  // raising the two the characterisation column needs raises those two for no extra frame.
+  void instrumentDrive(boolean raised) {
+    Hardware.configureSpark(
+        "Swerve" + name + "DriveFrames",
+        () ->
+            driveMotor.configure(
+                appliedOutputFrames(raised),
+                ResetMode.kNoResetSafeParameters,
+                PersistMode.kNoPersistParameters));
+  }
+
+  void instrumentSteer(boolean raised) {
+    Hardware.configureSpark(
+        "Swerve" + name + "SteerFrames",
+        () ->
+            steerMotor.configure(
+                appliedOutputFrames(raised),
+                ResetMode.kNoResetSafeParameters,
+                PersistMode.kNoPersistParameters));
+  }
+
+  // A fresh config each time, because the period setters keep the smaller of the requested and the
+  // value already in the object they are called on: restoring through one that has been raised
+  // leaves it raised.
+  private static SparkFlexConfig appliedOutputFrames(boolean raised) {
+    var config = new SparkFlexConfig();
+    int periodMs =
+        (int)
+            (raised
+                    ? DriveConstants.CHARACTERISATION_FRAME_PERIOD
+                    : DriveConstants.DIAGNOSTIC_FRAME_PERIOD)
+                .in(Milliseconds);
+    config.signals.appliedOutputPeriodMs(periodMs).busVoltagePeriodMs(periodMs);
+    return config;
+  }
+
   // kNoResetSafeParameters and kNoPersistParameters, both load-bearing: the first leaves every
   // setting this config does not name alone, and the second is what makes a tuned gain die at the
   // next power cycle rather than becoming an undocumented property of one controller.
@@ -301,6 +338,16 @@ final class SwerveModule {
 
   LinearVelocity getDriveSpeed() {
     return MetersPerSecond.of(driveEncoder.getVelocity().get());
+  }
+
+  // What the controller put on the motor, which is below what it was asked for whenever the
+  // current limit is binding. Applied output is a duty cycle, so the rail comes back with it.
+  Voltage getDriveAppliedVoltage() {
+    return Volts.of(driveMotor.getAppliedOutput().get() * driveMotor.getBusVoltage().get());
+  }
+
+  Voltage getSteerAppliedVoltage() {
+    return Volts.of(steerMotor.getAppliedOutput().get() * steerMotor.getBusVoltage().get());
   }
 
   // The sensor's own reading, before the module offset: it is the signal the steer loop closes on.

--- a/src/main/java/first/robot/sim/SimModuleState.java
+++ b/src/main/java/first/robot/sim/SimModuleState.java
@@ -6,5 +6,11 @@ package first.robot.sim;
 
 import org.wpilib.math.geometry.Rotation2d;
 
+// The applied volts are what reached the plant after the current limit, not what was commanded.
 public record SimModuleState(
-    double wheelPositionRad, double wheelVelocityRadPerSec, Rotation2d azimuth, boolean slipping) {}
+    double wheelPositionRad,
+    double wheelVelocityRadPerSec,
+    Rotation2d azimuth,
+    boolean slipping,
+    double driveAppliedVolts,
+    double steerAppliedVolts) {}

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -31,6 +31,8 @@ public final class SwerveDriveSim {
   private final double driveCurrentLimit;
   private final double steerCurrentLimit;
   private final double wheelRadius;
+  private final double[] driveAppliedVolts = new double[MODULES];
+  private final double[] steerAppliedVolts = new double[MODULES];
 
   private Pose2d pose = Pose2d.kZero;
   private ChassisVelocities velocity = new ChassisVelocities();
@@ -51,8 +53,10 @@ public final class SwerveDriveSim {
 
   public SimModuleState[] update(double[] driveVolts, double[] steerVolts, double dtSeconds) {
     for (int i = 0; i < MODULES; i++) {
-      drive[i].setInput(applied(drive[i], driveMotor, driveCurrentLimit, driveVolts[i]));
-      steer[i].setInput(applied(steer[i], steerMotor, steerCurrentLimit, steerVolts[i]));
+      driveAppliedVolts[i] = applied(drive[i], driveMotor, driveCurrentLimit, driveVolts[i]);
+      steerAppliedVolts[i] = applied(steer[i], steerMotor, steerCurrentLimit, steerVolts[i]);
+      drive[i].setInput(driveAppliedVolts[i]);
+      steer[i].setInput(steerAppliedVolts[i]);
       drive[i].update(dtSeconds);
       steer[i].update(dtSeconds);
     }
@@ -76,7 +80,9 @@ public final class SwerveDriveSim {
               drive[i].getAngularVelocity(),
               new Rotation2d(steer[i].getAngularPosition()),
               // Always false: free space has no ground contact to break.
-              false);
+              false,
+              driveAppliedVolts[i],
+              steerAppliedVolts[i]);
     }
     return states;
   }

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -6,6 +6,7 @@ package first.robot.sim;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.units.Units.Volts;
@@ -89,6 +90,30 @@ class SwerveDriveSimTest {
         sim.truePose().getTranslation().getNorm(),
         0.01,
         "the robot translated while spinning: " + sim.truePose());
+  }
+
+  // The controller reports what it applied, and under a current limit that is not what it was
+  // asked for: the two only meet once the wheel is turning fast enough that the back-EMF carries
+  // most of the command.
+  @Test
+  void theAppliedVoltsAreTheLimitedOnesUntilTheWheelIsUpToSpeed() {
+    double limited = config.drive().currentLimit().in(Amps) * config.drive().motor().R;
+    Arrays.fill(driveVolts, 12.0);
+
+    state = sim.update(driveVolts, steerVolts, SUB_STEP);
+
+    assertEquals(
+        limited,
+        state[0].driveAppliedVolts(),
+        limited * 0.02,
+        "a step from rest was applied as more than the current limit allows");
+
+    advance(Seconds.of(3));
+
+    assertTrue(
+        state[0].driveAppliedVolts() > 11.0,
+        "the wheel is at speed and the command is still being limited: "
+            + state[0].driveAppliedVolts());
   }
 
   @Test

--- a/src/test/java/first/robot/sysid/CharacterisationTest.java
+++ b/src/test/java/first/robot/sysid/CharacterisationTest.java
@@ -67,6 +67,10 @@ import org.wpilib.units.measure.Voltage;
 // no SPARK can be constructed in this JVM. What this proves is the pipeline; none of it is a
 // number about a robot.
 //
+// The routine configs mirror Drive's too, with one exception: the steer routine is built with
+// DRIVE_STEP_VOLTAGE where Drive uses STEER_STEP_VOLTAGE. Nothing here reads the steer step, so
+// the number is the harness's rather than the drive base's.
+//
 // One log, written once: DataLogManager is process-wide and its directory is fixed by the first
 // start() anything makes, so every assertion below reads the same file.
 //

--- a/src/test/java/first/robot/sysid/CharacterisationTest.java
+++ b/src/test/java/first/robot/sysid/CharacterisationTest.java
@@ -7,6 +7,7 @@ package first.robot.sysid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Microseconds;
@@ -32,6 +33,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -321,6 +323,29 @@ class CharacterisationTest {
     }
   }
 
+  // The current limiter binds from the first sample of a step from rest and lets go partway up, so
+  // the voltage that reaches the motor climbs where the request is one flat number. A log carrying
+  // the request fits that flat number against the acceleration the limited voltage produced, and
+  // what comes out is kA — the one gain the dynamic test exists to produce.
+  @Test
+  void theDynamicStepLogsTheVoltageTheLimiterAllowedRatherThanTheOneRequested() {
+    var axis = DriveConstants.simConfig().drive();
+    double limited = axis.currentLimit().in(Amps) * axis.motor().R;
+    double step = DriveConstants.DRIVE_STEP_VOLTAGE.in(Volts);
+    var volts =
+        log.valuesDuring("voltage-" + MOTOR + "-" + DRIVE_LOG, DRIVE_LOG, "dynamic-forward");
+
+    assertTrue(
+        volts.stream().anyMatch(v -> Math.abs(v - limited) < limited * 0.1),
+        "no sample of the step sat near the " + limited + " V the current limit allows: " + volts);
+    assertTrue(
+        volts.stream().anyMatch(v -> v > step * 0.95),
+        "the step never reached the " + step + " V it asked for, so the column is not a voltage");
+    assertTrue(
+        volts.stream().allMatch(v -> v <= step),
+        "a sample exceeded the " + step + " V step, which no applied output can: " + volts);
+  }
+
   @Test
   void theCancellationPathZeroesTheOutputAndClosesEveryTest() {
     // What the routines commanded, not what the plant was handed: the steer array carries the
@@ -416,10 +441,11 @@ class CharacterisationTest {
     steerOpenLoop = true;
   }
 
+  // The applied voltage, as Drive reads it back off the SPARK's applied-output frame.
   private void logDrive(SysIdRoutineLog motors) {
     motors
         .motor(MOTOR)
-        .voltage(Volts.of(lastDriveCommand))
+        .voltage(Volts.of(state[0].driveAppliedVolts()))
         .linearPosition(Meters.of(state[0].wheelPositionRad() * WHEEL_RADIUS))
         .linearVelocity(MetersPerSecond.of(state[0].wheelVelocityRadPerSec() * WHEEL_RADIUS));
   }
@@ -427,7 +453,7 @@ class CharacterisationTest {
   private void logSteer(SysIdRoutineLog motors) {
     motors
         .motor(MOTOR)
-        .voltage(Volts.of(lastSteerCommand))
+        .voltage(Volts.of(state[0].steerAppliedVolts()))
         .angularPosition(state[0].azimuth().getMeasure())
         .angularVelocity(RotationsPerSecond.of(azimuthRate));
   }
@@ -435,7 +461,7 @@ class CharacterisationTest {
   private void logRotation(SysIdRoutineLog motors) {
     motors
         .motor(MOTOR)
-        .voltage(Volts.of(lastDriveCommand))
+        .voltage(Volts.of(state[0].driveAppliedVolts()))
         .angularPosition(Radians.of(yawRadians))
         .angularVelocity(RadiansPerSecond.of(physics.trueVelocity().omega));
   }
@@ -513,15 +539,34 @@ class CharacterisationTest {
       return found;
     }
 
-    // The first sample of the named entry at or after the test's state value first appears.
-    double firstValueOf(String entry, String logName, String test) {
-      long start =
+    // The stamps over which the test's state value stands in the log.
+    LongSummaryStatistics window(String logName, String test) {
+      var stamps =
           samples.stream()
               .filter(sample -> sample.name.equals("sysid-test-state-" + logName))
               .filter(sample -> test.equals(sample.text))
               .mapToLong(Sample::timestampMicros)
-              .min()
-              .orElseThrow(() -> new AssertionError(test + " never ran on " + logName));
+              .summaryStatistics();
+      if (stamps.getCount() == 0) {
+        throw new AssertionError(test + " never ran on " + logName);
+      }
+      return stamps;
+    }
+
+    // Every sample of the named entry inside that window.
+    List<Double> valuesDuring(String entry, String logName, String test) {
+      var window = window(logName, test);
+      return samples.stream()
+          .filter(sample -> sample.name.equals(entry))
+          .filter(sample -> sample.timestampMicros >= window.getMin())
+          .filter(sample -> sample.timestampMicros <= window.getMax())
+          .map(Sample::value)
+          .toList();
+    }
+
+    // The first sample of the named entry at or after the test's state value first appears.
+    double firstValueOf(String entry, String logName, String test) {
+      long start = window(logName, test).getMin();
       return samples.stream()
           .filter(sample -> sample.name.equals(entry))
           .filter(sample -> sample.timestampMicros >= start)


### PR DESCRIPTION
Closes #81

The voltage column of a characterisation log was the number the routine handed over. That is the number the controller applies only while nothing else is limiting the output, and the smart current limit is something else limiting the output: it holds the applied voltage to `backEmf ± currentLimit · R`, so ADR 0008's 60 A on a NEO Vortex applies **3.41 V of a 7 V step from rest** and does not reach 7 V until **1.82 m/s**. Constant current is constant torque, so acceleration is flat across all of it, and `tools/sysid` does not trim it out — `TrimStepVoltageData` erases data before peak acceleration, and under limiting the acceleration *is* the peak from the first sample. The cost lands on `kA`, the one gain the dynamic test exists to produce and the one ADR 0011 hands to `arbFeedforward`.

## What this does

**The column is `getAppliedOutput() × getBusVoltage()`.** All three log callbacks read it back off the controller instead of echoing the request.

**ADR 0009's Status0 raise is built** — the decision #64 implemented around rather than implementing. Every characterisation command raises the applied-output frame to the loop rate on the one instrumented SPARK before it does anything else, and puts it back both when the body ends and when it is cancelled: `whenCanceled` does not run on the first path and the line after the body does not run on the second. The raise takes a fresh config each time, because the period setters keep the smaller of the requested and the already-set value — restoring through a config that has been raised leaves it raised. Which motor role it lands on is the routine's, so a routine cannot raise a frame on a controller it does not read.

**The simulation drives the signal.** Nothing did before. `SparkSim` is what REVLib writes applied output from, and ADR 0010 cannot load that class — it holds a `MovingAverageFilterSim`, which imports `org.wpilib.math.util.Pair`, a class WPILib moved to `org.wpilib.util.Pair`. The two values behind the column are written straight to the device's own `SimDevice`, which is where `SparkSim` writes them and where the sensor sims already reach theirs. `first.robot.sim` stays free of vendor types: the plant reports the volts it clamped to, and the vendor half of the write stays in `mechanisms`.

## Measured

Regenerated `logs/sysid-simulation.wpilog`, drive dynamic forward:

| t (s) | V | v (m/s) | a (m/s²) |
|---|---|---|---|
| 0.005 | 3.447 | 0.026 | 8.547 |
| 0.100 | 5.046 | 0.838 | 8.547 |
| 0.215 | 6.982 | 1.821 | 8.547 |
| 0.220 | 7.000 | 1.863 | 8.465 |

The flat acceleration is still in the plant — it is real, and it is what a current limit does. What changed is that the voltage column now rises with it instead of reading a constant 7 V across the whole stretch.

## Documents

- **ADR 0009** says under what condition the column is honest, and its Open item about this closes.
- **ADR 0007** budgets the raise: +190 frames/s to ~4110, 54–64%, still tagged `[unverified — arithmetic]`.
- **ADR 0010** carries applied output as a fourth simulated signal, and why it is written where `SparkSim` would write it.
- **CONTEXT.md** gains an *Applied output* entry.

## Departures worth naming

- **Steer has no settle** in front of its ramp, so its raise and its first sample share a loop and a steer log can open on one sample up to a frame period stale. ADR 0009 says so.
- **The restore is a blocking `configure()` on the loop thread**, running from the cancellation path, so a run that ends in a cancel can overrun its loop while the write retries. Accepted and recorded: it happens once, at the end of a supervised bench test, with the mechanism already stopped — and deferring it is how a frame stays raised into a match.
- **The SPARK-side half is untested.** `getDriveAppliedVoltage`, `SparkOutputSim` and `logDriveRamp` have no coverage, because REVLib's native cannot load in this JVM and nothing that stands up `Drive` can run. The test that does exist drives the plant into current limit through `CharacterisationTest`'s mirror of Drive's callbacks, and it goes red against the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)