### PR TITLE
The vision seam: maximum yaw rate over a window

### DIFF
--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -139,6 +139,11 @@ public final class DriveConstants {
   // measures the drift.
   public static final Matrix<N4, N1> STATE_STD_DEVS = VecBuilder.fill(0.1, 0.1, 0.1, 0.1);
 
+  // SwerveDrivePoseEstimator3d keeps its own 1.5 s of odometry and drops anything older, and its
+  // BUFFER_DURATION is private so this cannot be read off it. Shorter here is a second staleness
+  // cutoff carrying a different number from the one the estimator enforces.
+  public static final Time YAW_RATE_HISTORY = Seconds.of(1.5);
+
   // A pose estimator tuned against a gyro that never wanders is tuned against a robot that does
   // not exist. Roughly a degree a minute, which is the order a Pigeon2 drifts at.
   public static final AngularVelocity GYRO_SIM_DRIFT = DegreesPerSecond.of(1.0 / 60);

--- a/src/main/java/first/robot/PoseEstimator.java
+++ b/src/main/java/first/robot/PoseEstimator.java
@@ -86,6 +86,8 @@ public final class PoseEstimator {
   public void resetPose(Pose2d pose) {
     // Both, always. Reset one and the gap between them stops being wheel error and becomes wheel
     // error plus this offset, with nothing in the log to say which.
+    // Drive's yaw-rate history is deliberately not among them: yaw rate is frame-independent, and
+    // clearing it here would reject every vision frame for 1.5 s from autonomousInit.
     var widened = new Pose3d(pose);
     fused.resetPose(widened);
     odometryOnly.resetPose(widened);

--- a/src/main/java/first/robot/PoseEstimator.java
+++ b/src/main/java/first/robot/PoseEstimator.java
@@ -87,7 +87,7 @@ public final class PoseEstimator {
     // Both, always. Reset one and the gap between them stops being wheel error and becomes wheel
     // error plus this offset, with nothing in the log to say which.
     // Drive's yaw-rate history is deliberately not among them: yaw rate is frame-independent, and
-    // clearing it here would reject every vision frame for 1.5 s from autonomousInit.
+    // clearing it here would reject every vision frame for the whole history from autonomousInit.
     var widened = new Pose3d(pose);
     fused.resetPose(widened);
     odometryOnly.resetPose(widened);

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -228,6 +228,7 @@ public class Robot extends OpModeRobot {
     // decision on the robot is about to be made against a guess.
     allianceUnknown.set(RobotState.isDSAttached() && alliance.isEmpty());
 
+    drive.updateYawRateHistory();
     drive.log();
 
     // Before the scheduler, and the order is load-bearing: every command that runs below reads a

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -32,6 +32,7 @@ import first.robot.sim.SwerveDriveSim;
 import first.robot.sysid.SysIdRoutine;
 import first.robot.sysid.SysIdRoutine.Direction;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,6 +48,7 @@ import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.geometry.Rotation2d;
 import org.wpilib.math.geometry.Rotation3d;
 import org.wpilib.math.geometry.Translation2d;
+import org.wpilib.math.interpolation.TimeInterpolatableBuffer;
 import org.wpilib.math.kinematics.ChassisAccelerations;
 import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.kinematics.SwerveDriveKinematics;
@@ -58,6 +60,7 @@ import org.wpilib.sysid.SysIdRoutineLog;
 import org.wpilib.system.Timer;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Angle;
+import org.wpilib.units.measure.AngularVelocity;
 import org.wpilib.units.measure.Voltage;
 import org.wpilib.util.function.BooleanConsumer;
 
@@ -85,6 +88,8 @@ public class Drive implements Mechanism {
   private final SysIdRoutine steerCharacterisation;
   private final SysIdRoutine rotationCharacterisation;
   private final Rotation2d[] spinAzimuths = new Rotation2d[MODULES];
+  private final TimeInterpolatableBuffer<Double> yawRateHistory =
+      TimeInterpolatableBuffer.createDoubleBuffer(DriveConstants.YAW_RATE_HISTORY.in(Seconds));
 
   private ChassisVelocities desiredVelocities = new ChassisVelocities();
   private ModuleGains gains;
@@ -639,6 +644,34 @@ public class Drive implements Mechanism {
     // are driven, and are the same three numbers.
     return new Rotation3d(
         gyro.getRoll().getValue(), gyro.getPitch().getValue(), gyro.getYaw().getValue());
+  }
+
+  // Read once a loop and never cleared, including through a pose reset: yaw rate is
+  // frame-independent, and an empty history is a rejected frame for the whole buffer duration.
+  public void updateYawRateHistory() {
+    yawRateHistory.addSample(
+        // The monotonic clock, because a vision timestamp and the estimator's own buffer are both
+        // on it. Keyed on Timer.getTimestamp() instead, every query answers empty the moment
+        // something replaces the time base, and a fail-closed gate rejects every frame in silence.
+        Timer.getMonotonicTimestamp(),
+        // The buffer holds rad/s; the Pigeon signal reports deg/s.
+        gyro.getAngularVelocityZWorld().getValue().in(RadiansPerSecond));
+  }
+
+  public Optional<AngularVelocity> maxAbsYawRate(double startTime, double endTime) {
+    return maxAbsYawRate(yawRateHistory, startTime, endTime);
+  }
+
+  // Empty means no history covers the window, which is a different answer from zero and the only
+  // one a caller can safely reject on. Both instants are on the monotonic clock.
+  static Optional<AngularVelocity> maxAbsYawRate(
+      TimeInterpolatableBuffer<Double> history, double startTime, double endTime) {
+    var max =
+        history.getInternalBuffer().subMap(startTime, true, endTime, true).values().stream()
+            .mapToDouble(Math::abs)
+            .max();
+
+    return max.isPresent() ? Optional.of(RadiansPerSecond.of(max.getAsDouble())) : Optional.empty();
   }
 
   public SwerveModulePosition[] getModulePositions() {

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -646,8 +646,6 @@ public class Drive implements Mechanism {
         gyro.getRoll().getValue(), gyro.getPitch().getValue(), gyro.getYaw().getValue());
   }
 
-  // Read once a loop and never cleared, including through a pose reset: yaw rate is
-  // frame-independent, and an empty history is a rejected frame for the whole buffer duration.
   public void updateYawRateHistory() {
     yawRateHistory.addSample(
         // The monotonic clock, because a vision timestamp and the estimator's own buffer are both
@@ -662,8 +660,8 @@ public class Drive implements Mechanism {
     return maxAbsYawRate(yawRateHistory, startTime, endTime);
   }
 
-  // Empty means no history covers the window, which is a different answer from zero and the only
-  // one a caller can safely reject on. Both instants are on the monotonic clock.
+  // Empty is not zero: it means no history covers the window. Unlike PoseEstimator3d.sampleAt this
+  // does not clamp to the nearest sample, because a gate that fails open is not a gate.
   static Optional<AngularVelocity> maxAbsYawRate(
       TimeInterpolatableBuffer<Double> history, double startTime, double endTime) {
     var max =
@@ -700,7 +698,12 @@ public class Drive implements Mechanism {
     moduleLog.log("DesiredStates", desiredStates(), SwerveModuleVelocity.struct);
     moduleLog.log("MeasuredStates", measured, SwerveModuleVelocity.struct);
     odometryLog.log("GyroHeading", getGyroHeading(), Rotation3d.struct);
-    odometryLog.log("GyroRate", gyro.getAngularVelocityZWorld().getValue());
+    // The buffer's own newest sample rather than a second read of the signal: a GyroRate that
+    // stayed healthy while nothing was sampling would hide a blind gate rather than show it.
+    var latestYawRate = yawRateHistory.getInternalBuffer().lastEntry();
+    if (latestYawRate != null) {
+      odometryLog.log("GyroRate", RadiansPerSecond.of(latestYawRate.getValue()));
+    }
     for (var module : modules) {
       module.log();
     }

--- a/src/test/java/first/robot/mechanisms/YawRateHistoryTest.java
+++ b/src/test/java/first/robot/mechanisms/YawRateHistoryTest.java
@@ -61,7 +61,8 @@ class YawRateHistoryTest {
 
   @Test
   void theWindowIncludesBothOfItsEndpoints() {
-    var history = fill(0, 1, t -> t < LOOP / 2 ? 3.0 : 0.5);
+    // Short enough that nothing is evicted, so this test turns on the window and not the history.
+    var history = fill(0, 0.5, t -> t < LOOP / 2 ? 3.0 : 0.5);
 
     assertEquals(
         3.0,
@@ -70,13 +71,16 @@ class YawRateHistoryTest {
         "a window of one instant missed the sample sitting on it");
   }
 
+  // The estimator drops odometry older than its own 1.5 s, so a gate that ran dry sooner would
+  // reject frames the estimator would have accepted, and nobody would find it for a season.
   @Test
-  void theHistoryOutlastsAVisionFramesFlightTime() {
+  void theHistoryReachesBackAsFarAsTheEstimatorsOwnBuffer() {
+    // Samples out to t = 2, so "now" is 2 and the estimator's window opens at 0.5.
+    var history = fill(0, 2, t -> 1.0);
+
     assertTrue(
-        HISTORY >= 1.5,
-        "the history is shorter than the estimator's own buffer, so the gate rejects frames the"
-            + " estimator would have accepted: "
-            + HISTORY);
+        Drive.maxAbsYawRate(history, 0.55, 0.6).isPresent(),
+        "a frame 1.4 s old has no history to gate on, and the estimator would still have taken it");
   }
 
   private static TimeInterpolatableBuffer<Double> fill(

--- a/src/test/java/first/robot/mechanisms/YawRateHistoryTest.java
+++ b/src/test/java/first/robot/mechanisms/YawRateHistoryTest.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package first.robot.mechanisms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.RadiansPerSecond;
+import static org.wpilib.units.Units.Seconds;
+
+import first.robot.Constants;
+import first.robot.DriveConstants;
+import java.util.function.DoubleUnaryOperator;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.interpolation.TimeInterpolatableBuffer;
+
+class YawRateHistoryTest {
+  private static final double LOOP = Constants.LOOP_PERIOD.in(Seconds);
+  private static final double HISTORY = DriveConstants.YAW_RATE_HISTORY.in(Seconds);
+
+  @Test
+  void anEmptyHistoryAnswersNothingRatherThanZero() {
+    var history = TimeInterpolatableBuffer.createDoubleBuffer(HISTORY);
+
+    assertFalse(
+        Drive.maxAbsYawRate(history, 0, 1).isPresent(),
+        "an empty history answered a rate, which a fail-closed gate would accept");
+  }
+
+  @Test
+  void aWindowOlderThanTheHistoryAnswersNothingRatherThanTheOldestSample() {
+    var history = fill(0, HISTORY * 2, t -> 1.0);
+
+    assertFalse(
+        Drive.maxAbsYawRate(history, 0, HISTORY / 2).isPresent(),
+        "a window the buffer no longer covers answered a rate");
+  }
+
+  @Test
+  void theAnswerIsTheLargestMagnitudeInTheWindowAndNotTheOneAtItsEnd() {
+    // A spike a third of a second in, and the robot stationary again by the time the frame lands.
+    var history = fill(0, 1, t -> t > 0.3 && t < 0.32 ? -4.0 : 0.1);
+
+    var max = Drive.maxAbsYawRate(history, 0, 1);
+
+    assertTrue(max.isPresent(), "a full window answered nothing");
+    assertEquals(4.0, max.get().in(RadiansPerSecond), 1e-9, "the spike was averaged away");
+  }
+
+  @Test
+  void aWindowThatMissesTheSpikeAnswersTheQuietRate() {
+    var history = fill(0, 1, t -> t > 0.3 && t < 0.32 ? -4.0 : 0.1);
+
+    var max = Drive.maxAbsYawRate(history, 0.5, 1);
+
+    assertTrue(max.isPresent(), "a covered window answered nothing");
+    assertEquals(0.1, max.get().in(RadiansPerSecond), 1e-9, "the window did not bound the search");
+  }
+
+  @Test
+  void theWindowIncludesBothOfItsEndpoints() {
+    var history = fill(0, 1, t -> t < LOOP / 2 ? 3.0 : 0.5);
+
+    assertEquals(
+        3.0,
+        Drive.maxAbsYawRate(history, 0, 0).orElseThrow().in(RadiansPerSecond),
+        1e-9,
+        "a window of one instant missed the sample sitting on it");
+  }
+
+  @Test
+  void theHistoryOutlastsAVisionFramesFlightTime() {
+    assertTrue(
+        HISTORY >= 1.5,
+        "the history is shorter than the estimator's own buffer, so the gate rejects frames the"
+            + " estimator would have accepted: "
+            + HISTORY);
+  }
+
+  private static TimeInterpolatableBuffer<Double> fill(
+      double start, double end, DoubleUnaryOperator rate) {
+    var history = TimeInterpolatableBuffer.createDoubleBuffer(HISTORY);
+    for (double t = start; t <= end + 1e-9; t += LOOP) {
+      history.addSample(t, rate.applyAsDouble(t));
+    }
+    return history;
+  }
+}


### PR DESCRIPTION
Closes #65.

The drive base's vision-facing surface goes from zero methods to one. `Drive.maxAbsYawRate(startTime, endTime)` answers the largest magnitude the Pigeon's filtered yaw-rate signal reached anywhere in a caller-supplied window, off a 1.5 s `TimeInterpolatableBuffer` sampled once a robot loop. No vision implementation, no vision abstraction, no vision type — nothing added here names a camera.

## What the ticket left

Three criteria landed with #60 and are not rebuilt: the signal raise (four signals — yaw, pitch, roll and the rate — not the stale five, since nothing drives the quaternion in simulation), the simulation driving the same signal on the same path, and the vision signal names. Verified present before starting.

## The two things the keys had to get right

**The clock.** Samples are stamped with `Timer.getMonotonicTimestamp()` — the same clock `odometryUpdate` stamps the estimator with, and the clock a vision timestamp arrives on. On `Timer.getTimestamp()` instead, `subMap` answers empty the moment something replaces the time base, and a fail-closed gate rejects every frame with nothing in the log to say why.

**The duration.** 1.5 s, matching `SwerveDrivePoseEstimator3d`'s own buffer, whose `BUFFER_DURATION` is private and so cannot be read off it. Shorter would be a second, invisible staleness cutoff carrying a different number from the one the estimator enforces.

## Fail-closed, and the window is the caller's

`Optional.empty()` means no history covers that window — a different answer from zero, and the only one a caller can reject a frame on. Unlike `PoseEstimator3d.sampleAt`, it does not clamp to the nearest sample. The drive base owns no window constant: the physically-right window is exposure plus timestamp-latency uncertainty, which is a property of a camera nobody has bought.

The buffer is never cleared, and `resetPose` says so at the line. Yaw rate is frame-independent, and clearing it would blind the gate for the whole history starting at autonomous init — the moment vision matters most.

## Two departures worth a reviewer's eye

**Sampling is `Drive.updateYawRateHistory()`, called from `robotPeriodic`, rather than folded into `log()`.** ADR 0012 says the sample goes in "Drive's existing per-loop update", and `log()` is the only per-loop call into `Drive` today. Putting a state write inside `log()` makes the vision gate depend on telemetry staying enabled, and CLAUDE.md is explicit that names are the documentation. Same loop, same rate, no `addPeriodic`, no thread.

**`GyroRate` now comes off the buffer's newest entry instead of a second read of the signal**, which is what ADR 0012's *Logging* section already said it was. The logged value is unchanged — a `Measure` logs its base-unit magnitude either way — but a `GyroRate` that stayed healthy while nothing was sampling would have hidden a blind gate rather than shown it.

## Testing

Tier 1, six cases on the package-private static form — the buffer reachable without building `Drive`, the shape `Drive.stick` and `SwerveModule.openLoopVolts` already use, because constructing a SPARK still terminates the JVM. Confirmed red on a missing symbol before implementing, and the history test confirmed red when the duration is shortened to 1 s.

`spotlessCheck`, `checkstyleMain` and `pmdMain` clean; 76 passing, `WiringTest` skipped as it is on main.

**`updateYawRateHistory()` itself is unrun on this box** — nothing that stands up a `Pigeon2` inside `Drive` can execute here, so the deg/s to rad/s conversion and the monotonic key are reviewed rather than exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)