### PR TITLE
Cap the driver's stick at a turn a second, and log a setpoint you can subtract

### DIFF
--- a/src/main/java/first/robot/DriveConstants.java
+++ b/src/main/java/first/robot/DriveConstants.java
@@ -17,6 +17,7 @@ import static org.wpilib.units.Units.Pounds;
 import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.RadiansPerSecondPerSecond;
 import static org.wpilib.units.Units.Rotations;
+import static org.wpilib.units.Units.RotationsPerSecond;
 import static org.wpilib.units.Units.Second;
 import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.units.Units.Volts;
@@ -121,6 +122,12 @@ public final class DriveConstants {
   // once oversaturates the wheels, which desaturateWheelVelocities then scales back together.
   public static final AngularVelocity MAX_ANGULAR_VELOCITY =
       RadiansPerSecond.of(MAX_VELOCITY.in(MetersPerSecond) / DRIVE_RADIUS.in(Meters));
+
+  // What full right stick asks for, which is not MAX_ANGULAR_VELOCITY. That one is the whole
+  // wheel budget, so a driver holding it has nothing left to translate with and desaturation
+  // halves both. A turn a second is about 44 per cent of the budget, which leaves three quarters
+  // of a full translation available while spinning.
+  public static final AngularVelocity DRIVER_MAX_ANGULAR_VELOCITY = RotationsPerSecond.of(1);
 
   // The offset a used controller sits at with nobody touching it. Below this the command is
   // exactly zero, because even a small omega steers all four modules to a rotation angle.

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -635,11 +635,16 @@ public class Drive implements Mechanism {
   }
 
   private SwerveModuleVelocity[] moduleTargets(ChassisVelocities velocities) {
-    desiredVelocities = velocities;
     var target = velocities.discretize(Constants.LOOP_PERIOD.in(Seconds));
-    return SwerveDriveKinematics.desaturateWheelVelocities(
-        kinematics.toSwerveModuleVelocities(target),
-        DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
+    var states =
+        SwerveDriveKinematics.desaturateWheelVelocities(
+            kinematics.toSwerveModuleVelocities(target),
+            DriveConstants.MAX_VELOCITY.in(MetersPerSecond));
+    // What the wheels were actually asked for, which is what the measurement can be subtracted
+    // from. A translation and a spin at once oversaturate the modules, and the caller's request
+    // then names a chassis velocity nothing ever attempted.
+    desiredVelocities = kinematics.toChassisVelocities(states);
+    return states;
   }
 
   public void stopModules() {

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -594,7 +594,7 @@ public class Drive implements Mechanism {
         DriveConstants.MAX_VELOCITY.times(stick(-leftX) * perspective),
         // A rotation about field centre does not change which way is clockwise, so the spin is
         // the one component the perspective leaves alone.
-        DriveConstants.MAX_ANGULAR_VELOCITY.times(stick(-rightX)));
+        DriveConstants.DRIVER_MAX_ANGULAR_VELOCITY.times(stick(-rightX)));
   }
 
   // Asymptotically linear: the curve eases out of zero over the width and then converges onto the

--- a/src/test/java/first/robot/mechanisms/DriverInputTest.java
+++ b/src/test/java/first/robot/mechanisms/DriverInputTest.java
@@ -7,10 +7,13 @@ package first.robot.mechanisms;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wpilib.units.Units.MetersPerSecond;
+import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.Volts;
 
 import first.robot.DriveConstants;
 import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.ChassisVelocities;
+import org.wpilib.math.kinematics.SwerveDriveKinematics;
 
 class DriverInputTest {
   private static final double DEADBAND = DriveConstants.DRIVER_DEADBAND;
@@ -101,6 +104,35 @@ class DriverInputTest {
   // The perspective is a rotation about field centre, and a rotation does not change which way is
   // clockwise. A perspective that negates the spin turns the wrong way on one alliance only,
   // which reads as a gain problem rather than a sign error.
+  // Translation and rotation share one wheel budget, and each stick alone is defined to spend all
+  // of it -- MAX_ANGULAR_VELOCITY is the spin that puts the corner modules at MAX_VELOCITY. So
+  // full stick on both asks for twice what the modules have, and desaturation halves both. This
+  // is the whole of why the robot will not translate and spin at once at full deflection.
+  @Test
+  void fullTranslationAndFullRotationAtOnceAskForTwiceTheWheelsThereAre() {
+    var kinematics =
+        new SwerveDriveKinematics(
+            DriveConstants.DRIVE.frontLeft().location(),
+            DriveConstants.DRIVE.frontRight().location(),
+            DriveConstants.DRIVE.backLeft().location(),
+            DriveConstants.DRIVE.backRight().location());
+    double max = DriveConstants.MAX_VELOCITY.in(MetersPerSecond);
+
+    var both =
+        kinematics.toSwerveModuleVelocities(
+            new ChassisVelocities(
+                max, 0, DriveConstants.MAX_ANGULAR_VELOCITY.in(RadiansPerSecond)));
+
+    double fastest = 0;
+    for (var state : both) {
+      fastest = Math.max(fastest, Math.abs(state.velocity));
+    }
+
+    assertTrue(
+        fastest > 1.8 * max,
+        "a full translation and a full spin only asked for " + fastest / max + " of a wheel");
+  }
+
   @Test
   void thePerspectiveLeavesTheSpinAlone() {
     var blue = Drive.driverVelocities(0, 0, -0.7, BLUE);

--- a/src/test/java/first/robot/mechanisms/DriverInputTest.java
+++ b/src/test/java/first/robot/mechanisms/DriverInputTest.java
@@ -133,6 +133,33 @@ class DriverInputTest {
         "a full translation and a full spin only asked for " + fastest / max + " of a wheel");
   }
 
+  // And why the driver's stick is not allowed to ask for it. A turn a second leaves most of a
+  // translation available while spinning; the geometric maximum leaves none.
+  @Test
+  void fullStickOnBothLeavesMostOfATranslationAfterDesaturation() {
+    var kinematics =
+        new SwerveDriveKinematics(
+            DriveConstants.DRIVE.frontLeft().location(),
+            DriveConstants.DRIVE.frontRight().location(),
+            DriveConstants.DRIVE.backLeft().location(),
+            DriveConstants.DRIVE.backRight().location());
+    double max = DriveConstants.MAX_VELOCITY.in(MetersPerSecond);
+
+    var asked =
+        new ChassisVelocities(
+            max, 0, DriveConstants.DRIVER_MAX_ANGULAR_VELOCITY.in(RadiansPerSecond));
+    var states =
+        SwerveDriveKinematics.desaturateWheelVelocities(
+            kinematics.toSwerveModuleVelocities(asked), max);
+    var delivered = kinematics.toChassisVelocities(states);
+
+    double scale = Math.hypot(delivered.vx, delivered.vy) / max;
+    assertTrue(scale > 0.7, "a full translation and a full driver spin scaled back to " + scale);
+    assertTrue(
+        DriveConstants.DRIVER_MAX_ANGULAR_VELOCITY.lt(DriveConstants.MAX_ANGULAR_VELOCITY),
+        "the driver's stick is entitled to the whole wheel budget again");
+  }
+
   @Test
   void thePerspectiveLeavesTheSpinAlone() {
     var blue = Drive.driverVelocities(0, 0, -0.7, BLUE);


### PR DESCRIPTION
From driving `WPILIB_20260830_203817.wpilog`: translating and rotating at once, the robot delivers about a third of what the stick asks for.

## Measured

| | delivered / asked |
|---|---|
| translating only | 0.70 |
| **both at once** | **0.37 speed, 0.36 spin** |

The desaturation factor during combined motion is **exactly 0.500** at the median, and that is the whole explanation. `MAX_ANGULAR_VELOCITY` is *defined* as the spin that puts the corner modules at `MAX_VELOCITY` — the entire wheel budget. Full right stick alone spent all of it; full left stick alone spent all of it; both together asked for **twice the wheels that exist**, and `desaturateWheelVelocities` halved everything. Full deflection commanded 2.26 rotations a second, which is 136 RPM.

## The cap

The stick now asks for `DRIVER_MAX_ANGULAR_VELOCITY` — one rotation a second, ~44% of the budget.

| | full stick spin | full + full delivers |
|---|---|---|
| before | 2.26 rot/s | 3.24 m/s + 290°/s (54% of the ask) |
| after | 1.00 rot/s | 4.44 m/s + 267°/s (74% of the ask) |

More combined authority *and* barely less spin actually delivered, because the old number was being thrown away by desaturation before it reached a wheel.

`MAX_ANGULAR_VELOCITY` stays. It is the reason the chosen number is the number, and `fullTranslationAndFullRotationAtOnceAskForTwiceTheWheelsThereAre` asserts the 2:1 relationship that makes a cap necessary in the first place.

## The bug beside it

`DesiredVelocities` was logged *before* desaturation, so the log recorded a chassis velocity the robot never attempted — and subtracting the measurement from it made a drive delivering exactly what it commanded look like one that could not track. That is the same defect as the steer setpoint's branch cut in #96: a setpoint/measurement pair you cannot subtract. It now logs the desaturated states converted back to a chassis velocity.

## Not a simulation problem

Worth stating plainly, because the investigation started as one: none of this is sim fidelity. The same code and the same constants run on the robot, and it will feel identical on hardware. The gyro was the other suspect and it is clean — 0.49° median error against true pose, no measurable lag.

## Testing

Full suite green. Two new Tier 1 cases: the 2:1 oversaturation relationship, and that a full translation plus a full driver spin now survives desaturation at better than 0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)