### PR TITLE
Record what the sim's missing drag costs, and what it does not

### DIFF
--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -612,6 +612,33 @@ numbered recipe belongs in the README, not here.
   a top-down world. Its cost is also recorded there — it cuts against
   the prefer-built-in-WPILib principle, and it is that map's to confirm.
 
+- **The free-space model has no drag, and drag — not slip — is what the
+  driving feel is missing.** Nothing resists a rolling wheel, so the
+  chassis reaches `MAX_VELOCITY` exactly. That constant is the nameplate
+  free speed at this reduction, 5.99 m/s, and its own comment says it is
+  "not a measurement of a chassis"; a real one tops out lower once
+  rolling resistance and drivetrain losses are in. The error is not
+  confined to the top end: `SwerveModule.openLoopVolts` maps a stick
+  position to a fraction of 12 V *through* `MAX_VELOCITY`, so teleop's
+  whole curve is calibrated against a speed the robot cannot hold, and
+  every stick position under-delivers by the same ratio.
+
+  **A traction limit is not the lever, which is worth knowing before
+  the physics map spends effort on one.** At the 60 A drive limit each
+  wheel puts **121 N** at the contact patch against **125–167 N** of
+  grip for μ between 0.9 and 1.2, so the wheels never break traction in
+  a straight line and a slip model would sit inert. Braking and
+  launching are bounded by the current limit at
+  `4 · I · Kt · G / (m · r)` = **8.57 m/s²**, 0.87 g, and a driving log
+  measured a full-speed wheel reversal at 8.36 m/s² three times to
+  within a percent **[measured]**. Slip becomes reachable only above
+  about 69 A. **[measured]**
+
+  *Unblocked by* a chassis to drive flat out and time, which is the same
+  session that turns `MAX_VELOCITY` and ADR 0009's effective wheel
+  radius into measurements. Until then the sim is optimistic about top
+  speed by a knowable ratio and honest about everything else.
+
 ## Rejected
 
 ### maple-sim, as a vendordep or as a fork


### PR DESCRIPTION
Closing out the driving session that produced #96 and #97. Three causes there were real bugs and are fixed. What is left is that nothing in the free-space model resists a rolling wheel, and that now has a home in ADR 0010's *Open* section with the arithmetic behind it.

The entry is mostly a **negative result**, which is the part worth writing down. The instinct — mine included, and I said so out loud before measuring — is that a traction limit is the missing piece. It is not:

- At the 60 A drive limit each wheel puts **121 N** at the contact patch against **125–167 N** of grip (μ 0.9–1.2). The wheels never break traction in a straight line, so a slip model would sit inert.
- Launch and braking are bounded by the current limit at `4 · I · Kt · G / (m · r)` = **8.57 m/s²** (0.87 g). A driving log measured a full-speed wheel reversal at **8.36 m/s², three times, to within a percent**.
- Slip only becomes reachable above about **69 A**.

What *is* missing is drag, and it costs more than the top end: `MAX_VELOCITY` is the nameplate free speed (5.99 m/s, and its own comment admits it is "not a measurement of a chassis"), and `SwerveModule.openLoopVolts` maps stick position to volts *through* it — so teleop's whole curve is calibrated against a speed the robot cannot hold.

Both belong to the physics map rather than to this ADR, which already treats that as a separate effort. The entry says what would unblock them: the same bench session that turns ADR 0009's effective wheel radius into a measurement.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)