### PR TITLE
Give the driver an alliance, and the steer loop the device's units

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -272,6 +272,17 @@ The index of the ADRs themselves is
   by the Driver Station. A reflection where the flip is a rotation, so
   it inverts the spins the flip leaves alone
   ([ADR 0011](docs/adr/0011-autonomous-and-choreo.md)).
+- **Driver perspective** — the driver's *forward*, which is the field
+  half they are not standing in. The field is blue-origin whichever
+  alliance is driving, so +x is the red wall for both of them and a red
+  driver's stick has to be rotated 180 degrees before it means a field
+  velocity. Not *the flip*: the flip transforms a path once when the
+  follower is built, this transforms operator input every loop, and each
+  applied where the other belongs drives the robot at a wall. Read live,
+  because the alliance arrives after the Driver Station does
+  ([ADR 0011](docs/adr/0011-autonomous-and-choreo.md) owns the flip and
+  the mirror beside it).
+
 - **AprilTag** — the printed square markers around the field that a
   camera locates itself against.
 - **The gate** — a season's vision code deciding whether to accept one

--- a/docs/adr/0009-characterisation-and-tuning.md
+++ b/docs/adr/0009-characterisation-and-tuning.md
@@ -341,6 +341,15 @@ The sim gains want a comment at the line saying they exist to make the
 model track and are **not** a prediction of the real robot's. That is
 the one thing about them a reader cannot recover from the code.
 
+What separates the two sets has to be a property of the plant, and it is
+worth naming at the line: the model has no stiction to break, so both
+`kS` terms are zero, and nothing to damp, so steer needs no `kD`. The
+feedback gains themselves now **match** the real set, because ADR 0010's
+loop model reads them in the units the device does. A sim gain that
+differs from its real counterpart for no physical reason is a units bug
+being absorbed rather than a modelling choice, which is the same failure
+as tuning one until a test passes.
+
 This is a narrow graduation of the robot-identity question, not the
 whole of it. Competition-versus-practice gains stay fog — see Open.
 

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -15,7 +15,8 @@ desktop. `SparkSim` is still not loaded and this ADR still does not use
 it. Amended 2026-08-30, second: the loop model reads its
 feedback gains as a duty cycle rather than as volts, which is what the
 device does; `SIM_GAINS` moved with it. Amended 2026-08-30, third: the
-battery is charged the supply current rather than the winding current.
+battery is charged the supply current rather than the winding current. The applied output is
+reported against the rail it was clamped against.
 
 The *Open* item asking whether CI runs a headless robot program is
 answered by ADR 0013 and now sits under *Consequences*.
@@ -258,6 +259,18 @@ commanded one. `SwerveDriveSim` clamps against the current limit exactly
 where the controller does and now reports what it clamped to, so the
 simulated column has the same shape as the real one — including the flat
 stretch at the bottom of a step that ADR 0009's traps are about.
+
+**The duty cycle is reported against the rail it was clamped against.**
+`applied()` clamps to the rail as it stood *before* the step, and the
+pack sags *during* it, so dividing by the rail afterwards is dividing by
+a smaller number than the clamp used. Under a launch that gap put
+`/Drive/Modules/*/DriveOutput` at **1.647** **[measured]** — outside
+`[-1, 1]`, where no duty cycle goes, in the signal ADR 0009 builds a
+characterisation's voltage column from. `SwerveDriveSim` therefore
+reports `appliedRailVoltage()` beside `batteryVoltage()`, and the two
+`SimDevice` values are written as a matched pair, the way a real SPARK
+measures them. `RoboRioSim`'s VIn keeps the later number, because that
+is the freshest thing the rail knows about itself. **[decided]**
 
 `SimDeviceSim.getDouble` returns `null` for a name it cannot resolve
 (`wpilibj/src/main/java/org/wpilib/simulation/SimDeviceSim.java:117-123`)

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -12,7 +12,9 @@ would write it is the one that does not load. Amended 2026-08-30: this
 architecture now runs — ADR 0015's shim binds REVLib's native, and the
 whole of `updateSim()` has been executed against a real `Robot` on the
 desktop. `SparkSim` is still not loaded and this ADR still does not use
-it.
+it. Amended 2026-08-30, second: the loop model reads its
+feedback gains as a duty cycle rather than as volts, which is what the
+device does; `SIM_GAINS` moved with it.
 
 The *Open* item asking whether CI runs a headless robot program is
 answered by ADR 0013 and now sits under *Consequences*.
@@ -165,6 +167,39 @@ rejected hand-writing a copy of the onboard loop *for fidelity*; this is
 a different artefact at a different bar — #19's Tier 2 assertions are
 deliberately loose and #23's `sim-hitl` is *drive around in sim*.
 **[decided]**
+
+**The loop model's feedback output is a duty cycle, and its feedforward
+is volts.** They are not the same unit and the difference is the whole
+bus voltage. `ClosedLoopConfig.minOutput` and `maxOutput` are the only
+documented output units on the class and both are *"the minimum output
+value in the range [-1, 1]"*
+(`com/revrobotics/spark/config/ClosedLoopConfig.java:252, :277`); every
+`FeedForwardConfig` gain beside them is documented *"in Volts"*
+(`com/revrobotics/spark/config/FeedForwardConfig.java:64, :80`); and
+`arbFeedforward` is applied *"after the result of the specified control
+mode"* in units chosen from an `ArbFFUnits` of `kVoltage` or
+`kPercentOut` (`com/revrobotics/spark/SparkClosedLoopController.java:40-42,
+:140-142`). **[source]** No javadoc states outright what the P term
+outputs — it is firmware, so none can — so the reading itself is
+**[unverified]**, but nothing in the library contradicts it.
+
+`OnboardLoopSim` originally returned every term as volts, which made the
+modelled steer loop weaker than the device by a factor of twelve. That
+is not a fidelity nicety: a P loop on this plant is speed-limited rather
+than torque-limited, so the gain sets the closed-loop time constant
+directly, at `2π / (kP · V · Kv_module)`. A driving log measured the
+modules settling a 30-degree step in **895 ms** with a median tracking
+error of 8 degrees **[measured]**, which reads from the driver's seat as
+a floating, unresponsive robot and reads in a plot as a tuning problem.
+With the feedback terms scaled by the rail the same step settles in
+**220 ms** **[measured]**, and
+`SwerveDriveSimTest.aQuarterTurnStepSettlesInsideTheTimeADriverWouldNotice`
+is the regression that holds it there.
+
+The trap this ADR is guarding is not the units themselves but where they
+get absorbed: a model that reads a gain in the wrong unit looks exactly
+like a model that needs its own gains, and the second set of gains
+quietly becomes a conversion factor. See ADR 0009.
 
 **Write positions; do not call `iterate()`.** Our model owns the
 integration, so `setPosition` writes the value the model already

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -14,7 +14,8 @@ whole of `updateSim()` has been executed against a real `Robot` on the
 desktop. `SparkSim` is still not loaded and this ADR still does not use
 it. Amended 2026-08-30, second: the loop model reads its
 feedback gains as a duty cycle rather than as volts, which is what the
-device does; `SIM_GAINS` moved with it.
+device does; `SIM_GAINS` moved with it. Amended 2026-08-30, third: the
+battery is charged the supply current rather than the winding current.
 
 The *Open* item asking whether CI runs a headless robot program is
 answered by ADR 0013 and now sits under *Consequences*.
@@ -200,6 +201,32 @@ The trap this ADR is guarding is not the units themselves but where they
 get absorbed: a model that reads a gain in the wrong unit looks exactly
 like a model that needs its own gains, and the second set of gains
 quietly becomes a conversion factor. See ADR 0009.
+
+### The battery is loaded with supply current, not winding current
+
+`BatterySim.calculateDefaultBatteryLoadedVoltage` is `12 - Σ(I · 0.02)`
+(`wpilibj/src/main/java/org/wpilib/simulation/BatterySim.java:42-44`)
+**[source]**, and what it wants is the current out of the pack.
+`DCMotorSim.getCurrentDraw()` is the *winding* current, which is a
+different quantity: a half-bridge is a DC-DC converter, so
+`I_supply = I_motor · V_applied / V_bus`.
+
+The distinction is invisible at speed and dominant at a standstill,
+which is where a drive base spends every launch. Four drive motors held
+at a 60 A limit down at the ~3.4 V the limit allows from rest are 68 A
+out of the pack, not 240 A — and 240 A against this model is 7.2 V,
+the floor, at exactly the moment the volts were going to accelerate
+something. The rail then clamps `applied()` and caps the acceleration.
+A driving log measured **1440 ms** from rest to 90% of a request over
+4 m/s, with the pack's 5th percentile at 7.216 V **[measured]**;
+referred to the supply side the same launch reaches 4 m/s in **575 ms**
+with the rail above 10 V **[measured]**.
+
+Both halves of this ADR's amendments are the same mistake — a quantity
+used in the frame it was not measured in — and both presented as a
+simulation that felt sluggish rather than as a number that was wrong.
+`SwerveDriveSimTest.aFullThrottleLaunchReachesSpeedInTheTimeTheCurrentLimitAllows`
+and `aLaunchDoesNotCollapseTheRail` are the regressions.
 
 **Write positions; do not call `iterate()`.** Our model owns the
 integration, so `setPosition` writes the value the model already

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -16,7 +16,8 @@ it. Amended 2026-08-30, second: the loop model reads its
 feedback gains as a duty cycle rather than as volts, which is what the
 device does; `SIM_GAINS` moved with it. Amended 2026-08-30, third: the
 battery is charged the supply current rather than the winding current. The applied output is
-reported against the rail it was clamped against.
+reported against the rail it was clamped against. A regenerating motor is
+credited as no load rather than as a full one.
 
 The *Open* item asking whether CI runs a headless robot program is
 answered by ADR 0013 and now sits under *Consequences*.
@@ -222,6 +223,28 @@ A driving log measured **1440 ms** from rest to 90% of a request over
 4 m/s, with the pack's 5th percentile at 7.216 V **[measured]**;
 referred to the supply side the same launch reaches 4 m/s in **575 ms**
 with the rail above 10 V **[measured]**.
+
+`getCurrentDraw()` is signed against the bus — negative is a motor
+pushing power back into it
+(`wpilibj/src/main/java/org/wpilib/simulation/DCMotorSim.java:158-164`)
+**[source]** — and taking its magnitude charged the pack a *full load*
+for a motor that was feeding it. Under the supply referral above that
+turns into a runaway: a braking motor's applied volts sit close to its
+back-EMF, so the duty is near one, the sag drives the duty higher still,
+and the rail latches at the 7.2 V floor during exactly the manoeuvre the
+volts were braking. A regenerating motor is now credited as **nothing** —
+not as charge, because a simulation whose battery gains voltage under
+braking accelerates out of a stop better than the robot ever will, and
+not as a load either.
+
+What is left bounding a hard stop is the **drive current limit**, and it
+is arithmetic rather than a knob:
+`a = 4 · I_limit · Kt · G / (m · r)` = 8.6 m/s² at 60 A. A driving log
+measured a full-speed wheel reversal at **8.36 m/s², three times, to
+within a percent** **[measured]** — the limit, not a defect.
+`aHardReversalBrakesAtTheCurrentLimitWithoutSaggingThePack` asserts
+against that expression rather than against a number, so a changed limit
+moves the test with it.
 
 Both halves of this ADR's amendments are the same mistake — a quantity
 used in the frame it was not measured in — and both presented as a

--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -229,8 +229,12 @@ public final class DriveConstants {
   // and turning them until a test passes turns that test into a tautology. A characterisation run
   // in simulation fits the model it was given back to itself, so a gain fitted there describes the
   // model and never the robot.
+  //
+  // What separates them from REAL_GAINS is the friction the plant does not have: no stiction to
+  // break, so both kS terms are zero, and nothing to damp, so steer needs no kD. The feedback
+  // gains themselves match, because the loop model reads them in the same units the device does.
   public static final ModuleGains SIM_GAINS =
-      new ModuleGains(new DriveMotorGains(0.1, 0.0, 2.0), new SteerMotorGains(8.0, 0.0, 0.0, 0.0));
+      new ModuleGains(new DriveMotorGains(0.05, 0.0, 2.0), new SteerMotorGains(3.0, 0.0, 0.0, 0.0));
 
   public record SwerveModuleConfig(
       String name, int driveId, int steerId, Angle steerZeroOffset, Translation2d location) {}

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -14,18 +14,10 @@ import org.wpilib.math.trajectory.HolonomicSample;
 import org.wpilib.math.trajectory.HolonomicTrajectory;
 import org.wpilib.tunable.TunableBoolean;
 import org.wpilib.tunable.Tunables;
-import org.wpilib.util.Alert;
-import org.wpilib.util.Alert.Level;
 
 public final class FieldConstants {
   // False is the path exactly as it was drawn.
   public static final TunableBoolean MIRRORED = Tunables.addBoolean("Mirrored", false);
-
-  // Blue is the answer that looks right on a bench and is wrong in half of every match, so a
-  // missing alliance is said out loud rather than defaulted through.
-  private static final Alert ALLIANCE_UNKNOWN =
-      new Alert(
-          "path-alliance-unknown", "Following a path with no alliance; assuming blue", Level.HIGH);
 
   // Choreo draws in the blue-alliance-corner frame and WPILib publishes its tag layouts in it; the
   // robot works in field centre, which is where 2027 is going. The dimensions are the 2026 field's
@@ -106,9 +98,10 @@ public final class FieldConstants {
     return new Pose2d(pose.getX(), -pose.getY(), pose.getRotation().unaryMinus());
   }
 
-  private static boolean onRed() {
-    var alliance = MatchState.getAlliance();
-    ALLIANCE_UNKNOWN.set(alliance.isEmpty());
-    return alliance.orElse(Alliance.BLUE) == Alliance.RED;
+  // Blue is the answer that looks right on a bench and is wrong in half of every match. Robot's
+  // alliance-unknown alert is what says so out loud, and it is gated on a Driver Station actually
+  // being attached, which a guess made on a bench with nothing plugged in is not.
+  public static boolean onRed() {
+    return MatchState.getAlliance().orElse(Alliance.BLUE) == Alliance.RED;
   }
 }

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -25,6 +25,7 @@ import first.robot.DriveConstants;
 import first.robot.DriveConstants.DriveConfig;
 import first.robot.DriveConstants.ModuleGains;
 import first.robot.DriveConstants.SwerveModuleConfig;
+import first.robot.FieldConstants;
 import first.robot.Hardware;
 import first.robot.HolonomicPathFollower;
 import first.robot.sim.OnboardLoopSim;
@@ -545,7 +546,10 @@ public class Drive implements Mechanism {
   // wheel back to its setpoint, and a driver reads that as the robot arguing. A voltage does what
   // the stick did.
   public Command driverControl(CommandGamepad driver) {
-    return fieldRelative(() -> driverVelocities(driver), this::setOpenLoopVelocities)
+    // Read every loop: the alliance arrives after the Driver Station does, and latching it at
+    // construction hands a red driver blue controls for the whole match.
+    return fieldRelative(
+            () -> driverVelocities(driver, FieldConstants.onRed()), this::setOpenLoopVelocities)
         .named("Drive.DriverControl");
   }
 
@@ -571,13 +575,26 @@ public class Drive implements Mechanism {
         .whenCanceled(this::stopModules);
   }
 
+  private static ChassisVelocities driverVelocities(CommandGamepad driver, boolean onRed) {
+    return driverVelocities(driver.getLeftY(), driver.getLeftX(), driver.getRightX(), onRed);
+  }
+
   // Away from the driver station is +x and to the driver's left is +y, and both stick axes read
   // the other way round.
-  private static ChassisVelocities driverVelocities(CommandGamepad driver) {
+  //
+  // The field is blue-origin whichever alliance is driving, so +x is the red wall for both of
+  // them and a red driver's forward is -x. The axes and the alliance arrive as doubles because a
+  // CommandGamepad needs the HAL and DriverStationSim.setAllianceStationId segfaults the test
+  // JVM: what cannot be reached from Tier 1 is what nobody checks.
+  static ChassisVelocities driverVelocities(
+      double leftY, double leftX, double rightX, boolean onRed) {
+    double perspective = onRed ? -1 : 1;
     return new ChassisVelocities(
-        DriveConstants.MAX_VELOCITY.times(stick(-driver.getLeftY())),
-        DriveConstants.MAX_VELOCITY.times(stick(-driver.getLeftX())),
-        DriveConstants.MAX_ANGULAR_VELOCITY.times(stick(-driver.getRightX())));
+        DriveConstants.MAX_VELOCITY.times(stick(-leftY) * perspective),
+        DriveConstants.MAX_VELOCITY.times(stick(-leftX) * perspective),
+        // A rotation about field centre does not change which way is clockwise, so the spin is
+        // the one component the perspective leaves alone.
+        DriveConstants.MAX_ANGULAR_VELOCITY.times(stick(-rightX)));
   }
 
   // Asymptotically linear: the curve eases out of zero over the width and then converges onto the
@@ -732,11 +749,14 @@ public class Drive implements Mechanism {
     // The setpoints are held constant across the sub-steps, which is what reproduces a 200 Hz
     // robot commanding a 1 kHz controller rather than pretending they run at the same rate.
     for (int step = 0; step < SUB_STEPS; step++) {
+      double rail = physics.batteryVoltage().in(Volts);
       for (int i = 0; i < MODULES; i++) {
         double wheelSpeed =
             state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters);
         double sensor = modules[i].toSensorRotations(state[i].azimuth());
         if (!modules[i].isClosingLoops()) {
+          // Zero volts into a DCMotorSim is a shorted motor, which is what idleMode kBrake makes
+          // a stopped SPARK. Coasting would have to zero the current instead.
           driveVolts[i] = 0;
           steerVolts[i] = 0;
         } else {
@@ -745,11 +765,11 @@ public class Drive implements Mechanism {
           driveVolts[i] =
               modules[i].isDriveVoltageMode()
                   ? modules[i].getDriveVolts()
-                  : driveLoops[i].calculate(wheelSpeed, SUB_STEP);
+                  : driveLoops[i].calculate(wheelSpeed, SUB_STEP, rail);
           steerVolts[i] =
               modules[i].isSteerVoltageMode()
                   ? modules[i].getSteerVolts()
-                  : steerLoops[i].calculate(sensor, SUB_STEP);
+                  : steerLoops[i].calculate(sensor, SUB_STEP, rail);
         }
       }
       state = physics.update(driveVolts, steerVolts, SUB_STEP);

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -776,6 +776,10 @@ public class Drive implements Mechanism {
     }
 
     double busVolts = physics.batteryVoltage().in(Volts);
+    // The rail the plant clamped against, not the one it sagged to afterwards: the SPARK reports
+    // a duty cycle and a bus voltage measured together, and dividing by the later number puts the
+    // duty outside [-1, 1].
+    double appliedRail = physics.appliedRailVoltage().in(Volts);
     for (int i = 0; i < MODULES; i++) {
       // setPosition takes the value after the conversion factor, so these are the metres and the
       // rotations the mechanism will read back, not raw encoder units.
@@ -786,8 +790,8 @@ public class Drive implements Mechanism {
       steerSensorSims[i].setPosition(modules[i].toSensorRotations(state[i].azimuth()));
       // The plant's applied volts, not the mechanism's commanded ones: the model clamps where the
       // controller does, and this is the signal that reports the clamp.
-      driveOutputSims[i].set(state[i].driveAppliedVolts(), busVolts);
-      steerOutputSims[i].set(state[i].steerAppliedVolts(), busVolts);
+      driveOutputSims[i].set(state[i].driveAppliedVolts(), appliedRail);
+      steerOutputSims[i].set(state[i].steerAppliedVolts(), appliedRail);
     }
 
     RoboRioSim.setVInVoltage(busVolts);

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -319,8 +319,9 @@ final class SwerveModule {
   }
 
   void stop() {
-    // A zero velocity setpoint would hold the wheel against a shove, which is the brake a driver
-    // cannot drive out of. Dropping the output is what leaves the robot pushable.
+    // Both SPARKs idle in brake, so this is not a coast: dropping the output leaves the short
+    // across the motor, which resists a shove without driving back against one. A zero velocity
+    // setpoint would do the second, and that is the brake a driver cannot drive out of.
     driveMotor.stopMotor();
     steerMotor.stopMotor();
     desired = new SwerveModuleVelocity(0, getAngle());
@@ -386,7 +387,9 @@ final class SwerveModule {
     moduleLog.log("DriveOutput", driveMotor.getAppliedOutput().get());
     moduleLog.log("DriveCurrent", Amps.of(driveMotor.getOutputCurrent().get()));
     moduleLog.log("DriveTemp", Celsius.of(driveMotor.getMotorTemperature().get()));
-    moduleLog.log("SteerSetpoint", Rotations.of(steerSetpointRotations));
+    // The module angle, not the sensor rotations the SPARK was handed: the sensor frame runs
+    // [0, 1) and SteerAngle runs [-0.5, 0.5), so the logged pair could not be subtracted.
+    moduleLog.log("SteerSetpoint", desired.angle.getMeasure());
     moduleLog.log("SteerAngle", getAngle().getMeasure());
     moduleLog.log("SteerCurrent", Amps.of(steerMotor.getOutputCurrent().get()));
     moduleLog.log("SteerTemp", Celsius.of(steerMotor.getMotorTemperature().get()));

--- a/src/main/java/first/robot/sim/OnboardLoopSim.java
+++ b/src/main/java/first/robot/sim/OnboardLoopSim.java
@@ -45,7 +45,7 @@ public final class OnboardLoopSim {
     this.setpoint = setpoint;
   }
 
-  public double calculate(double measurement, double dtSeconds) {
+  public double calculate(double measurement, double dtSeconds, double busVolts) {
     double error = setpoint - measurement;
     if (wrapping) {
       error = MathUtil.inputModulus(error, -inputRange / 2, inputRange / 2);
@@ -58,6 +58,8 @@ public final class OnboardLoopSim {
     lastError = error;
     started = true;
 
-    return kP * error + kD * derivative + kS * Math.signum(setpoint) + kV * setpoint;
+    // The SPARK's feedback output is a duty cycle and its FeedForwardConfig gains are volts, so
+    // only the first pair scales with the rail.
+    return busVolts * (kP * error + kD * derivative) + kS * Math.signum(setpoint) + kV * setpoint;
   }
 }

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -37,6 +37,7 @@ public final class SwerveDriveSim {
   private Pose2d pose = Pose2d.kZero;
   private ChassisVelocities velocity = new ChassisVelocities();
   private double batteryVolts = BatterySim.calculateDefaultBatteryLoadedVoltage();
+  private double appliedRailVolts = batteryVolts;
 
   public SwerveDriveSim(SwerveSimConfig config) {
     kinematics = new SwerveDriveKinematics(config.moduleLocations());
@@ -52,6 +53,7 @@ public final class SwerveDriveSim {
   }
 
   public SimModuleState[] update(double[] driveVolts, double[] steerVolts, double dtSeconds) {
+    appliedRailVolts = batteryVolts;
     for (int i = 0; i < MODULES; i++) {
       driveAppliedVolts[i] = applied(drive[i], driveMotor, driveCurrentLimit, driveVolts[i]);
       steerAppliedVolts[i] = applied(steer[i], steerMotor, steerCurrentLimit, steerVolts[i]);
@@ -101,6 +103,13 @@ public final class SwerveDriveSim {
 
   public Voltage batteryVoltage() {
     return Volts.of(batteryVolts);
+  }
+
+  // The rail the last step's applied volts were clamped against, which is the one before that
+  // step's sag. Dividing them by any other number can put an applied output outside [-1, 1],
+  // where no duty cycle goes.
+  public Voltage appliedRailVoltage() {
+    return Volts.of(appliedRailVolts);
   }
 
   // A single-jointed arm with no gravity term is the plain DC motor plant, and DCMotorSim's own

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -144,14 +144,17 @@ public final class SwerveDriveSim {
   // couple of volts costs the pack a fraction of that current. Charging the pack with the winding
   // current instead collapses the rail at exactly the moment a robot launches, and the sag then
   // caps the volts that were going to accelerate it.
-  //
-  // Magnitudes: a regenerating motor charges the pack, and a simulation whose battery gains
-  // voltage under braking accelerates out of a stop better than the robot ever will.
   private double supplyCurrent(DCMotorSim axis, double appliedVolts) {
-    if (batteryVolts == 0) {
+    double motorAmps = axis.getCurrentDraw();
+    // getCurrentDraw is signed against the bus: negative is a motor pushing power back into it.
+    // A braking motor is credited as nothing rather than as charge, because a simulation whose
+    // battery gains voltage under braking accelerates out of a stop better than the robot ever
+    // will — but nothing is also not a full load, which is what taking the magnitude made it. A
+    // hard stop then sagged the rail into the clamp that was holding the wheels back.
+    if (motorAmps <= 0 || batteryVolts == 0) {
       return 0;
     }
-    return Math.abs(axis.getCurrentDraw()) * Math.abs(appliedVolts) / batteryVolts;
+    return motorAmps * Math.abs(appliedVolts) / batteryVolts;
   }
 
   private SwerveModuleVelocity[] velocities(SimModuleState[] states) {

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -124,12 +124,25 @@ public final class SwerveDriveSim {
   private double[] currents() {
     var currents = new double[MODULES * 2];
     for (int i = 0; i < MODULES; i++) {
-      // Magnitudes: a regenerating motor charges the pack, and a simulation whose battery gains
-      // voltage under braking accelerates out of a stop better than the robot ever will.
-      currents[i] = Math.abs(drive[i].getCurrentDraw());
-      currents[MODULES + i] = Math.abs(steer[i].getCurrentDraw());
+      currents[i] = supplyCurrent(drive[i], driveAppliedVolts[i]);
+      currents[MODULES + i] = supplyCurrent(steer[i], steerAppliedVolts[i]);
     }
     return currents;
+  }
+
+  // What the battery sees, not what the winding sees. A half-bridge is a DC-DC converter: it
+  // trades the rail's volts for the motor's amps, so a motor held at its current limit down at a
+  // couple of volts costs the pack a fraction of that current. Charging the pack with the winding
+  // current instead collapses the rail at exactly the moment a robot launches, and the sag then
+  // caps the volts that were going to accelerate it.
+  //
+  // Magnitudes: a regenerating motor charges the pack, and a simulation whose battery gains
+  // voltage under braking accelerates out of a stop better than the robot ever will.
+  private double supplyCurrent(DCMotorSim axis, double appliedVolts) {
+    if (batteryVolts == 0) {
+      return 0;
+    }
+    return Math.abs(axis.getCurrentDraw()) * Math.abs(appliedVolts) / batteryVolts;
   }
 
   private SwerveModuleVelocity[] velocities(SimModuleState[] states) {

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -5,10 +5,9 @@
 package first.robot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,6 @@ import org.wpilib.math.kinematics.ChassisAccelerations;
 import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.trajectory.HolonomicSample;
 import org.wpilib.math.trajectory.HolonomicTrajectory;
-import org.wpilib.util.AlertDataJNI;
 
 class FieldConstantsTest {
   private static final double TOLERANCE = 1e-9;
@@ -94,20 +92,13 @@ class FieldConstantsTest {
   }
 
   // No Driver Station is attached under a unit test, which is the same case as a robot on a bench
-  // with nobody plugged in.
+  // with nobody plugged in. Saying so out loud is Robot's alliance-unknown alert, which is gated
+  // on a Driver Station being attached and so stays silent here.
   @Test
-  void aMissingAllianceRaisesAnAlertRatherThanFlippingOnAGuess() {
+  void aMissingAllianceDefaultsToBlueRatherThanFlippingOnAGuess() {
     assertSame(
         PATH, FieldConstants.forAlliance(PATH), "a path was flipped with no alliance to go on");
-
-    assertTrue(
-        Arrays.stream(AlertDataJNI.getAlerts())
-            .anyMatch(
-                alert ->
-                    alert.id.equals("path-alliance-unknown")
-                        && alert.activeStartTime != 0
-                        && alert.level == AlertDataJNI.LEVEL_HIGH),
-        "no high-level alert was raised for a path followed without an alliance");
+    assertFalse(FieldConstants.onRed(), "a missing alliance did not default to blue");
   }
 
   // The mirror is a reflection and the flip is a rotation, so the mirror negates the two spins the

--- a/src/test/java/first/robot/PoseEstimatorTest.java
+++ b/src/test/java/first/robot/PoseEstimatorTest.java
@@ -10,6 +10,7 @@ import static org.wpilib.units.Units.Centimeters;
 import static org.wpilib.units.Units.Degrees;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.Seconds;
+import static org.wpilib.units.Units.Volts;
 
 import first.robot.sim.OnboardLoopSim;
 import first.robot.sim.SimModuleState;
@@ -187,10 +188,11 @@ class PoseEstimatorTest {
 
   private void tick() {
     for (int step = 0; step < SUB_STEPS; step++) {
+      double rail = sim.batteryVoltage().in(Volts);
       for (int i = 0; i < MODULES; i++) {
         // Rotation2d reads back over [-0.5, 0.5) and the analog sensor over [0, 1).
         double azimuth = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
-        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP);
+        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP, rail);
       }
       state = sim.update(driveVolts, steerVolts, SUB_STEP);
     }

--- a/src/test/java/first/robot/mechanisms/DriverInputTest.java
+++ b/src/test/java/first/robot/mechanisms/DriverInputTest.java
@@ -64,4 +64,49 @@ class DriverInputTest {
         "the fastest the wheel goes is not the whole battery");
     assertEquals(0, SwerveModule.openLoopVolts(0), 1e-9);
   }
+
+  // The stick's forward is -Y, so a shove forwards is getLeftY() = -1.
+  private static final double FORWARD = -1;
+  private static final boolean RED = true;
+  private static final boolean BLUE = false;
+
+  @Test
+  void aBlueDriverPushingForwardsDrivesAtTheRedWall() {
+    var velocities = Drive.driverVelocities(FORWARD, 0, 0, BLUE);
+
+    assertEquals(DriveConstants.MAX_VELOCITY.in(MetersPerSecond), velocities.vx, 1e-9);
+    assertEquals(0, velocities.vy, 1e-9);
+  }
+
+  // The field is blue-origin for both alliances, so +x is the red wall whoever is driving and a
+  // red driver standing at that wall has to be handed its negative. Getting this wrong drives the
+  // robot at the driver, which is what it did.
+  @Test
+  void aRedDriverPushingForwardsDrivesAwayFromTheRedWall() {
+    var velocities = Drive.driverVelocities(FORWARD, 0, 0, RED);
+
+    assertEquals(-DriveConstants.MAX_VELOCITY.in(MetersPerSecond), velocities.vx, 1e-9);
+    assertEquals(0, velocities.vy, 1e-9);
+  }
+
+  @Test
+  void thePerspectiveInvertsBothTranslationAxesTogether() {
+    var blue = Drive.driverVelocities(-0.6, -0.4, 0, BLUE);
+    var red = Drive.driverVelocities(-0.6, -0.4, 0, RED);
+
+    assertEquals(-blue.vx, red.vx, 1e-9, "forward did not invert");
+    assertEquals(-blue.vy, red.vy, 1e-9, "left did not invert");
+  }
+
+  // The perspective is a rotation about field centre, and a rotation does not change which way is
+  // clockwise. A perspective that negates the spin turns the wrong way on one alliance only,
+  // which reads as a gain problem rather than a sign error.
+  @Test
+  void thePerspectiveLeavesTheSpinAlone() {
+    var blue = Drive.driverVelocities(0, 0, -0.7, BLUE);
+    var red = Drive.driverVelocities(0, 0, -0.7, RED);
+
+    assertEquals(blue.omega, red.omega, 1e-9);
+    assertTrue(blue.omega > 0, "a right stick pushed left did not spin anticlockwise");
+  }
 }

--- a/src/test/java/first/robot/mechanisms/PathFollowingTest.java
+++ b/src/test/java/first/robot/mechanisms/PathFollowingTest.java
@@ -10,6 +10,7 @@ import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
 import static org.wpilib.units.Units.Radians;
 import static org.wpilib.units.Units.Seconds;
+import static org.wpilib.units.Units.Volts;
 
 import first.robot.Constants;
 import first.robot.DriveConstants;
@@ -187,12 +188,13 @@ class PathFollowingTest {
     var driveVolts = new double[MODULES];
     var steerVolts = new double[MODULES];
     for (int substep = 0; substep < SUB_STEPS; substep++) {
+      double rail = physics.batteryVoltage().in(Volts);
       for (int i = 0; i < MODULES; i++) {
         double wheelSpeed =
             state[i].wheelVelocityRadPerSec() * DriveConstants.WHEEL_RADIUS.in(Meters);
         double sensor = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
-        driveVolts[i] = driveLoops[i].calculate(wheelSpeed, SUB_STEP) + feedforward[i];
-        steerVolts[i] = steerLoops[i].calculate(sensor, SUB_STEP);
+        driveVolts[i] = driveLoops[i].calculate(wheelSpeed, SUB_STEP, rail) + feedforward[i];
+        steerVolts[i] = steerLoops[i].calculate(sensor, SUB_STEP, rail);
       }
       state = physics.update(driveVolts, steerVolts, SUB_STEP);
     }

--- a/src/test/java/first/robot/sim/OnboardLoopSimTest.java
+++ b/src/test/java/first/robot/sim/OnboardLoopSimTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class OnboardLoopSimTest {
   private static final double SUB_STEP = 0.001;
+  private static final double RAIL = 12.0;
 
   @Test
   void aWrappedPositionLoopTakesTheShortWayRound() {
@@ -17,7 +18,7 @@ class OnboardLoopSimTest {
     loop.setSetpoint(0.05);
 
     // 0.95 to 0.05 is a tenth of a turn forwards, not nine tenths of one backwards.
-    assertEquals(8 * 0.1, loop.calculate(0.95, SUB_STEP), 1e-9);
+    assertEquals(RAIL * 8 * 0.1, loop.calculate(0.95, SUB_STEP, RAIL), 1e-9);
   }
 
   @Test
@@ -25,7 +26,7 @@ class OnboardLoopSimTest {
     var loop = OnboardLoopSim.velocity(0.1, 0.15, 2.0);
     loop.setSetpoint(3.0);
 
-    assertEquals(0.15 + 2.0 * 3.0, loop.calculate(3.0, SUB_STEP), 1e-9);
+    assertEquals(0.15 + 2.0 * 3.0, loop.calculate(3.0, SUB_STEP, RAIL), 1e-9);
   }
 
   @Test
@@ -33,17 +34,31 @@ class OnboardLoopSimTest {
     var loop = OnboardLoopSim.position(0, 1, 0, 0, 1);
     loop.setSetpoint(0.25);
 
-    assertEquals(0, loop.calculate(0, SUB_STEP), 1e-9);
+    assertEquals(0, loop.calculate(0, SUB_STEP, RAIL), 1e-9);
   }
 
   @Test
   void theDerivativeFilterCarriesTheFractionItIsGiven() {
     var loop = OnboardLoopSim.position(0, 1, 0.5, 0, 1);
     loop.setSetpoint(0.25);
-    loop.calculate(0.25, SUB_STEP);
+    loop.calculate(0.25, SUB_STEP, RAIL);
 
     // The error steps to a quarter turn over a millisecond, so the raw derivative is 250 a
     // second and a filter of one half passes half of it.
-    assertEquals(0.5 * 250, loop.calculate(0, SUB_STEP), 1e-9);
+    assertEquals(RAIL * 0.5 * 250, loop.calculate(0, SUB_STEP, RAIL), 1e-9);
+  }
+
+  @Test
+  void theFeedbackTermsFollowTheRailAndTheFeedforwardTermsDoNot() {
+    var loop = OnboardLoopSim.velocity(0.1, 0.15, 2.0);
+    loop.setSetpoint(3.0);
+
+    double feedforward = 0.15 + 2.0 * 3.0;
+    double atTwelve = loop.calculate(0, SUB_STEP, 12.0) - feedforward;
+    double atSix = loop.calculate(0, SUB_STEP, 6.0) - feedforward;
+
+    // A SPARK browned out to half its rail applies half the duty cycle it was asking for, and
+    // the volts its FeedForwardConfig asked for are the ones it no longer has.
+    assertEquals(atTwelve / 2, atSix, 1e-9);
   }
 }

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -212,6 +212,32 @@ class SwerveDriveSimTest {
     return timeout.in(Seconds);
   }
 
+  // A launch is where this broke: the plant clamps against the rail from before the step and the
+  // pack sags during it, so dividing the applied volts by the later number reported a duty cycle
+  // of 1.65. Applied output is what ADR 0009's characterisation column is built from.
+  @Test
+  void theAppliedOutputStaysADutyCycleThroughAnAccelerationThatSagsThePack() {
+    Arrays.fill(driveVolts, 12.0);
+    // Half a turn of error, which asks the steer loop for more volts than the rail has.
+    for (int i = 0; i < MODULES; i++) {
+      steerLoops[i].setSetpoint(0.5);
+    }
+
+    int ticks = (int) Math.round(1.0 / Constants.LOOP_PERIOD.in(Seconds));
+    for (int tick = 0; tick < ticks; tick++) {
+      tick();
+      double rail = sim.appliedRailVoltage().in(Volts);
+      for (int i = 0; i < MODULES; i++) {
+        assertTrue(
+            Math.abs(state[i].driveAppliedVolts()) <= rail + 1e-9,
+            "drive applied " + state[i].driveAppliedVolts() + " volts against a " + rail + " rail");
+        assertTrue(
+            Math.abs(state[i].steerAppliedVolts()) <= rail + 1e-9,
+            "steer applied " + state[i].steerAppliedVolts() + " volts against a " + rail + " rail");
+      }
+    }
+  }
+
   // Seconds until every module is inside tolerance of the setpoint, or the timeout if it never is.
   private double settleTime(double setpointRotations, Angle tolerance, Time timeout) {
     int ticks = (int) Math.round(timeout.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -173,6 +173,45 @@ class SwerveDriveSimTest {
             + rolling);
   }
 
+  // The other half of the floaty-simulation bug. The battery model was charged the winding
+  // current, so four drives held at their limit down at a couple of volts read as 240 A and sagged
+  // the rail to its floor -- at exactly the moment a launch needs the volts. A log measured 1440 ms
+  // from rest to 90% of a request over 4 m/s.
+  @Test
+  void aFullThrottleLaunchReachesSpeedInTheTimeTheCurrentLimitAllows() {
+    Arrays.fill(driveVolts, 12.0);
+
+    double launched = timeToSpeed(4.0, Seconds.of(3));
+
+    assertTrue(
+        launched < 1.0, "the launch took " + Math.round(launched * 1000) + " ms to reach 4 m/s");
+  }
+
+  // A launch is current-limited, and a motor at its limit down at a couple of volts is a small
+  // load on the pack. A rail that collapses here is charging the battery the winding's amps.
+  @Test
+  void aLaunchDoesNotCollapseTheRail() {
+    Arrays.fill(driveVolts, 12.0);
+
+    advance(Seconds.of(1));
+
+    assertTrue(
+        sim.batteryVoltage().gt(Volts.of(10)),
+        "four current-limited modules sagged the pack to " + sim.batteryVoltage());
+  }
+
+  // Seconds until the chassis is at least this fast, or the timeout if it never is.
+  private double timeToSpeed(double metresPerSecond, Time timeout) {
+    int ticks = (int) Math.round(timeout.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));
+    for (int tick = 0; tick < ticks; tick++) {
+      tick();
+      if (Math.hypot(sim.trueVelocity().vx, sim.trueVelocity().vy) >= metresPerSecond) {
+        return (tick + 1) * Constants.LOOP_PERIOD.in(Seconds);
+      }
+    }
+    return timeout.in(Seconds);
+  }
+
   // Seconds until every module is inside tolerance of the setpoint, or the timeout if it never is.
   private double settleTime(double setpointRotations, Angle tolerance, Time timeout) {
     int ticks = (int) Math.round(timeout.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -7,7 +7,9 @@ package first.robot.sim;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wpilib.units.Units.Amps;
+import static org.wpilib.units.Units.Degrees;
 import static org.wpilib.units.Units.Meters;
+import static org.wpilib.units.Units.Rotations;
 import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.units.Units.Volts;
 
@@ -20,6 +22,7 @@ import org.wpilib.math.kinematics.ChassisVelocities;
 import org.wpilib.math.kinematics.SwerveDriveKinematics;
 import org.wpilib.math.system.DCMotor;
 import org.wpilib.math.util.MathUtil;
+import org.wpilib.units.measure.Angle;
 import org.wpilib.units.measure.Time;
 
 class SwerveDriveSimTest {
@@ -135,6 +138,62 @@ class SwerveDriveSimTest {
         "the battery did not recover once the wheels stopped accelerating");
   }
 
+  // The whole of the floaty-simulation bug: the SPARK's feedback output is a duty cycle, so a
+  // model that reads kP as volts steers at a twelfth of the authority the device has. A 90-degree
+  // step took 895 ms on the log that found this; the module physically slews a turn in 274 ms.
+  @Test
+  void aQuarterTurnStepSettlesInsideTheTimeADriverWouldNotice() {
+    for (int i = 0; i < MODULES; i++) {
+      steerLoops[i].setSetpoint(0.25);
+    }
+
+    double settled = settleTime(0.25, Degrees.of(5), Seconds.of(1));
+
+    assertTrue(
+        settled < 0.3, "steer took " + Math.round(settled * 1000) + " ms to settle a quarter turn");
+  }
+
+  // Both SPARKs idle in brake, and zero volts into the plant is the short across the motor that
+  // makes. A coasting module would hold its speed here instead.
+  @Test
+  void aWheelHandedZeroVoltsBrakesRatherThanCoasting() {
+    Arrays.fill(driveVolts, DRIVE_VOLTS);
+    advance(Seconds.of(3));
+    double rolling = state[0].wheelVelocityRadPerSec();
+    assertTrue(rolling > 1, "the wheel never spun up");
+
+    Arrays.fill(driveVolts, 0);
+    advance(Seconds.of(1));
+
+    assertTrue(
+        state[0].wheelVelocityRadPerSec() < rolling * 0.02,
+        "a wheel handed zero volts kept rolling at "
+            + state[0].wheelVelocityRadPerSec()
+            + " of "
+            + rolling);
+  }
+
+  // Seconds until every module is inside tolerance of the setpoint, or the timeout if it never is.
+  private double settleTime(double setpointRotations, Angle tolerance, Time timeout) {
+    int ticks = (int) Math.round(timeout.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));
+    for (int tick = 0; tick < ticks; tick++) {
+      tick();
+      boolean all = true;
+      for (int i = 0; i < MODULES; i++) {
+        double error =
+            MathUtil.inputModulus(
+                setpointRotations - MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1),
+                -0.5,
+                0.5);
+        all &= Math.abs(error) <= tolerance.in(Rotations);
+      }
+      if (all) {
+        return (tick + 1) * Constants.LOOP_PERIOD.in(Seconds);
+      }
+    }
+    return timeout.in(Seconds);
+  }
+
   private void advance(Time duration) {
     int ticks = (int) Math.round(duration.in(Seconds) / Constants.LOOP_PERIOD.in(Seconds));
     for (int i = 0; i < ticks; i++) {
@@ -146,10 +205,11 @@ class SwerveDriveSimTest {
   // across the sub-steps: what a 200 Hz robot commanding a 1 kHz loop actually looks like.
   private void tick() {
     for (int step = 0; step < SUB_STEPS; step++) {
+      double rail = sim.batteryVoltage().in(Volts);
       for (int i = 0; i < MODULES; i++) {
         // Rotation2d reads back over [-0.5, 0.5) and the analog sensor over [0, 1).
         double azimuth = MathUtil.inputModulus(state[i].azimuth().getRotations(), 0, 1);
-        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP);
+        steerVolts[i] = steerLoops[i].calculate(azimuth, SUB_STEP, rail);
       }
       state = sim.update(driveVolts, steerVolts, SUB_STEP);
     }

--- a/src/test/java/first/robot/sim/SwerveDriveSimTest.java
+++ b/src/test/java/first/robot/sim/SwerveDriveSimTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Degrees;
+import static org.wpilib.units.Units.Kilograms;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.Rotations;
 import static org.wpilib.units.Units.Seconds;
@@ -236,6 +237,39 @@ class SwerveDriveSimTest {
             "steer applied " + state[i].steerAppliedVolts() + " volts against a " + rail + " rail");
       }
     }
+  }
+
+  // Braking is where the pack was charged a full load for a motor that was pushing power back
+  // into it, and the sag then clamped the volts that were doing the braking. What is left is the
+  // current limit, which is arithmetic rather than a tuning knob.
+  @Test
+  void aHardReversalBrakesAtTheCurrentLimitWithoutSaggingThePack() {
+    Arrays.fill(driveVolts, 12.0);
+    advance(Seconds.of(3));
+    double rolling = sim.trueVelocity().vx;
+    assertTrue(rolling > 4, "the wheels never reached speed: " + rolling);
+
+    Arrays.fill(driveVolts, -12.0);
+    double started = sim.trueVelocity().vx;
+    double railFloor = 12.0;
+    int ticks = (int) Math.round(0.25 / Constants.LOOP_PERIOD.in(Seconds));
+    for (int i = 0; i < ticks; i++) {
+      tick();
+      railFloor = Math.min(railFloor, sim.batteryVoltage().in(Volts));
+    }
+    double decel = (started - sim.trueVelocity().vx) / 0.25;
+
+    // Four modules, each turning the limit into torque at the wheel and that into a share of the
+    // robot's mass. Nothing here is a gain.
+    double limit =
+        4
+            * config.drive().currentLimit().in(Amps)
+            * config.drive().motor().Kt
+            * DriveConstants.DRIVE_REDUCTION
+            / (DriveConstants.ROBOT_MASS.in(Kilograms) * DriveConstants.WHEEL_RADIUS.in(Meters));
+
+    assertEquals(limit, decel, limit * 0.1, "braking is not at the current limit");
+    assertTrue(railFloor > 10, "a regenerating pack sagged to " + railFloor + " volts");
   }
 
   // Seconds until every module is inside tolerance of the setpoint, or the timeout if it never is.

--- a/src/test/java/first/robot/sysid/CharacterisationTest.java
+++ b/src/test/java/first/robot/sysid/CharacterisationTest.java
@@ -400,10 +400,12 @@ class CharacterisationTest {
 
     var previousAzimuth = state[0].azimuth();
     for (int substep = 0; substep < SUB_STEPS; substep++) {
+      double rail = physics.batteryVoltage().in(Volts);
       if (!steerOpenLoop) {
         for (int i = 0; i < MODULES; i++) {
           steerLoops[i].setSetpoint(steerSetpoints[i]);
-          steerVolts[i] = steerLoops[i].calculate(sensorRotations(state[i].azimuth()), SUB_STEP);
+          steerVolts[i] =
+              steerLoops[i].calculate(sensorRotations(state[i].azimuth()), SUB_STEP, rail);
         }
       }
       state = physics.update(driveVolts, steerVolts, SUB_STEP);


### PR DESCRIPTION
Three things a desktop drive session found. The second is why the first two looked like separate problems.

## The driver's stick was never given the alliance

Every trajectory goes through `FieldConstants.forAlliance`, so the whole project is blue-origin: +x is the red wall whoever is driving. `driverControl` was the one path that rotated by the gyro heading alone, so a red driver pushing forward drove at their own wall.

The rotation goes in `driverVelocities`, read live every loop — the alliance arrives after the Driver Station does, and latching it at construction would hand a red driver blue controls for a whole match. It is confined to `driverControl`; path following already flips at construction and a second flip would drive auto into a wall.

`driverVelocities` now takes the axes and the alliance as `double`s. `CommandGamepad` needs the HAL and `DriverStationSim.setAllianceStationId` segfaults the test JVM, so a transform that reads either from inside is a transform Tier 1 cannot reach — and this is the bug that was worth a test.

## The loop model read the SPARK's gains in the wrong unit

`OnboardLoopSim` returned every term as volts. The device's feedback output is a **duty cycle**; its feedforward is volts:

- `ClosedLoopConfig.minOutput` / `maxOutput` are the only documented output units on the class, both *"in the range [-1, 1]"*
- every `FeedForwardConfig` gain beside them is documented *"in Volts"*
- `arbFeedforward` is applied *"after the result of the specified control mode"*, in units chosen from `ArbFFUnits.kVoltage` / `kPercentOut`

No javadoc says outright what the P term outputs — it is firmware — so the reading is inference, but nothing contradicts it.

This is not a fidelity nicety. A P loop on this plant is **speed-limited, not torque-limited**, so the gain sets the closed-loop time constant directly at `2π / (kP · V · Kv_module)`.

| | before | after |
|---|---|---|
| 30° step settle | **895 ms** (measured from `WPILIB_20260830_195120.wpilog`) | **220 ms** |
| median steer tracking error | 8° | — |
| p90 steer tracking error | 46° | — |

That is what "the sim is floaty and slow to respond" was. `SwerveDriveSimTest.aQuarterTurnStepSettlesInsideTheTimeADriverWouldNotice` holds it there.

`SIM_GAINS` move with the fix. What now separates them from `REAL_GAINS` is the friction the plant does not have — no stiction, so both `kS` are zero; nothing to damp, so steer needs no `kD` — rather than a units conversion nobody had written down.

### Two hypotheses this killed, for the record

- **Loop timing.** `/Robot/LoopDelta` over 171 s: p50 exactly 5.000 ms, 1.66% of loops over 6 ms. The sim holds 200 Hz and runs at real time.
- **Module-angle ill-conditioning near zero speed.** Setpoint slew across 11,370 transitions: p50 88°/s, p90 206°/s, against a 1315°/s physical ceiling. Of the 3.9% above 400°/s, median commanded speed was 5.99 m/s — full-stick driving, not noise amplification. 12 samples out of 11,370 paired a fast setpoint with a near-zero command. One fix, not two.

## Brake mode

The SPARKs were already `IdleMode.kBrake` and the plant already models it — zero volts into a `DCMotorSim` is the short across the motor, and coasting would have to zero the current instead. Neither said so, and `stop()`'s comment claimed the opposite ("leaves the robot pushable"). Both now say it and a test holds it. No explicit idle-mode field: nothing sets coast, so it would have exactly one possible value.

## Two things the investigation needed and did not have

- `SteerSetpoint` was logged in sensor rotations and `SteerAngle` as a `Rotation2d`, so the pair ran over `[0, 1)` and `[-0.5, 0.5)` and **could not be subtracted** — exactly the plot you reach for to judge steer tracking. Both are the module angle now.
- `FieldConstants` carried a second `alliance-unknown` alert, path-worded, duplicating the one `Robot` already toggles every loop. `Robot`'s is gated on a Driver Station actually being attached, so it is the one that survives. This is a departure from the plan, which said reword rather than delete — the duplicate only surfaced when the rename collided and `(group, id)` threw.

## Docs

`CONTEXT.md` gains **driver perspective**, cross-linked against *the flip* and *the mirror* — the failure being guarded is applying one where the other belongs. ADR 0010 is amended for the loop-output units, with the measurements and the sources. ADR 0009 gains a line on what may legitimately separate the two gain sets.

No ADR for driver perspective: it fails "hard to reverse."

## Out of scope, deliberately

The sim has no rolling resistance, no traction limit, and no independent chassis momentum. None of it caused this. Worth a separate ticket, and worth judging against a sim that is no longer lying about its controller.

## Testing

Full suite green, 94 tests. New Tier 1 coverage: red/blue perspective including that the spin is the one component it leaves alone, the steer settle bound, zero-volts braking, and that the loop model's feedback follows the rail while its feedforward does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)