### PR TITLE
Mirror a path across the field, without a second autonomous

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -266,6 +266,12 @@ The index of the ADRs themselves is
   the other alliance's version of it, applied once when the follower
   is constructed
   ([ADR 0011](docs/adr/0011-autonomous-and-choreo.md)).
+- **The mirror** — turning a trajectory drawn for one side of the
+  field into the other side's version of it, applied at the same
+  instant as the flip and chosen by the `Mirrored` tunable rather than
+  by the Driver Station. A reflection where the flip is a rotation, so
+  it inverts the spins the flip leaves alone
+  ([ADR 0011](docs/adr/0011-autonomous-and-choreo.md)).
 - **AprilTag** — the printed square markers around the field that a
   camera locates itself against.
 - **The gate** — a season's vision code deciding whether to accept one

--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -7,6 +7,9 @@ Accepted — 2026-08-26. Superseded in part by ADR 0011, which owns the
 an alert is visible during a match is answered by #22 and now sits
 under *Consequences*. Amended 2026-08-28: the signal list gains
 `/Check`, the opmode-scoped root the utility checks report under.
+Amended 2026-08-29 by #76: the signal list gains `/Match/Mirrored`, and
+the *Open* item on how `/Tunables` reaches the file records its first
+instance.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -133,6 +136,7 @@ habits below.
 | `/Robot/Alerts` | the active alert set, at 4 Hz — ADR 0004 |
 | `/Match/TimeRemaining` | `MatchState.getMatchTime()` (`:32`) |
 | `/Match/{Alliance,Station,FmsAttached,EventName,MatchType,MatchNumber,ReplayNumber,GameData}` | `MatchState` (`:43-101`), `RobotState.isFMSAttached()` — every loop, never once |
+| `/Match/Mirrored` | the `Mirrored` tunable — every loop, for the same reason `Alliance` is: it decides which half of the field the robot drives at, and it can change between one enable and the next — ADR 0011 |
 
 **[source]** for the accessors, all in
 `wpilibj/src/main/java/org/wpilib/system/RobotController.java` and
@@ -587,6 +591,13 @@ holds a season.
   exists to prevent. *Unblocked by* someone deciding the tunable set and
   reading `TunableRegistry` for whether a second backend or an explicit
   mirror is the cheaper route.
+
+  The first instance is decided rather than the rule: ADR 0011's
+  `Mirrored` takes the **explicit mirror** — `Robot` reads it every loop
+  and logs `/Match/Mirrored` beside `Alliance`, which is where a value
+  that decides where the robot drives has to be anyway. One value routed
+  by hand is not an answer for the tunable set; `GainTuningCheck`'s
+  seven gains still reach no log.
 
 - **The 13.1 MB and 65 µs figures were measured with ~50 synthetic
   signals**, not with this list attached to real mechanisms

--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -7,7 +7,7 @@ Accepted — 2026-08-26. Superseded in part by ADR 0011, which owns the
 an alert is visible during a match is answered by #22 and now sits
 under *Consequences*. Amended 2026-08-28: the signal list gains
 `/Check`, the opmode-scoped root the utility checks report under.
-Amended 2026-08-29 by #76: the signal list gains `/Match/Mirrored`, and
+Amended 2026-08-30 by #76: the signal list gains `/Match/Mirrored`, and
 the *Open* item on how `/Tunables` reaches the file records its first
 instance.
 

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -19,7 +19,7 @@ blue-corner flip as a reflection, which is the wrong flip for a
 rotationally symmetric field and is not what ChoreoLib does; corrected
 there.
 
-Amended again 2026-08-29 by #76, which adds the side mirror beside the
+Amended again 2026-08-30 by #76, which adds the side mirror beside the
 alliance flip — see *The side mirror is a reflection, chosen by a
 dashboard boolean*. The *Consequences* entry reading *"Autonomous is
 selected on the Driver Station, not a dashboard"* is **narrowed there**

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -25,8 +25,8 @@ dashboard boolean*. The *Consequences* entry reading *"Autonomous is
 selected on the Driver Station, not a dashboard"* is **narrowed there**
 to the string-chooser finding it rests on, which has nothing to say
 about a boolean. *No splits, no event markers* gains the rule that
-every pose trigger reads through `asAuthored`, and its example is
-corrected to show it — the example predated `asAuthored` and read a raw
+every pose trigger reads through `flipAndMirrorIfNeeded`, and its example is
+corrected to show it — the example predated `flipAndMirrorIfNeeded` and read a raw
 estimate.
 
 Amended by ADR 0012, which owns the pose
@@ -312,7 +312,7 @@ and a pose trigger —
 
 ```java
 public final Trigger inNeutralZone =
-    new Trigger(() -> inZone(FieldConstants.asAuthored(poseEstimator.getEstimatedPose())));
+    new Trigger(() -> inZone(FieldConstants.flipAndMirrorIfNeeded(poseEstimator.getEstimatedPose())));
 ```
 
 A **pose**-triggered action beats a **time**-triggered one for the
@@ -321,20 +321,25 @@ wheel slipped, a time marker fires in the wrong place and a pose
 trigger does not. Splits stop being necessary once each segment is its
 own file.
 
-⚠️ **Every pose trigger goes through `asAuthored`, and the threshold is
+⚠️ **Every pose trigger goes through `flipAndMirrorIfNeeded`, and the threshold is
 written against the path as drawn.** The estimate is where the robot
 is; the threshold was read off Choreo. Compare the two raw and the
-trigger is wrong on any run the path was transformed for — on red it is
-never reached, and on a mirrored run a `y` threshold is reached on the
-wrong side of the field. Both transforms are their own inverse and
-`asAuthored` applies whichever are in force, so one call covers the
+trigger fires at the wrong moment on any run the path was transformed
+for. **Which way it goes is the threshold's sign, not a rule**:
+`SweepLeftAuto`'s zone line is -4.27 m and the red path runs x +6.27 to
++2.77, so raw it is true on the *first loop*; a positive threshold on
+the same path would never be reached. On a mirrored run a `y` threshold
+fires on the wrong side of the field. Both transforms are their own
+inverse and
+`flipAndMirrorIfNeeded` applies whichever are in force, so one call covers the
 alliance flip and the side mirror together and will cover whatever is
 added beside them.
 
 This is a rule and not a mechanism. There is nothing to stop a trigger
 reading `getEstimatedPose()` directly, and a wrong one throws nothing —
-it just never fires. The only pose trigger that exists reads through
-`asAuthored`; the next one has to as well.
+it fires early, late, or not at all. The only pose trigger that exists
+reads through
+`flipAndMirrorIfNeeded`; the next one has to as well.
 
 ### Trajectories arrive in the robot's frame; the alliance flip happens at follower construction
 
@@ -417,12 +422,12 @@ fails when `omega` carries through unmirrored.
 **The two commute**, so nothing sequences them: `rot180 ∘ reflect` and
 `reflect ∘ rot180` are both `diag(-1, 1)`, and the heading composes to
 `-θ + π` either way. A test asserts it so the ordering cannot quietly
-become load-bearing. Each is also its own inverse, so `asAuthored`
+become load-bearing. Each is also its own inverse, so `flipAndMirrorIfNeeded`
 undoes both by applying whichever are in force again — a pose threshold
 written against the drawn path is compared in the frame it was written
 in on either side of the field, the same reason it already was on red.
 
-⚠️ `asAuthored` reads the toggle **every loop**, where the trajectory
+⚠️ `flipAndMirrorIfNeeded` reads the toggle **every loop**, where the trajectory
 reads it once at follower construction, so toggling mid-autonomous puts
 a pose trigger in a frame the path being driven is not in. That is the
 shape the alliance already has and nobody can change the alliance

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -24,7 +24,10 @@ alliance flip — see *The side mirror is a reflection, chosen by a
 dashboard boolean*. The *Consequences* entry reading *"Autonomous is
 selected on the Driver Station, not a dashboard"* is **narrowed there**
 to the string-chooser finding it rests on, which has nothing to say
-about a boolean.
+about a boolean. *No splits, no event markers* gains the rule that
+every pose trigger reads through `asAuthored`, and its example is
+corrected to show it — the example predated `asAuthored` and read a raw
+estimate.
 
 Amended by ADR 0012, which owns the pose
 estimator: `Drive.getGyroHeading()` returns a `Rotation3d` rather than a
@@ -308,7 +311,8 @@ express concurrency, and v3 can: `coroutine.fork`, `coroutine.await`,
 and a pose trigger —
 
 ```java
-public final Trigger inNeutralZone = new Trigger(() -> poseEstimator.inZone(NEUTRAL_ZONE));
+public final Trigger inNeutralZone =
+    new Trigger(() -> inZone(FieldConstants.asAuthored(poseEstimator.getEstimatedPose())));
 ```
 
 A **pose**-triggered action beats a **time**-triggered one for the
@@ -316,6 +320,21 @@ reason that matters on a field: if the robot runs 300 ms late because a
 wheel slipped, a time marker fires in the wrong place and a pose
 trigger does not. Splits stop being necessary once each segment is its
 own file.
+
+⚠️ **Every pose trigger goes through `asAuthored`, and the threshold is
+written against the path as drawn.** The estimate is where the robot
+is; the threshold was read off Choreo. Compare the two raw and the
+trigger is wrong on any run the path was transformed for — on red it is
+never reached, and on a mirrored run a `y` threshold is reached on the
+wrong side of the field. Both transforms are their own inverse and
+`asAuthored` applies whichever are in force, so one call covers the
+alliance flip and the side mirror together and will cover whatever is
+added beside them.
+
+This is a rule and not a mechanism. There is nothing to stop a trigger
+reading `getEstimatedPose()` directly, and a wrong one throws nothing —
+it just never fires. The only pose trigger that exists reads through
+`asAuthored`; the next one has to as well.
 
 ### Trajectories arrive in the robot's frame; the alliance flip happens at follower construction
 

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -19,6 +19,13 @@ blue-corner flip as a reflection, which is the wrong flip for a
 rotationally symmetric field and is not what ChoreoLib does; corrected
 there.
 
+Amended again 2026-08-29 by #76, which adds the side mirror beside the
+alliance flip — see *The side mirror is a reflection, chosen by a
+dashboard boolean*. The *Consequences* entry reading *"Autonomous is
+selected on the Driver Station, not a dashboard"* is **narrowed there**
+to the string-chooser finding it rests on, which has nothing to say
+about a boolean.
+
 Amended by ADR 0012, which owns the pose
 estimator: `Drive.getGyroHeading()` returns a `Rotation3d` rather than a
 `Rotation2d`, and the estimator beside `Drive` is
@@ -359,6 +366,93 @@ The correction is to the parenthetical, not to the decision. ADR 0005
 logs the alliance every loop for the same reason and raises this
 alert whenever a DS is attached without one.
 
+### The side mirror is a reflection, chosen by a dashboard boolean
+
+An autonomous drawn for one side of the field runs on the other side
+without a second opmode. The transform is a **reflection about the
+field's long axis**, it sits beside the alliance flip in
+`FieldConstants`, and it is applied at the same instant — follower
+construction. **[decided]**
+
+The two are different transforms and the difference is a sign, not a
+convention. Under the field-centre origin the flip is a 180° rotation
+about the origin and the mirror is a reflection across `y = 0`:
+
+| | alliance flip | side mirror |
+|---|---|---|
+| x, y | `-x, -y` | `x, `**`-y`** |
+| heading | `θ + π` | **`-θ`** |
+| vx, vy | `-vx, -vy` | `vx, `**`-vy`** |
+| ax, ay | `-ax, -ay` | `ax, `**`-ay`** |
+| **ω, α** | **unchanged** | **negated** |
+
+⚠️ **A rotation preserves handedness and a reflection does not.** A
+mirror that copies the flip's sign convention tracks translation
+perfectly and spins the wrong way, which on a path whose heading
+changes reads as a tuning problem rather than as a sign error.
+`FieldConstantsTest` pins each half of the table, and
+`PathFollowingTest` drives the mirrored path end to end against the
+drawn path's own tracking numbers — the heading bound is the one that
+fails when `omega` carries through unmirrored.
+
+**The two commute**, so nothing sequences them: `rot180 ∘ reflect` and
+`reflect ∘ rot180` are both `diag(-1, 1)`, and the heading composes to
+`-θ + π` either way. A test asserts it so the ordering cannot quietly
+become load-bearing. Each is also its own inverse, so `asAuthored`
+undoes both by applying whichever are in force again — a pose threshold
+written against the drawn path is compared in the frame it was written
+in on either side of the field, the same reason it already was on red.
+
+⚠️ `asAuthored` reads the toggle **every loop**, where the trajectory
+reads it once at follower construction, so toggling mid-autonomous puts
+a pose trigger in a frame the path being driven is not in. That is the
+shape the alliance already has and nobody can change the alliance
+mid-match; a dashboard boolean an operator can reach at any instant is
+the new part. Not worth a snapshot: the window is the fifteen seconds
+nobody is on a dashboard.
+
+The side is a `Tunables.addBoolean("Mirrored", false)`, and **false is
+the path exactly as it was drawn** — the state a robot boots into.
+`TunableBoolean` implements `BooleanSupplier` and `RobotBase` already
+registers `NetworkTablesTunableBackend(inst, "/Tunables")`
+(`RobotBase.java:237`) **[source]**, so no backend wiring is ours.
+ADR 0005 logs it every loop beside `Alliance` and it raises a `LOW`
+alert while armed: a non-default state that decides which half of the
+field the robot drives at belongs in front of the operator before the
+match, not reconstructed from the log after it.
+
+**This narrows the *Consequences* entry below**, which reads
+*"Autonomous is selected on the Driver Station, not a dashboard."* The
+finding under that sentence is about **strings**: AdvantageScope cannot
+write string NT values at all, and Elastic's support is an open,
+conflicted PR (`docs/research/choreo.md:129-133`, matrix at
+`:1337-1350`) **[source — #6]**. That rules out a string chooser and
+says the opposite about a boolean — AdvantageScope's tuner is
+**number/boolean only**: `LiveDataTuner.ts` declares `publish(key:
+string, value: number | boolean)` and `NT4Tuner.ts` gates on
+`LoggableType.Number || LoggableType.Boolean`
+(`docs/research/choreo.md:1344-1346`) **[source — #6]**. A boolean is
+the one shape the objection excludes rather than the one it covers.
+
+The routine stays on the Driver Station selector, which is what it is
+for; the side is a *modifier* on the selected routine, and putting it
+on the selector is combinatorial — four side-symmetric autos become
+eight entries an operator reads under time pressure to pick something
+that is not a different routine.
+
+One global boolean, not one per auto: a boolean per auto clutters a
+dashboard the way an entry per auto would have cluttered the Driver
+Station. The opmode's `@Autonomous(description = …)` names the side the
+path was drawn for, so the operator reads the pair together.
+
+⚠️ **The type is writable; the mode may not be.** The same reading
+records that `hasTunableFields()` returns `false` for
+`NT4Mode.Systemcore` and `NT4Mode.DriverStation` outright
+(`docs/research/choreo.md:1346-1347`) **[source — #6]** — which is the
+mode a real robot is in, and it gates *every* tunable rather than the
+string. Glass/SimGUI writes tune topics and is the dashboard this is
+known to work from. See *Open*.
+
 ### `kA` is in, at drivebase level, and only on the auto path
 
 The follower passes an acceleration feedforward: `kA · a` in volts,
@@ -476,11 +570,15 @@ produce it. ADR 0009 owns that.
   is configured with zero — which is the current behaviour with the
   term present and inert, not a different code path.
 
-- **Autonomous is selected on the Driver Station, not a dashboard.**
-  `SendableChooser` is deleted, AdvantageScope's tuner cannot write
-  string values at all, and Elastic's support is an open, conflicted
-  PR. **[source — #6]** The DS opmode selector is the path, and it is
-  ADR 0001's decision; autonomous inherits it and adds nothing.
+- **The autonomous *routine* is selected on the Driver Station, not a
+  dashboard.** `SendableChooser` is deleted, AdvantageScope's tuner
+  cannot write string values at all, and Elastic's support is an open,
+  conflicted PR. **[source — #6]** The DS opmode selector is the path,
+  and it is ADR 0001's decision; autonomous inherits it and adds
+  nothing. The finding is about **strings**, so it does not reach a
+  boolean *modifier* on the selected routine: the side mirror is a
+  tunable boolean — see *The side mirror is a reflection, chosen by a
+  dashboard boolean*.
 
 ## Traps
 
@@ -633,6 +731,26 @@ produce it. ADR 0009 owns that.
   long as we use Choreo. **[unverified]** *Unblocked by* the v3-native
   ChoreoLib port landing. Nothing depends on the answer today.
 
+- **Whether the dashboard in the pit can write the `Mirrored` boolean
+  on SystemCore.** The *type* is settled: AdvantageScope's tuner takes
+  number and boolean, which is why the string finding does not reach
+  this. The *mode* is not: `hasTunableFields()` returns `false` for
+  `NT4Mode.Systemcore` outright, which gates every tunable and not just
+  the string, and that reading is of AdvantageScope's source rather
+  than of a robot anyone has tuned. **[unverified]** *Unblocked by*
+  writing the boolean from the dashboard that will be in the pit,
+  before a match depends on it. Glass/SimGUI is the fallback and the
+  one this is known to work from.
+
+- **Whether the `Mirrored` toggle should survive a reboot.** A tunable
+  that persists carries a mirror left on from practice into a match;
+  one that does not makes the operator set it every boot.
+  `NetworkTablesTunableBackend` sets no persistent option on what it
+  publishes and only *subscribes* to the `tune` topic
+  (`NetworkTablesTunableBackend.java:127-132`) **[source]**, so
+  persistence would have to come from the writing dashboard plus
+  `networktables.json` — which nobody has checked. **[unverified]**
+
 - **`kA` has no number.** ADR 0009 owns producing it. Until then the
   term is present and configured zero.
 
@@ -640,6 +758,14 @@ produce it. ADR 0009 owns that.
   does not currently work with the real 2027 Driver Station, so the
   JUnit gate validates the **follower math** and not the selection
   flow. *Unblocked by* the DS/sim story settling; ADR 0013 tracks it.
+
+  The same gap now bounds the transforms. A JUnit run loads no HAL
+  simulation extension, and `DriverStationSim.setAllianceStationId`
+  **segfaults the JVM** in `HALSIM_SetDriverStationAllianceStationId`
+  when it is called there **[measured — #76]**, so no test can put
+  itself on red. Each transform is pinned on its own and the pair is
+  pinned by the commute and involution tests; *red and mirrored at
+  once* is argued rather than executed.
 
 ## Rejected
 

--- a/docs/research/choreo.md
+++ b/docs/research/choreo.md
@@ -1267,7 +1267,7 @@ should get the rotation rather than the mirror:
 | vx, vy, omega | `-vx, -vy, omega` | **unchanged** |
 | ax, ay, alpha | `-ax, -ay, alpha` | **unchanged** |
 
-Both forms are their own inverse (`L - (L - x) = x`), so `asAuthored`'s comment holds either way.
+Both forms are their own inverse (`L - (L - x) = x`), so `flipAndMirrorIfNeeded`'s comment holds either way.
 
 ---
 

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -54,11 +54,12 @@ public final class FieldConstants {
 
   // Each transform is its own inverse and the two commute, so applying whichever are in force
   // again carries a measured pose back into the frame the path was drawn in. A threshold written
-  // against the drawn path is wrong otherwise, and wrong by never being reached rather than by
-  // being reached in the wrong place.
-  public static Pose2d asAuthored(Pose2d pose) {
-    var unflipped = onRed() ? flip(pose) : pose;
-    return MIRRORED.getAsBoolean() ? mirror(unflipped) : unflipped;
+  // against the drawn path is compared in the wrong frame otherwise, and fires at the wrong
+  // moment — which way depends on the threshold's sign, so it is as likely to fire at once as
+  // never.
+  public static Pose2d flipAndMirrorIfNeeded(Pose2d pose) {
+    var flipped = onRed() ? flip(pose) : pose;
+    return MIRRORED.getAsBoolean() ? mirror(flipped) : flipped;
   }
 
   // The origin is field centre, where the flip is a 180-degree rotation about it. Anything drawn

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -12,10 +12,15 @@ import org.wpilib.math.kinematics.ChassisAccelerations;
 import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.trajectory.HolonomicSample;
 import org.wpilib.math.trajectory.HolonomicTrajectory;
+import org.wpilib.tunable.TunableBoolean;
+import org.wpilib.tunable.Tunables;
 import org.wpilib.util.Alert;
 import org.wpilib.util.Alert.Level;
 
 public final class FieldConstants {
+  // False is the path exactly as it was drawn.
+  public static final TunableBoolean MIRRORED = Tunables.addBoolean("Mirrored", false);
+
   // Blue is the answer that looks right on a bench and is wrong in half of every match, so a
   // missing alliance is said out loud rather than defaulted through.
   private static final Alert ALLIANCE_UNKNOWN =
@@ -43,11 +48,17 @@ public final class FieldConstants {
     return onRed() ? flip(trajectory) : trajectory;
   }
 
-  // The flip is its own inverse, so the same rotation carries a measured pose back into the frame
-  // the path was drawn in. A threshold written against the drawn path is wrong on red otherwise,
-  // and wrong by never being reached rather than by being reached in the wrong place.
+  public static HolonomicTrajectory forSide(HolonomicTrajectory trajectory) {
+    return MIRRORED.getAsBoolean() ? mirror(trajectory) : trajectory;
+  }
+
+  // Each transform is its own inverse and the two commute, so applying whichever are in force
+  // again carries a measured pose back into the frame the path was drawn in. A threshold written
+  // against the drawn path is wrong otherwise, and wrong by never being reached rather than by
+  // being reached in the wrong place.
   public static Pose2d asAuthored(Pose2d pose) {
-    return onRed() ? flip(pose) : pose;
+    var unflipped = onRed() ? flip(pose) : pose;
+    return MIRRORED.getAsBoolean() ? mirror(unflipped) : unflipped;
   }
 
   // The origin is field centre, where the flip is a 180-degree rotation about it. Anything drawn
@@ -71,6 +82,27 @@ public final class FieldConstants {
 
   public static Pose2d flip(Pose2d pose) {
     return new Pose2d(-pose.getX(), -pose.getY(), pose.getRotation().rotateBy(Rotation2d.kPi));
+  }
+
+  // A reflection across the field's long axis, which the centre origin puts at y = 0.
+  public static HolonomicTrajectory mirror(HolonomicTrajectory trajectory) {
+    return new HolonomicTrajectory(
+        trajectory.getSamples().stream().map(FieldConstants::mirror).toList());
+  }
+
+  private static HolonomicSample mirror(HolonomicSample sample) {
+    return new HolonomicSample(
+        sample.time,
+        mirror(sample.pose),
+        // A reflection reverses handedness, so the spins invert — the sign the flip, being a
+        // rotation, deliberately leaves alone.
+        new ChassisVelocities(sample.velocity.vx, -sample.velocity.vy, -sample.velocity.omega),
+        new ChassisAccelerations(
+            sample.acceleration.ax, -sample.acceleration.ay, -sample.acceleration.alpha));
+  }
+
+  public static Pose2d mirror(Pose2d pose) {
+    return new Pose2d(pose.getX(), -pose.getY(), pose.getRotation().unaryMinus());
   }
 
   private static boolean onRed() {

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -70,6 +70,11 @@ public class Robot extends OpModeRobot {
   private final Alert allianceUnknown =
       new Alert("alliance-unknown", "Driver Station attached with no alliance", Level.HIGH);
 
+  // A non-default state that decides which half of the field the robot drives at belongs in front
+  // of the operator before the match, not in the log afterwards.
+  private final Alert pathsMirrored =
+      new Alert("paths-mirrored", "Paths are mirrored across the field's long axis", Level.LOW);
+
   private final HttpClient http =
       HttpClient.newBuilder()
           .connectTimeout(
@@ -170,10 +175,11 @@ public class Robot extends OpModeRobot {
     return poseEstimator.getEstimatedPose();
   }
 
-  // The cache holds every path exactly as it was authored, and the flip is applied here — on a
-  // lookup, which autonomous makes once per schedule and therefore once per enable.
+  // The cache holds every path exactly as it was authored, and both transforms are applied here —
+  // on a lookup, which autonomous makes once per schedule and therefore once per enable. They
+  // commute, so this ordering is a reading preference and nothing else.
   public HolonomicTrajectory trajectory(String name) {
-    return FieldConstants.forAlliance(trajectories.get(name));
+    return FieldConstants.forSide(FieldConstants.forAlliance(trajectories.get(name)));
   }
 
   private static PowerDistribution openPdh() {
@@ -223,6 +229,10 @@ public class Robot extends OpModeRobot {
     matchLog.log("ReplayNumber", MatchState.getReplayNumber());
     matchLog.log("GameData", MatchState.getGameData().orElse(""));
     matchLog.log("TimeRemaining", Seconds.of(MatchState.getMatchTime()));
+
+    boolean mirrored = FieldConstants.MIRRORED.getAsBoolean();
+    matchLog.log("Mirrored", mirrored);
+    pathsMirrored.set(mirrored);
 
     // A DS that is attached and has not said which alliance it is means every alliance-dependent
     // decision on the robot is about to be made against a guess.

--- a/src/main/java/first/robot/opmode/SweepLeftAuto.java
+++ b/src/main/java/first/robot/opmode/SweepLeftAuto.java
@@ -38,12 +38,12 @@ public class SweepLeftAuto implements OpMode {
 
   public SweepLeftAuto(Robot robot) {
     // Measured against the path as it was drawn, so the line is in the same place on both
-    // alliances. Comparing the flipped estimate to a fixed threshold is a trigger that never fires
-    // on one of them.
+    // alliances and on both sides. Compared raw, this threshold is -4.27 m against a red path
+    // running x +6.27 to +2.77, so the trigger is true on the first loop rather than at the zone.
     pastZoneLine =
         new Trigger(
             () ->
-                FieldConstants.asAuthored(robot.poseEstimator.getEstimatedPose()).getX()
+                FieldConstants.flipAndMirrorIfNeeded(robot.poseEstimator.getEstimatedPose()).getX()
                     >= ZONE_LINE.in(Meters));
     pastZoneLine.onTrue(markZoneEntry(robot));
     enabled.onTrue(sweepLeft(robot));

--- a/src/main/java/first/robot/opmode/SweepLeftAuto.java
+++ b/src/main/java/first/robot/opmode/SweepLeftAuto.java
@@ -20,7 +20,9 @@ import org.wpilib.telemetry.TelemetryRegistry;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.measure.Distance;
 
-@Autonomous(group = "Competition", description = "Follows the SweepLeft path")
+@Autonomous(
+    group = "Competition",
+    description = "Follows the SweepLeft path, drawn left; Mirrored sweeps right")
 public class SweepLeftAuto implements OpMode {
   private static final String ROUTINE = "SweepLeftAuto";
   private static final String PATH = "SweepLeft";

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -168,14 +168,15 @@ class FieldConstantsTest {
   }
 
   // The same threshold problem the flip has: a trigger written against the drawn path is compared
-  // against a mirrored estimate and never fires, so one function has to undo both transforms.
+  // against a mirrored estimate and fires on the wrong side of the field, so one call has to undo
+  // both transforms.
   @Test
   void asAuthoredUndoesTheMirrorAsWellAsTheFlip() {
     FieldConstants.MIRRORED.set(true);
     var drawn = PATH.start().pose;
 
     var driven = FieldConstants.forSide(PATH).start().pose;
-    var back = FieldConstants.asAuthored(driven);
+    var back = FieldConstants.flipAndMirrorIfNeeded(driven);
 
     assertEquals(-3, driven.getY(), TOLERANCE);
     assertEquals(drawn.getX(), back.getX(), TOLERANCE);
@@ -183,9 +184,9 @@ class FieldConstantsTest {
     assertEquals(drawn.getRotation().getDegrees(), back.getRotation().getDegrees(), TOLERANCE);
   }
 
-  // What asAuthored leans on: it has to undo exactly what the trajectory flip did, or a threshold
-  // written against the drawn path is compared against the wrong half of the field on red — and a
-  // trigger that never fires is quieter than one that fires in the wrong place.
+  // What the pose call leans on: it has to undo exactly what the trajectory flip did, or a
+  // threshold written against the drawn path is compared against the wrong half of the field on
+  // red, and fires at a moment nothing in the log explains.
   @Test
   void thePoseFlipUndoesWhatTheTrajectoryFlipDidToTheSamePose() {
     var drawn = PATH.start().pose;

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.geometry.Rotation2d;
@@ -36,6 +37,13 @@ class FieldConstantsTest {
                   new Pose2d(4, 5, Rotation2d.fromDegrees(30)),
                   new ChassisVelocities(1, 2, 0.5),
                   new ChassisAccelerations(3, 4, 0.75))));
+
+  // The toggle is process-wide, so a test that leaves it armed mirrors every path in every test
+  // that runs after it.
+  @AfterEach
+  void disarmTheMirror() {
+    FieldConstants.MIRRORED.set(false);
+  }
 
   // The origin is field centre, so the flip is a rotation about it: the translation inverts, the
   // heading turns half a turn, and the two spins keep their sign because a rotation does not
@@ -100,6 +108,79 @@ class FieldConstantsTest {
                         && alert.activeStartTime != 0
                         && alert.level == AlertDataJNI.LEVEL_HIGH),
         "no high-level alert was raised for a path followed without an alliance");
+  }
+
+  // The mirror is a reflection and the flip is a rotation, so the mirror negates the two spins the
+  // flip deliberately leaves alone. A mirror that copies the flip's signs tracks translation
+  // perfectly and turns the wrong way, which reads as a tuning problem rather than a sign error.
+  @Test
+  void theMirrorIsAReflectionAboutTheLongAxisRatherThanARotation() {
+    var mirrored = FieldConstants.mirror(PATH).start();
+
+    assertEquals(2, mirrored.pose.getX(), TOLERANCE);
+    assertEquals(-3, mirrored.pose.getY(), TOLERANCE);
+    assertEquals(-30, mirrored.pose.getRotation().getDegrees(), TOLERANCE);
+    assertEquals(1, mirrored.velocity.vx, TOLERANCE);
+    assertEquals(-2, mirrored.velocity.vy, TOLERANCE);
+    assertEquals(-0.5, mirrored.velocity.omega, TOLERANCE);
+    assertEquals(3, mirrored.acceleration.ax, TOLERANCE);
+    assertEquals(-4, mirrored.acceleration.ay, TOLERANCE);
+    assertEquals(-0.75, mirrored.acceleration.alpha, TOLERANCE);
+  }
+
+  // Both transforms are applied at the same instant and nothing sequences them, so the order has
+  // to stay something nobody has to know.
+  @Test
+  void theMirrorAndTheAllianceFlipCommute() {
+    var mirrorThenFlip = FieldConstants.flip(FieldConstants.mirror(PATH)).start();
+    var flipThenMirror = FieldConstants.mirror(FieldConstants.flip(PATH)).start();
+
+    assertEquals(mirrorThenFlip.pose.getX(), flipThenMirror.pose.getX(), TOLERANCE);
+    assertEquals(mirrorThenFlip.pose.getY(), flipThenMirror.pose.getY(), TOLERANCE);
+    assertEquals(
+        mirrorThenFlip.pose.getRotation().getDegrees(),
+        flipThenMirror.pose.getRotation().getDegrees(),
+        TOLERANCE);
+    assertEquals(mirrorThenFlip.velocity.vx, flipThenMirror.velocity.vx, TOLERANCE);
+    assertEquals(mirrorThenFlip.velocity.vy, flipThenMirror.velocity.vy, TOLERANCE);
+    assertEquals(mirrorThenFlip.velocity.omega, flipThenMirror.velocity.omega, TOLERANCE);
+    assertEquals(mirrorThenFlip.acceleration.ax, flipThenMirror.acceleration.ax, TOLERANCE);
+    assertEquals(mirrorThenFlip.acceleration.ay, flipThenMirror.acceleration.ay, TOLERANCE);
+    assertEquals(mirrorThenFlip.acceleration.alpha, flipThenMirror.acceleration.alpha, TOLERANCE);
+  }
+
+  @Test
+  void mirroringTwiceIsTheOriginalPath() {
+    var round = FieldConstants.mirror(FieldConstants.mirror(PATH)).start();
+
+    assertEquals(2, round.pose.getX(), TOLERANCE);
+    assertEquals(3, round.pose.getY(), TOLERANCE);
+    assertEquals(30, round.pose.getRotation().getDegrees(), TOLERANCE);
+    assertEquals(0.5, round.velocity.omega, TOLERANCE);
+  }
+
+  // The path as drawn is what a robot boots into, so a mirror left on from practice cannot be the
+  // state nobody set.
+  @Test
+  void aPathIsFollowedAsAuthoredUntilTheDashboardSaysOtherwise() {
+    assertSame(
+        PATH, FieldConstants.forSide(PATH), "a path was mirrored with nothing asking for it");
+  }
+
+  // The same threshold problem the flip has: a trigger written against the drawn path is compared
+  // against a mirrored estimate and never fires, so one function has to undo both transforms.
+  @Test
+  void asAuthoredUndoesTheMirrorAsWellAsTheFlip() {
+    FieldConstants.MIRRORED.set(true);
+    var drawn = PATH.start().pose;
+
+    var driven = FieldConstants.forSide(PATH).start().pose;
+    var back = FieldConstants.asAuthored(driven);
+
+    assertEquals(-3, driven.getY(), TOLERANCE);
+    assertEquals(drawn.getX(), back.getX(), TOLERANCE);
+    assertEquals(drawn.getY(), back.getY(), TOLERANCE);
+    assertEquals(drawn.getRotation().getDegrees(), back.getRotation().getDegrees(), TOLERANCE);
   }
 
   // What asAuthored leans on: it has to undo exactly what the trajectory flip did, or a threshold

--- a/src/test/java/first/robot/mechanisms/PathFollowingTest.java
+++ b/src/test/java/first/robot/mechanisms/PathFollowingTest.java
@@ -5,12 +5,15 @@
 package first.robot.mechanisms;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Degrees;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.Radians;
 import static org.wpilib.units.Units.Seconds;
 
 import first.robot.Constants;
 import first.robot.DriveConstants;
+import first.robot.FieldConstants;
 import first.robot.HolonomicPathFollower;
 import first.robot.TrajectoryLoader;
 import first.robot.sim.OnboardLoopSim;
@@ -28,6 +31,7 @@ import org.wpilib.telemetry.MockTelemetryBackend;
 import org.wpilib.telemetry.TelemetryRegistry;
 import org.wpilib.telemetry.TelemetryTable;
 import org.wpilib.units.Measure;
+import org.wpilib.units.measure.Angle;
 import org.wpilib.units.measure.Distance;
 import org.wpilib.units.measure.Time;
 
@@ -82,20 +86,43 @@ class PathFollowingTest {
   // number measures only what it claims to.
   @Test
   void aStraightPathIsDrivenWithinAWheelsWidthOfItself() {
-    drive("StraightAhead", Meters.of(0.05), Seconds.of(1.5));
+    drive("StraightAhead", Meters.of(0.05), Degrees.of(1), Seconds.of(1.5));
   }
 
   // Heading and translation change together, which is where a robot-relative follower and a dropped
-  // centripetal term both show up. The threshold is loose because the drive lags its velocity
+  // centripetal term both show up. Both thresholds are loose because the drive lags its velocity
   // setpoint by a plant time constant with no acceleration feedforward to cancel it, and on a curve
-  // that lag is read as cross-track. It tightens when characterisation produces a kA.
+  // that lag is read as cross-track and as heading. They tighten when characterisation produces a
+  // kA.
   @Test
   void aPathThatTurnsWhileItTranslatesIsDrivenTheSameWay() {
-    drive("SweepLeft", Meters.of(0.8), Seconds.of(2));
+    drive("SweepLeft", Meters.of(0.8), Degrees.of(40), Seconds.of(2));
   }
 
-  private void drive(String pathName, Distance maxCrossTrack, Time margin) {
-    var trajectory = load(pathName);
+  // The same manoeuvre reflected, which a symmetric drive base tracks exactly as well — so the
+  // numbers are the drawn path's. A mirror that carried omega through unmirrored would drive with
+  // the drawn path's turn against the reflected path's heading, and it is the heading bound rather
+  // than the cross-track one that says so.
+  @Test
+  void theMirrorOfThatPathIsDrivenTheSameWay() {
+    drive(
+        FieldConstants.mirror(load("SweepLeft")),
+        "SweepLeft mirrored",
+        Meters.of(0.8),
+        Degrees.of(40),
+        Seconds.of(2));
+  }
+
+  private void drive(String pathName, Distance maxCrossTrack, Angle maxHeadingError, Time margin) {
+    drive(load(pathName), pathName, maxCrossTrack, maxHeadingError, margin);
+  }
+
+  private void drive(
+      HolonomicTrajectory trajectory,
+      String pathName,
+      Distance maxCrossTrack,
+      Angle maxHeadingError,
+      Time margin) {
     physics.resetPose(trajectory.start().pose);
 
     var follower =
@@ -103,6 +130,7 @@ class PathFollowingTest {
             trajectory, physics::truePose, () -> now, DriveConstants.PATH_FOLLOWER, log);
 
     double worstCrossTrack = 0;
+    double worstHeadingError = 0;
     double deadline = trajectory.duration + margin.in(Seconds);
     while (!follower.isDone() && now < deadline) {
       step(follower);
@@ -110,6 +138,9 @@ class PathFollowingTest {
       worstCrossTrack =
           Math.max(
               worstCrossTrack, Math.abs(backend.getLastValue("/CrossTrackError", Double.class)));
+      worstHeadingError =
+          Math.max(
+              worstHeadingError, Math.abs(backend.getLastValue("/HeadingError", Double.class)));
     }
 
     assertTrue(
@@ -118,6 +149,9 @@ class PathFollowingTest {
     assertTrue(
         worstCrossTrack <= maxCrossTrack.in(Meters),
         pathName + " ran " + worstCrossTrack + " m off the path at its worst");
+    assertTrue(
+        worstHeadingError <= maxHeadingError.in(Radians),
+        pathName + " ran " + worstHeadingError + " rad off the path's heading at its worst");
   }
 
   // Everything Drive does between a follower and the plant, with the SPARK-side loops modelled at


### PR DESCRIPTION
Closes #76.

`FieldConstants.mirror` sits beside `forAlliance` and reflects a
trajectory about the field's long axis, selected by a
`Tunables.addBoolean("Mirrored", false)` and applied at the same instant
the alliance flip is — `Robot.trajectory`, which autonomous calls once
per enable. No new opmode and no new Driver Station entry.

## The sign that separates the two transforms

A rotation preserves handedness and a reflection does not, so where the
flip carries `omega` and `alpha` through untouched, the mirror negates
them. Every other cell of the ticket's table is implemented as written:
`x, -y`, heading `-θ`, `vy` and `ay` negated.

That sign is pinned twice, and both were confirmed red before the code
went in. `FieldConstantsTest` asserts the whole table.
`PathFollowingTest` drives the mirrored path end to end — and carrying
`omega` through unmirrored fails only the **heading** bound, at 1.02 rad
against 0.66 rad for the drawn path, while cross-track stays inside its
threshold. So the two pre-existing follower tests gained a heading bound
as well; without one the end-to-end mirrored test passes with the trap
in it and says nothing.

The two transforms commute — `rot180 ∘ reflect` and `reflect ∘ rot180`
are both `diag(-1, 1)` — and a test asserts it so the ordering in
`Robot.trajectory` stays a reading preference. Each is its own inverse,
so `asAuthored` undoes both by applying whichever are in force again,
which is what keeps `SweepLeftAuto`'s pose trigger comparing in the
frame its threshold was written in.

## The ADR sentence, narrowed rather than overturned

ADR 0011's *"Autonomous is selected on the Driver Station, not a
dashboard"* now reads as being about the **routine**, with the side as a
modifier on it.

The ticket cites `docs/research/choreo.md:64-66` for the finding
underneath that sentence; those lines are the ChoreoLib release table.
The finding is at `:129-133` with the matrix at `:1337-1350`, and it
says more than the ticket assumed: AdvantageScope's tuner is
**number/boolean only** — `LiveDataTuner.ts` declares `publish(key:
string, value: number | boolean)` — so a boolean is the shape the
string objection excludes, not inference from it. The real hazard is
narrower and now recorded as *Open*: `hasTunableFields()` returns
`false` for `NT4Mode.Systemcore` outright, which gates every tunable.
Glass/SimGUI is the fallback.

ADR 0005 gains `/Match/Mirrored`, and its open question on how
`/Tunables` reaches the WPILOG gains its first instance — the explicit
mirror, since a value deciding where the robot drives has to be logged
beside `Alliance` anyway. `GainTuningCheck`'s seven gains still reach no
log; the rule is not answered here.

## Two limits worth a reviewer's eye

**`asAuthored` reads the toggle every loop** where the trajectory reads
it once. Toggling mid-autonomous puts a pose trigger in a frame the path
is not in. Same shape the alliance already has, except an operator can
reach a dashboard boolean at any instant — judged not worth a snapshot
for a fifteen-second window, and said in the ADR at the line.

**Red and mirrored at once is argued, not executed.** A JUnit run loads
no HAL simulation extension, and `DriverStationSim.setAllianceStationId`
segfaults the JVM in `HALSIM_SetDriverStationAllianceStationId` when
called there, so no test can put itself on red. Each transform is pinned
alone and the pair by the commute and involution tests. Recorded under
ADR 0011's *Open*.

The two Open items the ticket declined to close stay open: whether the
toggle survives a reboot — `NetworkTablesTunableBackend` sets no
persistent option and only subscribes to the `tune` topic, so it would
have to come from the writing dashboard — and which dashboard in the pit
can write it.

## Testing

`spotlessCheck` and `build` clean; 82 passing, `WiringTest` skipped as it
is on main.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
