### PR TITLE
Simplify language and clarify robot interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,105 +1,51 @@
 # 2027beta
 
-FRC team 8852's swerve drive base for the 2027 season, on the SystemCore
-control system. WPILib 2027 alpha, Java 25, Commands v3.
+Team 8852's 2027 SystemCore swerve drive base. Read the relevant ADR before
+changing code.
 
-The architecture was decided before it was built, and it is written
-down here — see *Where things are*. Read the ADR covering whatever you
-are about to change before you change it.
+## WPILib 2027
 
-## WPILib 2027 is not the WPILib you know
+This is a major API rewrite. Check `~/dev/allwpilib` instead of copying online
+examples.
 
-2027 is a rewrite. Every snippet on the internet, and every completion
-your training gives you, is wrong at the import line. Check the source
-at `~/dev/allwpilib` before believing yourself.
+- Package root: `org.wpilib`, not `edu.wpi.first`.
+- `ChassisSpeeds` is now `ChassisVelocities`.
+- `SwerveModuleState` is now `SwerveModuleVelocity`.
+- `vxMetersPerSecond` and `vyMetersPerSecond` are now `vx` and `vy`.
+- `MathUtil` is now `math.util`; `LinearSystemId` is now `Models`.
+- `Sendable`, `SmartDashboard`, `RobotContainer`, `Subsystem`, and several old
+  command classes are gone. Mechanisms are fields on `Robot`; opmodes own
+  bindings.
 
-The package root is `org.wpilib`. There is no `edu.wpi.first`.
+Field hazards that still compile:
 
-Renamed, with no deprecation shim:
+- `Rotation2d` uses `[-0.5, 0.5]` rotations; the steer sensor uses `[0, 1)`.
+- Use the two-argument `ChassisAccelerations.toWheelAccelerations()` so it keeps
+  the centripetal term.
+- Coroutine cancellation runs `whenCanceled()`, not `finally`.
+- Coroutine loops must be `while`; `for (;;)` bypasses the missing-`yield` check.
 
-| You will write | It is now |
-|---|---|
-| `ChassisSpeeds` | `ChassisVelocities` |
-| `SwerveModuleState` | `SwerveModuleVelocity` |
-| `vxMetersPerSecond`, `vyMetersPerSecond` | `vx`, `vy` |
-| `MathUtil` | `math.util` |
-| `LinearSystemId` | `Models` |
-| `edu.wpi.first.math.system.plant` | deleted |
+`Alert` is `org.wpilib.util.Alert`. Its `id` is required and duplicate
+`(group, id)` values throw.
 
-Deleted outright, so any code reaching for them will not compile:
-`Sendable`, `SendableBuilder`, `SendableChooser`, `SmartDashboard`,
-`SwerveControllerCommand`, `HolonomicDriveController`. Commands v3 has
-no `Subsystem` type and no `RobotContainer` — mechanisms are fields on
-`Robot`, and op modes carry the bindings.
+## REVLib 2027
 
-Four traps that compile fine and fail on the field:
-
-- `Rotation2d` stores cos/sin only, so `getRotations()` returns
-  `[-0.5, 0.5]` while our steer sensor reads `[0, 1)`. Converting
-  between them is not optional. `AbsoluteEncoderConfig.zeroCentered`
-  would delete the mismatch, and does not exist for an analog sensor.
-- `ChassisAccelerations.toWheelAccelerations()` hardcodes ω = 0 and
-  silently drops the centripetal term, which dominates during rotation.
-  Always use the 2-argument form.
-- Commands v3 cancellation is not an exception unwind. Cleanup goes in
-  `whenCanceled()`. A `finally` block never runs.
-- The compiler plugin's missing-`yield` check covers `while` only.
-  Loops in coroutine bodies are always `while` — a `for(;;)` compiles
-  clean and hangs the robot.
-
-`Alert` exists, at `org.wpilib.util.Alert`, and takes a mandatory `id`.
-Duplicate `(group, id)` throws.
-
-## REVLib 2027 renamed the two calls you use most
-
-Every SPARK snippet on the internet is wrong at the call, not the
-import. Read the sources from `maven.revrobotics.com`, not your memory.
-
-| You will write | It is now |
-|---|---|
-| `controller.setReference(...)` | `controller.setSetpoint(...)` |
-| `spark.set(throttle)` | `spark.setThrottle(throttle)` |
-
-Plain-double getters are gone: reads return `Signal<T>`.
-
-`configure()` throws on failure, except for `kTimeout` and
-`kCannotPersistParametersWhileEnabled`, which it returns. Success is no
-exception *and* `kOk` — checking only one of those misses half the
-failures.
-
-`AnalogSensorConfig` has three setters — `inverted`,
-`positionConversionFactor`, `velocityConversionFactor` — and no
-`zeroOffset`. The device cannot hold a module zero, so the offset is
-folded into the setpoint by hand; ADR 0008 owns where the loops run and
-what feeds them.
+- Use `controller.setSetpoint(...)`, not `setReference(...)`.
+- Use `spark.setThrottle(...)`, not `set(...)`.
+- Getters return `Signal<T>`, not plain doubles.
+- `configure()` can throw or return an error. Check for both.
+- Analog sensors have no zero offset. Apply the module offset to the setpoint.
 
 ## Comments
 
-Comment the line that confuses. A non-obvious unit, a surprising
-ordering, a workaround for someone else's bug — one line, at the line.
+Keep only short comments that explain a surprising unit, order, or workaround.
+Let names and small methods explain the normal case. Do not add public-method
+Javadoc or history links to code; link upstream bugs only when a workaround
+needs a removal condition.
 
-Everything else the code says better, and says truthfully. A comment
-describing intent is a claim that stops being checked the moment the
-code changes.
+## Documents
 
-Names are the documentation. When a block needs a paragraph to explain,
-extract it and let the method name carry the paragraph.
-
-Code names no issue, ADR or document. That history lives in the commit
-message and the PR. The one exception is an *upstream* defect — an
-allwpilib, REV or CTRE bug — because that link is the only thing that
-tells a future reader when the workaround can be deleted.
-
-Public methods get no Javadoc. Command names already follow
-`Mechanism.Action`, and every quantity is a `Measure`, so a summary
-line and a units line would both be restating the signature.
-
-## Where things are
-
-<!-- This file points; it never restates. -->
-
-- `docs/adr/` — the architecture decisions, one area per document.
-  `docs/adr/README.md` indexes them.
-- `CONTEXT.md` — the glossary.
-- `docs/commands-v3-house-style.md` — how commands get written here.
-- `docs/research/` — verified findings from the design map, with sources.
+- `docs/adr/` — architecture decisions.
+- `CONTEXT.md` — project glossary.
+- `docs/commands-v3-house-style.md` — command style.
+- `docs/research/` — sources and measurements.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,9 +22,8 @@ The index of the ADRs themselves is
 - **Fog** — a question you can see coming but cannot yet phrase
   sharply. It is recorded rather than omitted, and *Open* is where it
   lands.
-- **Load-bearing** — said of a line, a rule or a fact that something
-  else quietly depends on. The ADRs mark them so that a later reader
-  does not tidy one away.
+- **Important dependency** — a line, rule, or fact that other work
+  depends on. ADRs mark these so they are not removed by accident.
 - **Enforcement machinery** — a framework, base class, lint rule or
   compliance test whose whole job is to make people follow a rule.
   This project repeatedly declines it in favour of a construction
@@ -241,6 +240,8 @@ The index of the ADRs themselves is
   `Drive.getModulePositions()` hands the pose estimator, and it is a
   different quantity from module angle rather than a longer name for
   it.
+- **Module target** — the requested wheel speed and module angle. A
+  `SwerveModule` optimizes and applies it to both motors.
 - **Field-relative** — velocities expressed against the field, so
   *forward* means the same direction whichever way the robot is
   facing. **Robot-relative** is against the chassis. The follower

--- a/README.md
+++ b/README.md
@@ -1,240 +1,80 @@
 # 2027beta
 
-FRC team 8852's swerve drive base for the 2027 season, on the SystemCore
-control system. WPILib 2027 alpha, Java 25, Commands v3.
+FRC Team 8852's 2027 SystemCore swerve drive base. It uses WPILib 2027
+alpha, Java 25, and Commands v3.
 
-The architecture was decided and written down before it was built.
-Fourteen ADRs in [`docs/adr/`](docs/adr/README.md) hold the decisions,
-[`CONTEXT.md`](CONTEXT.md) defines every word this project invents or
-overloads,
-[`docs/commands-v3-house-style.md`](docs/commands-v3-house-style.md)
-teaches the code you are about to write, and
-[`docs/research/`](docs/research/) holds the measurements they cite.
+Read these before changing code:
 
-The robot code is the next effort, and so is most of the tooling below.
-Anything specified but not yet built says so where it is described.
+- [`CONTEXT.md`](CONTEXT.md) defines the project's special terms.
+- [`docs/adr/`](docs/adr/README.md) records architecture decisions.
+- [`docs/commands-v3-house-style.md`](docs/commands-v3-house-style.md)
+  teaches this project's command style.
+- [`docs/research/`](docs/research/) contains the measurements and source
+  notes behind the ADRs.
 
-## Getting set up
+## Start here
 
-1. **JDK 25** and the **WPILib 2027 VSCode extension.** The extension
-   installs a JDK and the local maven home the build reads from.
-2. **Clone it and open it in VSCode.** Trusting the project is one
-   keystroke, and there is nothing else to install — what an agent needs
-   is in the repo, described under *What is checked in for agents*.
-3. **`./gradlew simulateJava`** — the sim GUI and the simulated Driver
-   Station are both enabled in `build.gradle`.
-4. **`./gradlew test`** — Tier 1, where every number this project
-   asserts lives. It needs no hardware and no HAL.
-5. **`./gradlew sysidLog`**, when you are characterising — it runs the
-   routines against the simulation and writes
-   `logs/sysid-simulation.wpilog`, which opens in the SysId analyser.
-   Every gain fitted from it describes the model and not a robot.
-6. **`uv`**, only if you are touching `tools/logtool`. *Not built yet.*
+1. Install JDK 25 and the WPILib 2027 VSCode extension.
+2. Clone the repository and open it in VSCode.
+3. Run `./gradlew simulateJava` to start the simulation.
+4. Run `./gradlew test` to run tests without hardware.
+5. Run `./gradlew sysidLog` when working on SysId. Its log describes the
+   simulation, not the real robot.
+6. Install `uv` only when working on `tools/logtool`, which is not built yet.
 
-Then read [`CONTEXT.md`](CONTEXT.md), the house style, and the ADR
-covering whatever you are about to change.
+The project currently uses a local allwpilib checkout. See
+[ADR 0003](docs/adr/0003-project-and-package-structure.md) and
+[`docs/research/systemcore-deploy.md`](docs/research/systemcore-deploy.md).
 
-**Nobody pushes to `main`.** Branch, push the branch, open a pull
-request. [ADR 0013](docs/adr/0013-ci-and-test-strategy.md) makes the
-gated workflow a required check including administrators, with a
-per-event branch as the escape hatch during competition — a branch is a
-thing you have to mean, where an admin override is a habit that gets
-used on a Tuesday. `main` carries that ruleset now: the check is
-required, and deletion and force-push are refused.
+## Working safely
 
-While 2027 is in flux the project builds against a local allwpilib
-checkout rather than a published release; see
-[ADR 0003](docs/adr/0003-project-and-package-structure.md) for the
-decision and
-[`docs/research/systemcore-deploy.md`](docs/research/systemcore-deploy.md)
-for the recipe.
+- Never push directly to `main`. Use a branch and pull request.
+- An agent may build, test, simulate, and deploy. A person must enable a real
+  robot.
+- No agent may commit to `main`.
 
-## Seats, and who gets one
+The required CI workflow protects `main`, including for administrators. During
+competition, use a deliberate per-event branch if needed. See
+[ADR 0013](docs/adr/0013-ci-and-test-strategy.md).
 
-**Team plan seats for the mentor and for students who are 18 or over.**
-Everyone else works through the reviewer.
+## AI access
 
-That is not a budget decision. **Nobody under 18 can hold a Claude
-account, on any plan.** The rule is written in four places, recorded
-here rather than left on the tracker so that the 2028 fork does not
-re-derive it:
+Team-plan seats are for the mentor and students who are at least 18. Everyone
+else uses the reviewer. Anthropic requires users to be at least 18; team plans,
+school use, and mentor supervision do not change that. Details and sources are
+in [issue #24](https://github.com/Drew-Robotics/2027beta/issues/24).
 
-| Source | What it says |
-|---|---|
-| [Consumer Terms](https://www.anthropic.com/legal/consumer-terms) (eff. 2025-10-08) | At least 18, or your local minimum age, whichever is higher. |
-| [Usage Policy](https://www.anthropic.com/legal/aup) (eff. 2025-09-15) | A minor is anyone under 18, *regardless of jurisdiction* — which closes the local-age reading the Consumer Terms leave open. |
-| [Minimum age requirement](https://support.claude.com/en/articles/13117299-minimum-age-requirement-access-restriction) | All users must be at least 18 to create and use an account. **No exception** for a school, an institution, an education program, parental consent or supervision. |
-| [Team plan](https://support.claude.com/en/articles/9266767-what-is-the-team-plan) | No age exception. An admin invite does not bypass account creation, so each member still meets the gate personally. |
-
-Two things make signing up anyway a bad plan rather than a grey one.
-[Age assurance](https://support.claude.com/en/articles/15171100-age-assurance-on-claude)
-shipped on 2026-05-18: it fires on under-18 signals and *disables* the
-account until verification passes, so the failure mode is a student
-losing their account mid-season with no warning and nothing a mentor can
-do. And
-[Claude for Teachers](https://www.anthropic.com/news/claude-for-teachers)
-(2026-07-14) is free premium access including Claude Code — for the
-teacher: *"Claude for Teachers is for educators only, consistent with
-Claude's 18-and-over policy."* If a student path existed anywhere, that
-product is where it would be. The full finding, including why the API
-door leads somewhere a volunteer team cannot go, is on
-[#24](https://github.com/Drew-Robotics/2027beta/issues/24).
-
-The consequence worth stating plainly: **for most of this team, the
-reviewer is the whole channel.** It is not a nice-to-have on top of
-per-student seats — it is what delivers the same assistance to a student
-who cannot have an account, and it needs no student identity at all.
-
-## The safety rule
-
-**An agent may build, test, simulate and deploy freely. A human presses
-enable.**
-
-Sim and unit tests are unbounded on purpose — the whole autonomous loop
-closes with no HAL precisely so that an agent can iterate there. But
-nothing an agent does may put a real robot in motion. There is no undo
-on a swerve base at 4 m/s.
-
-No agent commits to `main`.
-
-Past that one rule the guardrail is review, not configuration. A student
-reading agent-written code and asking why it does that is the learning,
-not an obstacle to it.
-
-## What is checked in for agents
-
-**`.claude/settings.json` holds a permission allowlist, and nothing
-else** — the calls that should never prompt: `./gradlew *`, read-only
-`git`, read-only `gh issue`, `ssh systemcore@…`, `uv run`. The argument
-for it is safety rather than convenience: being prompted constantly
-teaches you to approve without reading, which is the actual risk.
-Personal preferences belong in `.claude/settings.local.json`, which
-stays out of the repo. *Neither file is committed yet.*
-
-**No hooks.** A format-on-save or build-before-commit hook is
-enforcement machinery, and the gated workflow already owns enforcement.
-A hook would put the same rule in a second place, invisible in the CI
-log that is supposed to be the record.
-
-**No MCP servers.** Every candidate is already a CLI an agent drives
-natively — the device is `ssh` and `journalctl`, the log store is
-`tools/logtool`, the tracker is `gh`. A server would buy no capability
-and add a process to install, version, keep alive and re-approve on
-every clone. Revisit only if something turns out to be genuinely
-unreachable from a shell.
-
-**One skill, `/analyze-match`**, because it is a *process* with a
-completion bar — every one of five question classes reported with a
-finding or an explicit *clear*
-([ADR 0014](docs/adr/0014-ai-log-analysis-contract.md)). Reference
-material gets a pointer in a document instead: a scaffolder for
-mechanisms or autos would be a second copy of the house style, and a
-second copy drifts. *Not built yet.*
-
-`CLAUDE.md` is the file agents actually load. It points rather than
-copies; what it holds inline is only the small set of things an agent
-cannot look up because it does not know it is wrong — the 2027 API
-renames, the four hazards that compile clean and fail on the field, and
-the comment rule.
-
-## The reviewer
-
-*Specified in [ADR 0013](docs/adr/0013-ci-and-test-strategy.md) and on
-[#18](https://github.com/Drew-Robotics/2027beta/issues/18); not built
-yet.*
-
-It is a normal Claude Code session with a different opening prompt. It
-reads `CLAUDE.md` and the ADRs like any other session, so there is no
-second knowledge store to keep in sync.
-
-- **Trigger:** `workflow_run` against the gated workflow, gated on
-  `conclusion == success`. It does not spend a review on defects the
-  build catches in seconds — and, more importantly, `workflow_run` runs
-  the workflow definition from `main`, so a student with write access
-  cannot edit the reviewer's workflow inside their own pull request and
-  print the key.
-- **Credential:** a Console API key with a monthly spend cap, held in a
-  GitHub Environment whose required reviewer is the map owner. It is
-  never a student's account and no student ever sees it.
-- **Remit:** what CI structurally cannot check — the 2027 hazards, and
-  the comment rule. Pasting `ChassisSpeeds` out of a 2025 tutorial is
-  the single most likely defect in this repo, and an agent catches it in
-  seconds.
-- **Not its job:** formatting, which spotless owns; anything a test
-  covers; general opinions about your code.
-- **Output:** inline comments where the problem is, and a summary at the
-  end. The cost of the trigger lands here: a `workflow_run` job does not
-  know its pull request, so posting means resolving the number and
-  calling the review API by hand.
+The reviewer is specified in [ADR 0013](docs/adr/0013-ci-and-test-strategy.md)
+and [issue #18](https://github.com/Drew-Robotics/2027beta/issues/18), but is not
+built yet. It reviews successful pull requests for field-only risks that CI
+cannot detect. It is not a replacement for student review.
 
 ## Deploying
 
-Use the VSCode extension's deploy button, or `./gradlew deploy`. It is
-plain SSH and SFTP — stop `robot.service`, copy over the jars, the JNI
-`.so` files, `robotCommand` and everything in `src/main/deploy/`, start
-the unit again.
+Use the VSCode deploy button or `./gradlew deploy`. Deployment stops
+`robot.service`, copies the robot files, and starts the service again.
 
-**There is no riolog.** The console is the systemd journal, on the
-device:
+Watch the robot journal with:
 
 ```bash
 ssh systemcore@robot.local journalctl -u robot -f
 ```
 
-The web terminal at port 4901 is the same thing without an SSH client.
-And never `println` from anything that runs periodically — one was
-measured at ~25 ms, enough to trip the watchdog by itself
-([ADR 0003](docs/adr/0003-project-and-package-structure.md)).
+Do not use `println` in periodic code. It can exceed the loop budget.
 
-**The failure that costs an afternoon.** The OS image and the allwpilib
-commit are a version *pair*, and a mismatch is not a build error: the
-HAL terminates at startup, `robot.service` restarts it three seconds
-later, and it does that forever. **A robot that reboots every three
-seconds is an ABI mismatch** — flash the Pi forward to the current
-image. There is no pin to look up, deliberately: a recorded triple goes
-stale within the week and would eventually tell a student to flash
-backwards ([#51](https://github.com/Drew-Robotics/2027beta/issues/51)).
+If the robot restarts every three seconds, the SystemCore image and allwpilib
+checkout are incompatible. Update the Pi to the current image. See
+[issue #51](https://github.com/Drew-Robotics/2027beta/issues/51).
 
-[#18](https://github.com/Drew-Robotics/2027beta/issues/18) proposed
-catching this before deploy, as a Gradle task wired ahead of `deploy`
-rather than a skill — because a skill only reaches someone running an
-agent, and the person who most needs the check is the student clicking
-the VSCode button. [ADR 0013](docs/adr/0013-ci-and-test-strategy.md)
-declined the probe as over-engineering a system that is going stable
-shortly. What detects the drift instead is the nightly bench build
-going red as the floating dependency outruns the flashed image, and what
-gets a student out of it at the bench is the paragraph above.
+## Local references
 
-## The machines around this project
-
-**`~/dev/allwpilib` — the reference for reading source.** A *built*
-checkout of the alpha-7 WPILib that `CONTEXT.md` defines and pins. Read
-it before believing yourself: `docs.wpilib.org` lags the alpha badly,
-and 2027 renamed enough that every snippet on the internet is wrong at
-the import line. It carries built javadoc under `*/build/docs/javadoc/`
-and upstream's own design docs under `design-docs/`.
-
-**The bench Pi — one Raspberry Pi 5 running the SystemCore image** at
-`192.168.1.202`, also reachable as `robot.local`. Key-based SSH is
-installed and the stock `systemcore` / `systemcore` password still
-works; a key survives an OS update applied as a `.llupdate` payload but
-is wiped by a full reflash from the `.zip` image. No CAN hardware is
-attached to it, and deploy from a dev machine is verified end to end
-([`docs/research/systemcore-smoketest.md`](docs/research/systemcore-smoketest.md)).
-There is exactly one of it, which is why it can never gate anything:
-hardware CI is advisory, and an unreachable bench is a skip rather than
-a red.
-
-**Where the logs are — two different logs.** The console is the systemd
-journal, and it exists only on the device. The `.wpilog` is the artifact
-of record: `/u/logs` when a USB stick is mounted, `/home/systemcore/logs`
-otherwise. Pulling it is a habit rather than a convenience, because the
-robot deletes old logs on its own and the filename is the only place a
-match's identity exists
-([ADR 0014](docs/adr/0014-ai-log-analysis-contract.md)).
-
-**The image is BusyBox, and it is missing the tools you will reach for
-first:** `timeout`, `pgrep`, `gcc`/`cc`, `perf`, `unzip`. Use `jcmd -l`
-where you wanted `pgrep`. A full JDK 25 *is* on the device, along with
-`python3` and the binutils, so profiling there is JFR rather than
-`perf`.
+- `~/dev/allwpilib` is the WPILib source reference. Check it before using online
+  examples: 2027 APIs changed substantially.
+- The bench Pi is at `192.168.1.202` or `robot.local`. It has no CAN hardware,
+  so hardware CI is advisory only.
+- The system journal is the console. WPILOG files are stored in `/u/logs` with a
+  USB stick or `/home/systemcore/logs` otherwise. Copy logs before the robot
+  deletes old files.
+- The SystemCore image uses BusyBox. It does not include `timeout`, `pgrep`,
+  compilers, `perf`, or `unzip`. Use `jcmd -l` instead of `pgrep`; use JFR for
+  profiling.

--- a/docs/adr/0001-opmoderobot-and-commands-v3.md
+++ b/docs/adr/0001-opmoderobot-and-commands-v3.md
@@ -63,7 +63,7 @@ public class Robot extends OpModeRobot {
   @Override
   public void robotPeriodic() {
     poseEstimator.odometryUpdate(
-        drive.getGyroHeading(), drive.getModulePositions());
+        drive.getGyroOrientation(), drive.getModulePositions());
     Scheduler.getDefault().run();
   }
 }
@@ -322,7 +322,7 @@ should start a thread near a command either.
 
   Remove it and eight listeners stop being registered
   (`javacPlugin/.../WPILibJavacPlugin.java:22-29`) **[source]**, five of
-  which are load-bearing here:
+  which matter here:
 
   | Listener | What stops being caught |
   |---|---|

--- a/docs/adr/0002-loop-rate-and-jvm.md
+++ b/docs/adr/0002-loop-rate-and-jvm.md
@@ -345,7 +345,7 @@ Java holds a 1 ms period at p99 (1.021 ms with RT priority) and JIT-ed
 math comes within ~17% of C++. **[measured]** It is not rejected for being
 impossible. It is rejected because the fidelity it would buy is gated on
 CAN frame rates we cannot raise that far (ADR 0007), the tail behaviour at
-1 ms is where RT priority starts being load-bearing rather than optional,
+1 ms is where RT priority becomes necessary rather than optional,
 and 200 Hz already spends 1.3% of the budget for everything we know we
 need.
 

--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -77,7 +77,7 @@ public Robot() {
 }
 ```
 
-Five things are load-bearing in those four lines.
+Five things in those four lines are necessary.
 
 **`registerBackend("", ...)` replaces the backend `RobotBase` already
 installed.** `RobotBase`'s constructor registers a

--- a/docs/adr/0006-commands-v3-house-style.md
+++ b/docs/adr/0006-commands-v3-house-style.md
@@ -219,7 +219,7 @@ built-in `idle()` attaches that priority for you (`Mechanism.java:106-108`)
 
 Any other `withPriority` call **needs a comment naming what it is meant
 to beat.** If you cannot name it, you do not want a priority. Priorities
-are load-bearing in a way that is easy to miss — see Traps.
+are easy to miss but necessary — see Traps.
 
 ### `StateMachine` is an escape hatch, and the drive base does not use it
 

--- a/docs/adr/0008-closed-loop-on-the-spark.md
+++ b/docs/adr/0008-closed-loop-on-the-spark.md
@@ -346,7 +346,7 @@ budget is ADR 0007's.
   (`AbsoluteEncoderConfig.java:210-217`) **[source]** and would have
   deleted the conversion outright — **it does not exist for
   an analog sensor.** The `inputModulus` in the Decision is the whole
-  fix and it is load-bearing.
+  fix and it is necessary.
 
 - **A `kV` in `FeedForwardConfig` and a `kV·v` term in
   `arbFeedforward` double the feedforward, and nothing throws.** They

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -482,7 +482,7 @@ numbered recipe belongs in the README, not here.
   have not modelled.
 
 - **The project keeps building against a released alpha.** ADR 0003's
-  rule that `~/dev/allwpilib` is reference-only is load-bearing here
+  rule that `~/dev/allwpilib` is reference-only is necessary here
   specifically: building against local `main` costs the sim story and
   nothing else, which is the failure that would be noticed last.
 

--- a/docs/adr/0011-autonomous-and-choreo.md
+++ b/docs/adr/0011-autonomous-and-choreo.md
@@ -25,12 +25,12 @@ dashboard boolean*. The *Consequences* entry reading *"Autonomous is
 selected on the Driver Station, not a dashboard"* is **narrowed there**
 to the string-chooser finding it rests on, which has nothing to say
 about a boolean. *No splits, no event markers* gains the rule that
-every pose trigger reads through `flipAndMirrorIfNeeded`, and its example is
-corrected to show it — the example predated `flipAndMirrorIfNeeded` and read a raw
+every pose trigger reads through `toAuthoredPathFrame`, and its example is
+corrected to show it — the example predated `toAuthoredPathFrame` and read a raw
 estimate.
 
 Amended by ADR 0012, which owns the pose
-estimator: `Drive.getGyroHeading()` returns a `Rotation3d` rather than a
+estimator: `Drive.getGyroOrientation()` returns a `Rotation3d` rather than a
 `Rotation2d`, and the estimator beside `Drive` is
 `SwerveDrivePoseEstimator3d`. Two statements below survive the widening
 because ADR 0012 keeps them true deliberately rather than by luck —
@@ -176,7 +176,7 @@ paid again on every scroll of the dropdown.
 `PoseEstimator` is a **plain class, not a `Mechanism`**, held as a
 public field on `Robot` (`.../rebuiltcmdv3/Robot.java:27`)
 **[source]**. What `Drive` exposes *for pose* is two accessors and
-nothing else — `getGyroHeading()` and `getModulePositions()`
+nothing else — `getGyroOrientation()` and `getModulePositions()`
 (`.../rebuiltcmdv3/mechanisms/SwerveDrive.java:69, 78`) **[source]**.
 It has no `getPose()`, no `resetPose()` and no estimator field. (The
 flagship's `SwerveDrive` also exposes `getModuleVelocities()` (`:82`)
@@ -184,13 +184,13 @@ and its `kinematics` (`:33`) **[source]**; those are telemetry and
 wiring, not pose.)
 
 `robotPeriodic()` updates odometry **before** running the scheduler,
-and the flagship comments the order because it is load-bearing
+and the flagship comments the order because it matters
 (`Robot.java:40-46`) **[source]**:
 
 ```java
 @Override
 public void robotPeriodic() {
-  poseEstimator.odometryUpdate(drive.getGyroHeading(), drive.getModulePositions());
+  poseEstimator.odometryUpdate(drive.getGyroOrientation(), drive.getModulePositions());
   Scheduler.getDefault().run();
 }
 ```
@@ -312,7 +312,7 @@ and a pose trigger —
 
 ```java
 public final Trigger inNeutralZone =
-    new Trigger(() -> inZone(FieldConstants.flipAndMirrorIfNeeded(poseEstimator.getEstimatedPose())));
+    new Trigger(() -> inZone(FieldConstants.toAuthoredPathFrame(poseEstimator.getEstimatedPose())));
 ```
 
 A **pose**-triggered action beats a **time**-triggered one for the
@@ -321,7 +321,7 @@ wheel slipped, a time marker fires in the wrong place and a pose
 trigger does not. Splits stop being necessary once each segment is its
 own file.
 
-⚠️ **Every pose trigger goes through `flipAndMirrorIfNeeded`, and the threshold is
+⚠️ **Every pose trigger goes through `toAuthoredPathFrame`, and the threshold is
 written against the path as drawn.** The estimate is where the robot
 is; the threshold was read off Choreo. Compare the two raw and the
 trigger fires at the wrong moment on any run the path was transformed
@@ -331,7 +331,7 @@ for. **Which way it goes is the threshold's sign, not a rule**:
 the same path would never be reached. On a mirrored run a `y` threshold
 fires on the wrong side of the field. Both transforms are their own
 inverse and
-`flipAndMirrorIfNeeded` applies whichever are in force, so one call covers the
+`toAuthoredPathFrame` applies whichever are in force, so one call covers the
 alliance flip and the side mirror together and will cover whatever is
 added beside them.
 
@@ -339,7 +339,7 @@ This is a rule and not a mechanism. There is nothing to stop a trigger
 reading `getEstimatedPose()` directly, and a wrong one throws nothing —
 it fires early, late, or not at all. The only pose trigger that exists
 reads through
-`flipAndMirrorIfNeeded`; the next one has to as well.
+`toAuthoredPathFrame`; the next one has to as well.
 
 ### Trajectories arrive in the robot's frame; the alliance flip happens at follower construction
 
@@ -422,12 +422,12 @@ fails when `omega` carries through unmirrored.
 **The two commute**, so nothing sequences them: `rot180 ∘ reflect` and
 `reflect ∘ rot180` are both `diag(-1, 1)`, and the heading composes to
 `-θ + π` either way. A test asserts it so the ordering cannot quietly
-become load-bearing. Each is also its own inverse, so `flipAndMirrorIfNeeded`
+become necessary. Each is also its own inverse, so `toAuthoredPathFrame`
 undoes both by applying whichever are in force again — a pose threshold
 written against the drawn path is compared in the frame it was written
 in on either side of the field, the same reason it already was on red.
 
-⚠️ `flipAndMirrorIfNeeded` reads the toggle **every loop**, where the trajectory
+⚠️ `toAuthoredPathFrame` reads the toggle **every loop**, where the trajectory
 reads it once at follower construction, so toggling mid-autonomous puts
 a pose trigger in a frame the path being driven is not in. That is the
 shape the alliance already has and nobody can change the alliance
@@ -638,9 +638,9 @@ produce it. ADR 0009 owns that.
   robot is a metre short of where the next command assumes it is.
   **Read the result and log it.**
 
-- **The follower's velocities are FIELD-relative.** `PathFollower.next()`
+- **The follower's velocities are FIELD-relative.** `PathFollower.nextFieldRelativeVelocities()`
   is documented as such, and `driveFieldRelative` does the conversion
-  with `toRobotRelative(getGyroHeading())`
+  with `toRobotRelative(getGyroOrientation())`
   (`SwerveDrive.java:197-200`) **[source]**. A follower that returns
   robot-relative velocities compiles, runs, and drives a path that is
   correct only while the robot faces field-forward. The symptom is a
@@ -880,7 +880,7 @@ tracking well and the residual error is per-module.
 on the reason under Decision: a pose estimator has nothing to own, so
 it is not a mechanism, and putting pose on `Drive` would drag ADR
 0012's vision seam into the drive base with it. `Drive` exposing
-`getGyroHeading()` and `getModulePositions()` and nothing else is what
+`getGyroOrientation()` and `getModulePositions()` and nothing else is what
 keeps both autonomous and vision out of it.
 
 ### Module-force feedforward

--- a/docs/adr/0012-pose-estimation-and-vision.md
+++ b/docs/adr/0012-pose-estimation-and-vision.md
@@ -115,7 +115,7 @@ layout checks that before trusting it, and fails rather than adapting.
 Nothing in the drive base does this, because nothing in the drive base
 reads a layout.
 
-`Drive` is untouched by this. It exposes `getGyroHeading()` and
+`Drive` is untouched by this. It exposes `getGyroOrientation()` and
 `getModulePositions()` for pose, exactly as ADR 0011 left it, and
 nothing was added to it *for vision* — see the yaw-rate section below
 for the one method that looks like an exception and is not.
@@ -177,7 +177,7 @@ is not.
 
 Four consequences, all of them mechanical:
 
-- **`Drive.getGyroHeading()` returns `Rotation3d`**, built as
+- **`Drive.getGyroOrientation()` returns `Rotation3d`**, built as
   `new Rotation3d(roll, pitch, yaw)` over the Pigeon's own three angle
   signals — an amendment to ADR 0011, which had it as `Rotation2d`.
   **[decided]** The Pigeon does expose a full 3d rotation, which is
@@ -330,7 +330,7 @@ base's own past, and any caller is welcome to it for any reason.
 ### The rate comes from the Pigeon's own signal, whose default frequency is too low
 
 The sample is `getAngularVelocityZWorld()`, **not a differenced
-`getGyroHeading()`**. Differencing over a 5 ms step multiplies
+`getGyroOrientation()`**. Differencing over a 5 ms step multiplies
 quantization noise by 200, and `max` is the worst possible statistic to
 run over noisy data — it selects the noise spike by construction,
 turning the gate into a false-reject machine. CTRE's rate signal is
@@ -715,7 +715,7 @@ older spellings appears anywhere.
   simulation, at which point the two are interchangeable and the
   simpler call wins.
 
-- **Do not synthesise yaw rate by differencing `getGyroHeading()`.** It
+- **Do not synthesise yaw rate by differencing `getGyroOrientation()`.** It
   compiles and it is one line, which is the whole danger; Decision owns
   the arithmetic. What it looks like on the field is the reason it is
   repeated here: the gate turns into a false-reject machine that
@@ -895,9 +895,9 @@ settles `maxAbsYawRate`'s shape, its fail-closed contract, its 1.5 s
 history and its exemption from reset.
 
 The pose estimator's placement beside `Drive`, and `Drive` exposing
-`getGyroHeading()` and `getModulePositions()` and nothing else, are
+`getGyroOrientation()` and `getModulePositions()` and nothing else, are
 [#15](https://github.com/Drew-Robotics/2027beta/issues/15) and ADR 0011;
-this ADR amends `getGyroHeading()` to `Rotation3d`. The log naming and
+this ADR amends `getGyroOrientation()` to `Rotation3d`. The log naming and
 the `Measure`-everywhere rule are
 [#11](https://github.com/Drew-Robotics/2027beta/issues/11) and ADR 0005;
 the config placement for the signal frequencies is

--- a/docs/adr/0014-ai-log-analysis-contract.md
+++ b/docs/adr/0014-ai-log-analysis-contract.md
@@ -139,7 +139,7 @@ It is still fully schema-driven — it hardcodes no type name — it simply
 does not implement enums, arrays or bitfields. **[decided]**
 
 **On a schema it cannot parse it reports the signal as opaque and prints
-the schema text.** That is the load-bearing half of the decision.
+the schema text.** That is the necessary half of the decision.
 Silence would be indistinguishable from a signal that was not logged,
 and there is exactly one such schema in our own file — see *Traps*.
 

--- a/docs/adr/0015-binding-revlibs-native.md
+++ b/docs/adr/0015-binding-revlibs-native.md
@@ -290,7 +290,7 @@ where REVLib never makes a console call at all: the same interposer on
 calls from REVLib across a full SPARK construction, while a control
 proves the interposition is live on that platform. **[executed]** So a
 rebuilt REVLib would turn `-PnoRevShim` green while the aarch64 half is
-still load-bearing, and somebody would delete a directory the robot
+still necessary, and somebody would delete a directory the robot
 needs. The second half of the trigger is a deploy with the preload
 dropped, confirmed to reach *"Robot program startup complete"* on the
 Pi. Both commands live in `revshim.cpp`'s header comment. Nothing
@@ -419,7 +419,7 @@ which WPILib's own calls looked shifted. The signatures come from
 `hal/src/main/native/include/wpi/hal/DriverStation.h` in
 `~/dev/allwpilib`. **[source]**
 
-**`LD_PRELOAD` order is load-bearing on the Pi and not on the desktop.**
+**`LD_PRELOAD` order matters on the Pi, not on the desktop.**
 `libwpiutil.so` must be named before `librevshim.so`. Reversing them, or
 dropping wpiutil, gives `symbol lookup error: undefined symbol:
 _ZN3wpi4util13WaitForObjectEi` at JVM start — on a machine where

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,26 +1,21 @@
 # Architecture decision records
 
-One decision area per document. Each ADR states the decision **as it
-stands today** — corrections and withdrawn arguments are resolved, not
-narrated. The argument that produced a decision lives on the tracker;
-the ADR links it under *Source*.
+One decision area per document. Each ADR states the current decision.
+The tracker holds the discussion that led to it; the ADR links that
+discussion under *Source*.
 
 Every ADR carries the same seven sections, in this order:
 
 **Status** · **Context** · **Decision** · **Consequences** · **Traps** ·
 **Rejected** · **Source**
 
-An ADR that carries unresolved fog adds an **Open** heading before
-*Rejected*, naming each open question and what would unblock it. Fog is
-recorded, never omitted — an absent Open heading means the area has
-none, not that nobody looked.
+An ADR with unresolved fog adds **Open** before *Rejected*. It names each
+question and what would answer it. No *Open* heading means no known open
+questions.
 
-*Decision* is written to be read by a first-year programmer without
-*Traps*. *Traps* is the section that earns the document: the failure
-modes that compile clean and fail on the field, each with the source
-location that verifies it. *Rejected* records what was ruled out and
-why, including where an option must not be re-raised without new
-evidence.
+*Decision* should make sense to a first-year programmer without *Traps*.
+*Traps* lists failures that compile but fail on the field, with evidence.
+*Rejected* lists ruled-out options and why.
 
 ## Claim tags
 
@@ -29,16 +24,15 @@ names the source tree and commit its `[source]` tags were read at.
 
 | Tag | Means |
 |---|---|
-| **[source]** | Read out of a named file, cited by path and line. |
-| **[measured]** | Measured on the Pi. The number and its method live in `docs/research/`. |
-| **[executed]** | Verified by running it, not by reading it. |
-| **[field]** | From field evidence — someone else's season, not ours. |
-| **[decided]** | A team decision. There is nothing to verify: it is a choice, and the ticket carries the argument. |
-| **[unverified]** | Nobody has checked. Tagged so that fog stays visibly fog rather than reading as fact. |
+| **[source]** | Read from a named file, cited by path and line. |
+| **[measured]** | Measured on the Pi; method is in `docs/research/`. |
+| **[executed]** | Verified by running it. |
+| **[field]** | Evidence from another team's season. |
+| **[decided]** | Team choice; the ticket records why. |
+| **[unverified]** | Not checked yet. |
 
-The first four are not interchangeable, and the distinction is the point
-— a number measured on the Pi and a behaviour inferred from source are
-worth different amounts when one of them turns out to be wrong.
+These tags are not interchangeable: source, measurement, and execution
+support claims differently.
 
 ## Index
 
@@ -60,14 +54,11 @@ worth different amounts when one of them turns out to be wrong.
 | [0014](0014-ai-log-analysis-contract.md) | AI log-analysis contract | **Accepted** — 2026-08-27 |
 | [0015](0015-binding-revlibs-native.md) | Binding REVLib's native | **Accepted** — 2026-08-30 |
 
-Numbering follows decision area, not the date a document landed. The
-set is complete: every row above resolves to a document.
+Numbers follow decision area, not document date. Every row has a document.
 
 ## Related documents
 
-- [`CONTEXT.md`](../../CONTEXT.md) — the project glossary: every term this
-  project invents or overloads, pointing at the ADR that owns the concept.
+- [`CONTEXT.md`](../../CONTEXT.md) — the project glossary.
 - [`docs/commands-v3-house-style.md`](../commands-v3-house-style.md) — the
-  student-facing teaching document for ADR 0006. The drive base is its
-  worked example.
-- [`docs/research/`](../research/) — the measurements and source readings the ADRs cite, with their methods.
+  student guide for ADR 0006.
+- [`docs/research/`](../research/) — cited measurements and source notes.

--- a/docs/research/ds-headless-control.md
+++ b/docs/research/ds-headless-control.md
@@ -64,7 +64,7 @@ wrong or incomplete:
 | `/Dscomm/Status/StatusByte` | The live topic is **`/Dscomm/Status/StatusWord`** (int). `LoggingKeys.md` is stale. |
 | `hal/.../systemcore/DriverStation.cpp` is a shim into "the closed `libMrcLib.so`" | True but understated. `GetMrcLibDs()` resolves to `MrcLibDsImpl` in **open source** at `hal/src/main/native/cpp/mrclib/MrcLibDs.cpp` (704 lines), which calls the closed C API. The mrclib headers ship in the Gradle cache and document the whole DS↔robot struct set. See §10. |
 
-Two things #22 got right that are worth restating because they were load-bearing: the
+Two parts of #22 are especially important: the
 `control_word` bit layout and the `current_op_mode` packing are both exactly as documented, and
 both were confirmed against live traffic (§11).
 

--- a/docs/research/physics-sim.md
+++ b/docs/research/physics-sim.md
@@ -168,7 +168,7 @@ public static void setAccelX(double accelMpss); /* ... */
 
 ### 1.5 Kinematics API renames (2027 alpha 5+)
 
-These are load-bearing for anything that touches swerve, ours or a vendor's:
+These are necessary for anything that touches swerve, ours or a vendor's:
 
 | 2026 | 2027 |
 |---|---|

--- a/docs/research/vendordeps.md
+++ b/docs/research/vendordeps.md
@@ -664,7 +664,7 @@ minimum allowed supply voltage is 4 V - values below this will be promoted to 4 
 `Orientation`/`ChassisReference` field** on `Pigeon2SimState` (unlike `TalonFXSimState` /
 `CANcoderSimState`), no getters, and no `setYaw`.
 
-**Use `setRawYaw` (absolute), not `addYaw`.** The `setRawYaw` javadoc is the load-bearing text **[V]**:
+**Use `setRawYaw` (absolute), not `addYaw`.** The `setRawYaw` javadoc is the key text **[V]**:
 
 > Sets the simulated raw yaw of the Pigeon2. **Inputs to this function over time should be
 > continuous**, as user calls of `CorePigeon2.setYaw(double)` will be accounted for in the callee.
@@ -834,7 +834,7 @@ CTRE changelog at `https://api.ctr-electronics.com/changelog`, dated **2026/06/1
 `SystemcoreTesting/CTR-Phoenix.md` agrees **[C]**: WPILib `2027_alpha5`-compatible release →
 Phoenix 6 `26.50.0-alpha-1`; compatible firmware → any `26.X`. **Nothing claims alpha-7.**
 
-Other load-bearing changelog lines for `26.50.0-alpha-1`, all **[V]**:
+Other key changelog lines for `26.50.0-alpha-1`, all **[V]**:
 
 > - Device constructors accepting a CAN bus string have been removed. Construct a `CANBus` object instead.
 > - Device constructors accepting a device ID without a CAN bus have been removed. **A CANBus object must be provided to the device constructor.**

--- a/src/main/java/first/Main.java
+++ b/src/main/java/first/Main.java
@@ -6,22 +6,11 @@ package first;
 
 import org.wpilib.framework.RobotBase;
 
-/**
- * Do NOT add any static variables to this class, or any initialization at all. Unless you know what
- * you are doing, do not modify this file except to change the parameter class to the startRobot
- * call.
- */
 public final class Main {
   private Main() {}
 
-  /**
-   * Main initialization function. Do not perform any initialization here.
-   *
-   * <p>If you change your main robot class, change the parameter type.
-   */
   public static void main(String... args) {
-    // Departs from the template: the generator still passes a Class, and startRobot now
-    // takes a Supplier.
+    // startRobot now takes a Supplier, not the template's Class.
     RobotBase.startRobot(first.robot.Robot::new);
   }
 }

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -16,13 +16,9 @@ import org.wpilib.tunable.TunableBoolean;
 import org.wpilib.tunable.Tunables;
 
 public final class FieldConstants {
-  // False is the path exactly as it was drawn.
   public static final TunableBoolean MIRRORED = Tunables.addBoolean("Mirrored", false);
 
-  // Choreo draws in the blue-alliance-corner frame and WPILib publishes its tag layouts in it; the
-  // robot works in field centre, which is where 2027 is going. The dimensions are the 2026 field's
-  // because that is the field the paths were drawn against, and both halves go to zero when the
-  // origin moves.
+  // Choreo paths use the 2026 blue-corner frame; this code uses field center.
   private static final double HALF_LENGTH = 16.541 / 2;
   private static final double HALF_WIDTH = 8.0692 / 2;
 
@@ -36,34 +32,27 @@ public final class FieldConstants {
     return y - HALF_WIDTH;
   }
 
-  public static HolonomicTrajectory forAlliance(HolonomicTrajectory trajectory) {
+  public static HolonomicTrajectory forCurrentAlliance(HolonomicTrajectory trajectory) {
     return onRed() ? flip(trajectory) : trajectory;
   }
 
-  public static HolonomicTrajectory forSide(HolonomicTrajectory trajectory) {
+  public static HolonomicTrajectory withDashboardMirror(HolonomicTrajectory trajectory) {
     return MIRRORED.getAsBoolean() ? mirror(trajectory) : trajectory;
   }
 
-  // Each transform is its own inverse and the two commute, so applying whichever are in force
-  // again carries a measured pose back into the frame the path was drawn in. A threshold written
-  // against the drawn path is compared in the wrong frame otherwise, and fires at the wrong
-  // moment — which way depends on the threshold's sign, so it is as likely to fire at once as
-  // never.
-  public static Pose2d flipAndMirrorIfNeeded(Pose2d pose) {
+  // Convert a measured pose back to the path's frame before comparing it to path thresholds.
+  public static Pose2d toAuthoredPathFrame(Pose2d pose) {
     var flipped = onRed() ? flip(pose) : pose;
     return MIRRORED.getAsBoolean() ? mirror(flipped) : flipped;
   }
 
-  // The origin is field centre, where the flip is a 180-degree rotation about it. Anything drawn
-  // against a corner comes through fromCornerX and fromCornerY first; vision is told the same
-  // answer through Field.setOrigin.
+  // With a center origin, an alliance flip is a 180-degree rotation.
   public static HolonomicTrajectory flip(HolonomicTrajectory trajectory) {
     return new HolonomicTrajectory(
         trajectory.getSamples().stream().map(FieldConstants::flip).toList());
   }
 
-  // Not HolonomicTrajectory.transformBy: it is rigid about the trajectory's own first pose rather
-  // than about the origin, and it carries the velocities and accelerations through unrotated.
+  // transformBy uses the first pose as its origin and does not rotate velocity or acceleration.
   private static HolonomicSample flip(HolonomicSample sample) {
     return new HolonomicSample(
         sample.time,
@@ -77,7 +66,7 @@ public final class FieldConstants {
     return new Pose2d(-pose.getX(), -pose.getY(), pose.getRotation().rotateBy(Rotation2d.kPi));
   }
 
-  // A reflection across the field's long axis, which the centre origin puts at y = 0.
+  // Reflect across the field's long axis (y = 0).
   public static HolonomicTrajectory mirror(HolonomicTrajectory trajectory) {
     return new HolonomicTrajectory(
         trajectory.getSamples().stream().map(FieldConstants::mirror).toList());
@@ -87,8 +76,7 @@ public final class FieldConstants {
     return new HolonomicSample(
         sample.time,
         mirror(sample.pose),
-        // A reflection reverses handedness, so the spins invert — the sign the flip, being a
-        // rotation, deliberately leaves alone.
+        // A reflection reverses rotation direction.
         new ChassisVelocities(sample.velocity.vx, -sample.velocity.vy, -sample.velocity.omega),
         new ChassisAccelerations(
             sample.acceleration.ax, -sample.acceleration.ay, -sample.acceleration.alpha));
@@ -98,9 +86,7 @@ public final class FieldConstants {
     return new Pose2d(pose.getX(), -pose.getY(), pose.getRotation().unaryMinus());
   }
 
-  // Blue is the answer that looks right on a bench and is wrong in half of every match. Robot's
-  // alliance-unknown alert is what says so out loud, and it is gated on a Driver Station actually
-  // being attached, which a guess made on a bench with nothing plugged in is not.
+  // Default to blue until the Driver Station reports an alliance.
   public static boolean onRed() {
     return MatchState.getAlliance().orElse(Alliance.BLUE) == Alliance.RED;
   }

--- a/src/main/java/first/robot/HolonomicPathFollower.java
+++ b/src/main/java/first/robot/HolonomicPathFollower.java
@@ -60,7 +60,7 @@ public final class HolonomicPathFollower implements PathFollower {
   }
 
   @Override
-  public ChassisVelocities next() {
+  public ChassisVelocities nextFieldRelativeVelocities() {
     setpoint = trajectory.sampleAt(elapsed());
 
     var current = pose.get();
@@ -74,15 +74,15 @@ public final class HolonomicPathFollower implements PathFollower {
         setpoint.velocity.omega + config.thetaKp() * headingError.getRadians());
   }
 
-  // The sample next() left behind, so this has to be read after it within the same iteration.
-  public ChassisAccelerations acceleration() {
+  // Read after nextFieldRelativeVelocities() in the same iteration.
+  public ChassisAccelerations currentAcceleration() {
     return setpoint.acceleration;
   }
 
   // Not time alone: a robot pinned against a defender runs the clock out where it is standing, and
   // a follower that reports done there hands the next command a robot a metre from where it thinks.
   @Override
-  public boolean isDone() {
+  public boolean isFinished() {
     var current = pose.get();
     var end = trajectory.end().pose;
     return elapsed() >= trajectory.duration

--- a/src/main/java/first/robot/PathFollower.java
+++ b/src/main/java/first/robot/PathFollower.java
@@ -6,11 +6,9 @@ package first.robot;
 
 import org.wpilib.math.kinematics.ChassisVelocities;
 
-// next() returns FIELD-relative velocities. No type and no name says so, and a follower that
-// returns robot-relative ones compiles, runs, and tracks a straight path perfectly right up to the
-// moment the robot rotates.
+// nextFieldRelativeVelocities() returns field-relative velocities.
 public interface PathFollower {
-  ChassisVelocities next();
+  ChassisVelocities nextFieldRelativeVelocities();
 
-  boolean isDone();
+  boolean isFinished();
 }

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -154,7 +154,7 @@ public class Robot extends OpModeRobot {
     poseEstimator =
         new PoseEstimator(
             drive.getKinematics(),
-            drive.getGyroHeading(),
+            drive.getGyroOrientation(),
             drive.getModulePositions(),
             TelemetryRegistry.getTable("/Drive"));
 
@@ -179,7 +179,8 @@ public class Robot extends OpModeRobot {
   // on a lookup, which autonomous makes once per schedule and therefore once per enable. They
   // commute, so this ordering is a reading preference and nothing else.
   public HolonomicTrajectory trajectory(String name) {
-    return FieldConstants.forSide(FieldConstants.forAlliance(trajectories.get(name)));
+    return FieldConstants.withDashboardMirror(
+        FieldConstants.forCurrentAlliance(trajectories.get(name)));
   }
 
   private static PowerDistribution openPdh() {
@@ -217,8 +218,7 @@ public class Robot extends OpModeRobot {
       pdhLog.log("TotalEnergy", Joules.of(pdh.getTotalEnergy()));
     }
 
-    // Read every loop, never once. driverStationConnected() fires on the control word's
-    // DS-attached bit, and the alliance station arrives from the FMS some time after that.
+    // Alliance can arrive after the Driver Station connects, so read it every loop.
     var alliance = MatchState.getAlliance();
     matchLog.log("Alliance", alliance.map(Enum::name).orElse("Unknown"));
     matchLog.log("Station", MatchState.getLocation().orElse(0));
@@ -234,20 +234,17 @@ public class Robot extends OpModeRobot {
     matchLog.log("Mirrored", mirrored);
     pathsMirrored.set(mirrored);
 
-    // A DS that is attached and has not said which alliance it is means every alliance-dependent
-    // decision on the robot is about to be made against a guess.
+    // An attached Driver Station without an alliance would make alliance logic guess.
     allianceUnknown.set(RobotState.isDSAttached() && alliance.isEmpty());
 
     drive.updateYawRateHistory();
     drive.log();
 
-    // Before the scheduler, and the order is load-bearing: every command that runs below reads a
-    // pose built from this iteration's module positions rather than the previous one's.
-    poseEstimator.odometryUpdate(drive.getGyroHeading(), drive.getModulePositions());
+    // Update before commands so they use this loop's module positions.
+    poseEstimator.odometryUpdate(drive.getGyroOrientation(), drive.getModulePositions());
     poseEstimator.log();
 
-    // Nothing in OpModeRobot runs the Commands v3 scheduler, so a mechanism whose scheduler is
-    // never run has a default command that never starts and commands that never execute.
+    // OpModeRobot does not run the Commands v3 scheduler.
     Scheduler.getDefault().run();
 
     var can = RobotController.getCANStatus(Constants.CAN_BUS);

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -286,8 +286,10 @@ public class Drive implements Mechanism {
           followingLog.log("TimedOut", false);
           autoLog.log("PlannedPath", follower.plannedPath(), Pose2d.struct);
 
-          coroutine.fork(driveFieldRelative(follower::next, follower::acceleration));
-          var result = coroutine.waitUntil(follower::isDone, follower.timeout());
+          coroutine.fork(
+              driveFieldRelative(
+                  follower::nextFieldRelativeVelocities, follower::currentAcceleration));
+          var result = coroutine.waitUntil(follower::isFinished, follower.timeout());
           pathTimedOut = result.timedOut();
           followingLog.log("TimedOut", result.timedOut());
         })
@@ -568,7 +570,7 @@ public class Drive implements Mechanism {
       Supplier<ChassisVelocities> velocities, Consumer<ChassisVelocities> output) {
     return run(coroutine -> {
           while (true) {
-            output.accept(velocities.get().toRobotRelative(getGyroHeading().toRotation2d()));
+            output.accept(velocities.get().toRobotRelative(getGyroOrientation().toRotation2d()));
             coroutine.yield();
           }
         })
@@ -612,7 +614,7 @@ public class Drive implements Mechanism {
   public void setVelocities(ChassisVelocities velocities) {
     var states = moduleTargets(velocities);
     for (int i = 0; i < MODULES; i++) {
-      modules[i].setVelocity(states[i]);
+      modules[i].setTarget(states[i]);
     }
   }
 
@@ -623,14 +625,14 @@ public class Drive implements Mechanism {
     var moduleAccelerations =
         kinematics.toSwerveModuleAccelerations(accelerations, velocities.omega);
     for (int i = 0; i < MODULES; i++) {
-      modules[i].setVelocity(states[i], moduleAccelerations[i]);
+      modules[i].setTarget(states[i], moduleAccelerations[i]);
     }
   }
 
   public void setOpenLoopVelocities(ChassisVelocities velocities) {
     var states = moduleTargets(velocities);
     for (int i = 0; i < MODULES; i++) {
-      modules[i].setOpenLoopVelocity(states[i]);
+      modules[i].setOpenLoopTarget(states[i]);
     }
   }
 
@@ -660,7 +662,7 @@ public class Drive implements Mechanism {
     return pathTimedOut;
   }
 
-  public Rotation3d getGyroHeading() {
+  public Rotation3d getGyroOrientation() {
     // Not Pigeon2.getRotation3d(): through 26.50.0-alpha-1 nothing drives the four quaternion
     // signals it reads in simulation, so it answers identity there for ever. Yaw, pitch and roll
     // are driven, and are the same three numbers.
@@ -706,7 +708,7 @@ public class Drive implements Mechanism {
     return kinematics;
   }
 
-  public ChassisVelocities getVelocities() {
+  public ChassisVelocities getMeasuredVelocities() {
     return kinematics.toChassisVelocities(measuredStates());
   }
 
@@ -719,7 +721,7 @@ public class Drive implements Mechanism {
     // reads, and a corner/index mismatch is only visible if both are written.
     moduleLog.log("DesiredStates", desiredStates(), SwerveModuleVelocity.struct);
     moduleLog.log("MeasuredStates", measured, SwerveModuleVelocity.struct);
-    odometryLog.log("GyroHeading", getGyroHeading(), Rotation3d.struct);
+    odometryLog.log("GyroHeading", getGyroOrientation(), Rotation3d.struct);
     // The buffer's own newest sample rather than a second read of the signal: a GyroRate that
     // stayed healthy while nothing was sampling would hide a blind gate rather than show it.
     var latestYawRate = yawRateHistory.getInternalBuffer().lastEntry();
@@ -830,7 +832,7 @@ public class Drive implements Mechanism {
   private SwerveModuleVelocity[] measuredStates() {
     var states = new SwerveModuleVelocity[MODULES];
     for (int i = 0; i < MODULES; i++) {
-      states[i] = modules[i].getVelocity();
+      states[i] = modules[i].getMeasuredVelocity();
     }
     return states;
   }

--- a/src/main/java/first/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/first/robot/mechanisms/SwerveModule.java
@@ -168,11 +168,11 @@ final class SwerveModule {
         .setpointPeriodMs(diagnosticMs);
   }
 
-  void setVelocity(SwerveModuleVelocity target) {
+  void setTarget(SwerveModuleVelocity target) {
     command(resolve(target), 0, false);
   }
 
-  void setVelocity(SwerveModuleVelocity target, SwerveModuleAcceleration acceleration) {
+  void setTarget(SwerveModuleVelocity target, SwerveModuleAcceleration acceleration) {
     // Resolved once, so the direction the feedforward is projected onto is the same one the wheel
     // is commanded in. Reading the sensor twice can straddle the 90-degree optimise boundary and
     // leave the feedforward pushing against the setpoint.
@@ -181,7 +181,7 @@ final class SwerveModule {
         resolved, DriveConstants.DRIVE_KA * accelerationAlong(acceleration, resolved.angle), false);
   }
 
-  void setOpenLoopVelocity(SwerveModuleVelocity target) {
+  void setOpenLoopTarget(SwerveModuleVelocity target) {
     command(resolve(target), 0, true);
   }
 
@@ -267,9 +267,7 @@ final class SwerveModule {
                 PersistMode.kNoPersistParameters));
   }
 
-  // A fresh config each time, because the period setters keep the smaller of the requested and the
-  // value already in the object they are called on: restoring through one that has been raised
-  // leaves it raised.
+  // Build a fresh config: period setters cannot restore a lower period.
   private static SparkFlexConfig appliedOutputFrames(boolean raised) {
     var config = new SparkFlexConfig();
     int periodMs =
@@ -282,9 +280,7 @@ final class SwerveModule {
     return config;
   }
 
-  // kNoResetSafeParameters and kNoPersistParameters, both load-bearing: the first leaves every
-  // setting this config does not name alone, and the second is what makes a tuned gain die at the
-  // next power cycle rather than becoming an undocumented property of one controller.
+  // Do not reset unspecified settings or persist temporary tuning changes.
   void applyGains(ModuleGains gains) {
     Hardware.configureSpark(
         "Swerve" + name + "DriveGains",
@@ -371,7 +367,7 @@ final class SwerveModule {
     return Rotation2d.fromRotations(steerSensor.getPosition().get() - steerOffsetRotations);
   }
 
-  SwerveModuleVelocity getVelocity() {
+  SwerveModuleVelocity getMeasuredVelocity() {
     return new SwerveModuleVelocity(driveEncoder.getVelocity().get(), getAngle());
   }
 

--- a/src/main/java/first/robot/opmode/SweepLeftAuto.java
+++ b/src/main/java/first/robot/opmode/SweepLeftAuto.java
@@ -43,7 +43,7 @@ public class SweepLeftAuto implements OpMode {
     pastZoneLine =
         new Trigger(
             () ->
-                FieldConstants.flipAndMirrorIfNeeded(robot.poseEstimator.getEstimatedPose()).getX()
+                FieldConstants.toAuthoredPathFrame(robot.poseEstimator.getEstimatedPose()).getX()
                     >= ZONE_LINE.in(Meters));
     pastZoneLine.onTrue(markZoneEntry(robot));
     enabled.onTrue(sweepLeft(robot));

--- a/src/test/java/first/robot/FieldConstantsTest.java
+++ b/src/test/java/first/robot/FieldConstantsTest.java
@@ -97,7 +97,9 @@ class FieldConstantsTest {
   @Test
   void aMissingAllianceDefaultsToBlueRatherThanFlippingOnAGuess() {
     assertSame(
-        PATH, FieldConstants.forAlliance(PATH), "a path was flipped with no alliance to go on");
+        PATH,
+        FieldConstants.forCurrentAlliance(PATH),
+        "a path was flipped with no alliance to go on");
     assertFalse(FieldConstants.onRed(), "a missing alliance did not default to blue");
   }
 
@@ -155,7 +157,9 @@ class FieldConstantsTest {
   @Test
   void aPathIsFollowedAsAuthoredUntilTheDashboardSaysOtherwise() {
     assertSame(
-        PATH, FieldConstants.forSide(PATH), "a path was mirrored with nothing asking for it");
+        PATH,
+        FieldConstants.withDashboardMirror(PATH),
+        "a path was mirrored with nothing asking for it");
   }
 
   // The same threshold problem the flip has: a trigger written against the drawn path is compared
@@ -166,8 +170,8 @@ class FieldConstantsTest {
     FieldConstants.MIRRORED.set(true);
     var drawn = PATH.start().pose;
 
-    var driven = FieldConstants.forSide(PATH).start().pose;
-    var back = FieldConstants.flipAndMirrorIfNeeded(driven);
+    var driven = FieldConstants.withDashboardMirror(PATH).start().pose;
+    var back = FieldConstants.toAuthoredPathFrame(driven);
 
     assertEquals(-3, driven.getY(), TOLERANCE);
     assertEquals(drawn.getX(), back.getX(), TOLERANCE);

--- a/src/test/java/first/robot/HolonomicPathFollowerTest.java
+++ b/src/test/java/first/robot/HolonomicPathFollowerTest.java
@@ -84,7 +84,7 @@ class HolonomicPathFollowerTest {
   void aRobotSittingOnThePathIsHandedTheSamplesOwnVelocity() {
     pose = new Pose2d(0, 0, Rotation2d.kZero);
 
-    var velocities = follower(straightAlongX(Rotation2d.kZero)).next();
+    var velocities = follower(straightAlongX(Rotation2d.kZero)).nextFieldRelativeVelocities();
 
     assertEquals(SPEED, velocities.vx, TOLERANCE);
     assertEquals(0, velocities.vy, TOLERANCE);
@@ -97,7 +97,7 @@ class HolonomicPathFollowerTest {
   void theCorrectionIsInFieldTermsRatherThanTheRobots() {
     pose = new Pose2d(0, 0.1, Rotation2d.kCCW_Pi_2);
 
-    var velocities = follower(straightAlongX(Rotation2d.kCCW_Pi_2)).next();
+    var velocities = follower(straightAlongX(Rotation2d.kCCW_Pi_2)).nextFieldRelativeVelocities();
 
     assertEquals(SPEED, velocities.vx, TOLERANCE);
     assertEquals(-0.5, velocities.vy, TOLERANCE);
@@ -109,7 +109,7 @@ class HolonomicPathFollowerTest {
     // away from being a lag, and x/y error alone cannot say so.
     pose = new Pose2d(-0.3, 0, Rotation2d.kCCW_Pi_2);
 
-    follower(straightAlongX(Rotation2d.kCCW_Pi_2)).next();
+    follower(straightAlongX(Rotation2d.kCCW_Pi_2)).nextFieldRelativeVelocities();
 
     assertEquals(0, backend.getLastValue("/AlongTrackError", Double.class), TOLERANCE);
     assertEquals(-0.3, backend.getLastValue("/CrossTrackError", Double.class), TOLERANCE);
@@ -122,10 +122,10 @@ class HolonomicPathFollowerTest {
 
     now = LENGTH / SPEED + 1;
 
-    assertFalse(follower.isDone(), "a robot half a path short of the end reported done");
+    assertFalse(follower.isFinished(), "a robot half a path short of the end reported done");
 
     pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
-    assertTrue(follower.isDone(), "a robot at the end of a finished path did not report done");
+    assertTrue(follower.isFinished(), "a robot at the end of a finished path did not report done");
   }
 
   @Test
@@ -133,7 +133,7 @@ class HolonomicPathFollowerTest {
     var follower = follower(straightAlongX(Rotation2d.kZero));
     pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
 
-    assertFalse(follower.isDone(), "a path reported done before it had run");
+    assertFalse(follower.isFinished(), "a path reported done before it had run");
   }
 
   @Test
@@ -163,9 +163,9 @@ class HolonomicPathFollowerTest {
                     new ChassisAccelerations(2.5, 0, 0.75))));
     var follower = follower(accelerating);
 
-    follower.next();
+    follower.nextFieldRelativeVelocities();
 
-    assertEquals(2.5, follower.acceleration().ax, TOLERANCE);
-    assertEquals(0.75, follower.acceleration().alpha, TOLERANCE);
+    assertEquals(2.5, follower.currentAcceleration().ax, TOLERANCE);
+    assertEquals(0.75, follower.currentAcceleration().alpha, TOLERANCE);
   }
 }

--- a/src/test/java/first/robot/mechanisms/PathFollowingTest.java
+++ b/src/test/java/first/robot/mechanisms/PathFollowingTest.java
@@ -133,7 +133,7 @@ class PathFollowingTest {
     double worstCrossTrack = 0;
     double worstHeadingError = 0;
     double deadline = trajectory.duration + margin.in(Seconds);
-    while (!follower.isDone() && now < deadline) {
+    while (!follower.isFinished() && now < deadline) {
       step(follower);
       now += LOOP;
       worstCrossTrack =
@@ -145,7 +145,7 @@ class PathFollowingTest {
     }
 
     assertTrue(
-        follower.isDone(),
+        follower.isFinished(),
         pathName + " was still not done " + now + " s in, against a deadline of " + deadline);
     assertTrue(
         worstCrossTrack <= maxCrossTrack.in(Meters),
@@ -159,9 +159,9 @@ class PathFollowingTest {
   // their own rate rather than at the robot's.
   private void step(HolonomicPathFollower follower) {
     var heading = physics.truePose().getRotation();
-    var field = follower.next();
+    var field = follower.nextFieldRelativeVelocities();
     var robotRelative = field.toRobotRelative(heading);
-    var accelerations = follower.acceleration().toRobotRelative(heading);
+    var accelerations = follower.currentAcceleration().toRobotRelative(heading);
 
     var targets =
         SwerveDriveKinematics.desaturateWheelVelocities(


### PR DESCRIPTION
## Summary

- simplify student-facing docs and code comments
- replace the excluded terminology with plain language
- rename field, measurement, follower, and module-target interfaces for clearer intent

## Verification

- > Task :generateBuildMetadata
> Task :compileJava
> Task :processResources NO-SOURCE
> Task :classes
> Task :compileTestJava
> Task :extractReleaseNative UP-TO-DATE
> Task :processTestResources NO-SOURCE
> Task :testClasses
HAL Extensions: No extensions found

> Task :test

FieldConstantsTest > theCornerConversionPutsTheFieldSymmetricallyAboutTheOrigin() STANDARD_ERROR
    Tunable warning: no backend for path '/Mirrored'
    	at org.wpilib.tunable.TunableRegistry.defaultReportWarning(TunableRegistry.java:104)
    	at org.wpilib.tunable.TunableRegistry.reportWarning(TunableRegistry.java:149)
    	at org.wpilib.tunable.TunableRegistry.publish(TunableRegistry.java:501)
    	at org.wpilib.tunable.TunableTable.publish(TunableTable.java:68)
    	at org.wpilib.tunable.Tunables.publish(Tunables.java:142)
    	at org.wpilib.tunable.Tunables.addBoolean(Tunables.java:78)
    	at first.robot.FieldConstants.<clinit>(FieldConstants.java:19)
    	at first.robot.FieldConstantsTest.theCornerConversionPutsTheFieldSymmetricallyAboutTheOrigin(FieldConstantsTest.java:69)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
    	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
    	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.processAllTestDefinitions(JUnitPlatformTestDefinitionProcessor.java:179)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.access$000(JUnitPlatformTestDefinitionProcessor.java:122)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor.stop(JUnitPlatformTestDefinitionProcessor.java:116)
    	at org.gradle.api.internal.tasks.testing.SuiteTestDefinitionProcessor.stop(SuiteTestDefinitionProcessor.java:63)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.gradle.internal.dispatch.MethodInvocation.invokeOn(MethodInvocation.java:77)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:28)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:19)
    	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
    	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:88)
    	at jdk.proxy1/jdk.proxy1.$Proxy4.stop(Unknown Source)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:195)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:126)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
    	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:122)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:72)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


FieldConstantsTest > theCornerConversionPutsTheFieldSymmetricallyAboutTheOrigin() PASSED

FieldConstantsTest > theMirrorAndTheAllianceFlipCommute() PASSED

FieldConstantsTest > thePoseFlipUndoesWhatTheTrajectoryFlipDidToTheSamePose() PASSED

FieldConstantsTest > asAuthoredUndoesTheMirrorAsWellAsTheFlip() PASSED

FieldConstantsTest > flippingTwiceIsTheOriginalPath() PASSED

FieldConstantsTest > theFlipIsARotationAboutTheOriginRatherThanAReflection() PASSED

FieldConstantsTest > mirroringTwiceIsTheOriginalPath() PASSED

FieldConstantsTest > aPathIsFollowedAsAuthoredUntilTheDashboardSaysOtherwise() PASSED

FieldConstantsTest > aCornerFramePoseFlipsToTheRotationOfItselfAboutTheFieldCentre() PASSED

FieldConstantsTest > aMissingAllianceDefaultsToBlueRatherThanFlippingOnAGuess() PASSED

FieldConstantsTest > theMirrorIsAReflectionAboutTheLongAxisRatherThanARotation() PASSED

HardwareTest > aTimeoutIsRetriedUntilItSucceeds() PASSED

HardwareTest > aReturnedErrorThatIsNotATimeoutIsNeverRetried() PASSED

HardwareTest > aPersistentTimeoutStopsAtFiveAttemptsAndAlerts() PASSED

HardwareTest > aThrownFailureIsNeverRetried() PASSED

HardwareTest > phoenixRetriesANonOkStatusAndStopsAtFive() PASSED

HolonomicPathFollowerTest > poseErrorIsReportedAlongAndAcrossTheTrackRatherThanInXAndY() PASSED

HolonomicPathFollowerTest > aRobotSittingOnThePathIsHandedTheSamplesOwnVelocity() PASSED

HolonomicPathFollowerTest > theCorrectionIsInFieldTermsRatherThanTheRobots() PASSED

HolonomicPathFollowerTest > aPathThatHasNotRunItsDurationIsNotDoneEvenSittingOnTheEndPose() PASSED

HolonomicPathFollowerTest > theAccelerationHandedOnIsTheSamplesOwnRatherThanADerivative() PASSED

HolonomicPathFollowerTest > theTimeoutIsAMarginOverTheTrajectoryDurationRatherThanAnAbsolute() PASSED

HolonomicPathFollowerTest > aPathWhoseClockRanOutSomewhereElseIsNotDone() PASSED

InjectedTelemetryTest > aSignalWrittenThroughAnInjectedTableIsReadableByName() PASSED

PoseEstimatorTest > theOdometryOnlyPoseTracksTheSimulationsTruePoseThroughATranslation() PASSED

PoseEstimatorTest > resettingThePoseMovesBothEstimatorsTogether() PASSED

PoseEstimatorTest > theOdometryOnlyPoseTracksTheSimulationsTruePoseThroughASpin() PASSED

PoseEstimatorTest > aVisionMeasurementMovesOnlyTheFusedEstimate() PASSED

TrajectoryLoaderTest > everyCommittedTrajectoryLoads() STANDARD_ERROR
    Tunable warning: no backend for path '/Mirrored'
    	at org.wpilib.tunable.TunableRegistry.defaultReportWarning(TunableRegistry.java:104)
    	at org.wpilib.tunable.TunableRegistry.reportWarning(TunableRegistry.java:149)
    	at org.wpilib.tunable.TunableRegistry.publish(TunableRegistry.java:501)
    	at org.wpilib.tunable.TunableTable.publish(TunableTable.java:68)
    	at org.wpilib.tunable.Tunables.publish(Tunables.java:142)
    	at org.wpilib.tunable.Tunables.addBoolean(Tunables.java:78)
    	at first.robot.FieldConstants.<clinit>(FieldConstants.java:19)
    	at first.robot.TrajectoryLoader.convert(TrajectoryLoader.java:132)
    	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
    	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
    	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
    	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
    	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:635)
    	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:291)
    	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:652)
    	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:658)
    	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:663)
    	at first.robot.TrajectoryLoader.read(TrajectoryLoader.java:103)
    	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$0(Collectors.java:180)
    	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
    	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
    	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
    	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
    	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
    	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
    	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
    	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
    	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
    	at first.robot.TrajectoryLoader.<init>(TrajectoryLoader.java:58)
    	at first.robot.TrajectoryLoaderTest.everyCommittedTrajectoryLoads(TrajectoryLoaderTest.java:172)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
    	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
    	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.processAllTestDefinitions(JUnitPlatformTestDefinitionProcessor.java:179)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.access$000(JUnitPlatformTestDefinitionProcessor.java:122)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor.stop(JUnitPlatformTestDefinitionProcessor.java:116)
    	at org.gradle.api.internal.tasks.testing.SuiteTestDefinitionProcessor.stop(SuiteTestDefinitionProcessor.java:63)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.gradle.internal.dispatch.MethodInvocation.invokeOn(MethodInvocation.java:77)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:28)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:19)
    	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
    	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:88)
    	at jdk.proxy1/jdk.proxy1.$Proxy4.stop(Unknown Source)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:195)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:126)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
    	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:122)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:72)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


TrajectoryLoaderTest > everyCommittedTrajectoryLoads() PASSED

TrajectoryLoaderTest > anEmptyDirectoryIsRejected(Path) PASSED

TrajectoryLoaderTest > aCommittedPathIsStillOnTheFieldAfterTheAllianceFlip() PASSED

TrajectoryLoaderTest > anUnknownNameNamesWhatWasLoaded(Path) PASSED

TrajectoryLoaderTest > theFlatSampleShapeBecomesTheNestedOne(Path) PASSED

TrajectoryLoaderTest > aTrajectoryThatLastsNoTimeIsRejected(Path) PASSED

TrajectoryLoaderTest > aDifferentialTrajectoryIsRejected(Path) PASSED

TrajectoryLoaderTest > theCornerFrameChoreoEmitsBecomesTheFieldCentreOneTheRobotUses(Path) PASSED

TrajectoryLoaderTest > anUnexpectedSchemaVersionIsRejected(Path) PASSED

TrajectoryLoaderTest > anUngeneratedTrajectoryIsRejected(Path) PASSED

TrajectoryLoaderTest > aMalformedTrajectoryNamesTheFileItCouldNotParse(Path) PASSED

TrajectoryLoaderTest > aMissingDirectoryIsRejected(Path) PASSED

HAL Extensions: No extensions found
DataLog: Logging to '/home/drew/dev/2027beta/logs/WPILIB_TBD_15660082431ffbb5.wpilog' (837.5 GiB free space)
[phoenix] CANbus Connected: sim
[phoenix] CANbus Network Up: sim
DataLog: Renamed log file from 'WPILIB_TBD_15660082431ffbb5.wpilog' to 'WPILIB_20260830_224950.wpilog'

> Task :test

WiringTest > theScriptedCheckDrivesTheRealRobot() STANDARD_OUT
    ********** Robot program startup complete **********
    ********** Creating OpMode DrivePathCheck **********
    ********** Starting OpMode DrivePathCheck **********

WiringTest > theScriptedCheckDrivesTheRealRobot() PASSED

HAL Extensions: No extensions found
[phoenix] CANbus Connected: sim
[phoenix] CANbus Network Up: sim

> Task :test

DriveSchedulingTest > oneCommandRunsToCompletion() PASSED

DriveSchedulingTest > anEdgeTriggerIsHighForExactlyOneCycleSoWhileTrueCancelsImmediately() PASSED

DriveSchedulingTest > theMechanismRegistersAgainstTheInjectedScheduler() PASSED

DriverInputTest > fullTranslationAndFullRotationAtOnceAskForTwiceTheWheelsThereAre() PASSED

DriverInputTest > thePerspectiveInvertsBothTranslationAxesTogether() PASSED

DriverInputTest > aRedDriverPushingForwardsDrivesAwayFromTheRedWall() PASSED

DriverInputTest > fullStickOnBothLeavesMostOfATranslationAfterDesaturation() PASSED

DriverInputTest > aRestingStickCommandsExactlyNothing() PASSED

DriverInputTest > theTopWheelSpeedIsTheWholeRail() PASSED

DriverInputTest > theStepAtTheDeadbandIsSmallerThanTheDriverCanFeel() PASSED

DriverInputTest > fullTravelIsFullOutputAndTheCurveIsOdd() PASSED

DriverInputTest > aBlueDriverPushingForwardsDrivesAtTheRedWall() PASSED

DriverInputTest > thePerspectiveLeavesTheSpinAlone() PASSED

DriverInputTest > theCurveIsSoftBelowTheStraightLineAndConvergesOntoIt() PASSED

PathFollowingTest > aStraightPathIsDrivenWithinAWheelsWidthOfItself() STANDARD_ERROR
    Tunable warning: no backend for path '/Mirrored'
    	at org.wpilib.tunable.TunableRegistry.defaultReportWarning(TunableRegistry.java:104)
    	at org.wpilib.tunable.TunableRegistry.reportWarning(TunableRegistry.java:149)
    	at org.wpilib.tunable.TunableRegistry.publish(TunableRegistry.java:501)
    	at org.wpilib.tunable.TunableTable.publish(TunableTable.java:68)
    	at org.wpilib.tunable.Tunables.publish(Tunables.java:142)
    	at org.wpilib.tunable.Tunables.addBoolean(Tunables.java:78)
    	at first.robot.FieldConstants.<clinit>(FieldConstants.java:19)
    	at first.robot.TrajectoryLoader.convert(TrajectoryLoader.java:132)
    	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
    	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
    	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
    	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
    	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:635)
    	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:291)
    	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:652)
    	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:658)
    	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:663)
    	at first.robot.TrajectoryLoader.read(TrajectoryLoader.java:103)
    	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$0(Collectors.java:180)
    	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
    	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
    	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
    	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
    	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
    	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
    	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
    	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
    	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
    	at first.robot.TrajectoryLoader.<init>(TrajectoryLoader.java:58)
    	at first.robot.mechanisms.PathFollowingTest.load(PathFollowingTest.java:204)
    	at first.robot.mechanisms.PathFollowingTest.drive(PathFollowingTest.java:118)
    	at first.robot.mechanisms.PathFollowingTest.aStraightPathIsDrivenWithinAWheelsWidthOfItself(PathFollowingTest.java:90)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
    	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
    	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
    	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
    	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
    	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.processAllTestDefinitions(JUnitPlatformTestDefinitionProcessor.java:179)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.access$000(JUnitPlatformTestDefinitionProcessor.java:122)
    	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor.stop(JUnitPlatformTestDefinitionProcessor.java:116)
    	at org.gradle.api.internal.tasks.testing.SuiteTestDefinitionProcessor.stop(SuiteTestDefinitionProcessor.java:63)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    	at org.gradle.internal.dispatch.MethodInvocation.invokeOn(MethodInvocation.java:77)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:28)
    	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:19)
    	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
    	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:88)
    	at jdk.proxy1/jdk.proxy1.$Proxy4.stop(Unknown Source)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:195)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:126)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
    	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
    	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:122)
    	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:72)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
    	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


PathFollowingTest > aStraightPathIsDrivenWithinAWheelsWidthOfItself() PASSED

PathFollowingTest > theMirrorOfThatPathIsDrivenTheSameWay() PASSED

PathFollowingTest > aPathThatTurnsWhileItTranslatesIsDrivenTheSameWay() PASSED

SwerveModuleTest > theSensorSpansOneModuleRotationOverItsSupplyRail() PASSED

SwerveModuleTest > aWheelDrivenAgainstTheAccelerationBrakesAgainstIt() PASSED

SwerveModuleTest > theSecondHalfTurnComesBackInsideTheSensorsRange() PASSED

SwerveModuleTest > anOffsetPastTheBoundaryWrapsRatherThanRunningOffTheEnd() PASSED

SwerveModuleTest > everyAngleLandsInsideTheConfiguredWrappingRange() PASSED

SwerveModuleTest > aWheelTurnedAcrossTheAccelerationTakesNoneOfIt() PASSED

WheelRadiusTest > aClockwiseSpinMeasuresTheSameRadius() PASSED

WheelRadiusTest > theArcRecoversTheRadiusItWasBuiltFrom() PASSED

WheelRadiusTest > aRobotThatHasNotMovedHasNoAnswer() PASSED

YawRateHistoryTest > aWindowOlderThanTheHistoryAnswersNothingRatherThanTheOldestSample() PASSED

YawRateHistoryTest > anEmptyHistoryAnswersNothingRatherThanZero() PASSED

YawRateHistoryTest > theAnswerIsTheLargestMagnitudeInTheWindowAndNotTheOneAtItsEnd() PASSED

YawRateHistoryTest > aWindowThatMissesTheSpikeAnswersTheQuietRate() PASSED

YawRateHistoryTest > theHistoryReachesBackAsFarAsTheEstimatorsOwnBuffer() PASSED

YawRateHistoryTest > theWindowIncludesBothOfItsEndpoints() PASSED

OnboardLoopSimTest > theFirstCalculateHasNoDerivativeKick() PASSED

OnboardLoopSimTest > theFeedbackTermsFollowTheRailAndTheFeedforwardTermsDoNot() PASSED

OnboardLoopSimTest > aVelocityLoopAtItsSetpointStillWritesItsFeedforward() PASSED

OnboardLoopSimTest > aWrappedPositionLoopTakesTheShortWayRound() PASSED

OnboardLoopSimTest > theDerivativeFilterCarriesTheFractionItIsGiven() PASSED

SwerveDriveSimTest > aQuarterTurnStepSettlesInsideTheTimeADriverWouldNotice() PASSED

SwerveDriveSimTest > theBatterySagsUnderTheCurrentItIsAskedFor() PASSED

SwerveDriveSimTest > aFullThrottleLaunchReachesSpeedInTheTimeTheCurrentLimitAllows() PASSED

SwerveDriveSimTest > aWheelHandedZeroVoltsBrakesRatherThanCoasting() PASSED

SwerveDriveSimTest > theAppliedOutputStaysADutyCycleThroughAnAccelerationThatSagsThePack() PASSED

SwerveDriveSimTest > theAppliedVoltsAreTheLimitedOnesUntilTheWheelIsUpToSpeed() PASSED

SwerveDriveSimTest > pureRotationTurnsTheRobotAndDoesNotMoveIt() PASSED

SwerveDriveSimTest > aConstantVoltageSettlesAtTheFreeSpeedThatVoltageBuys() PASSED

SwerveDriveSimTest > aHardReversalBrakesAtTheCurrentLimitWithoutSaggingThePack() PASSED

SwerveDriveSimTest > aLaunchDoesNotCollapseTheRail() PASSED

HAL Extensions: No extensions found
DataLog: Logging to '/tmp/junit12781956566183176204/sysid-simulation.wpilog' (11.7 GiB free space)

> Task :test

CharacterisationTest STANDARD_OUT
    SysId log: /tmp/junit12781956566183176204/sysid-simulation.wpilog

CharacterisationTest > theDynamicStepLogsTheVoltageTheLimiterAllowedRatherThanTheOneRequested() PASSED

CharacterisationTest > everyDynamicTestStartsFromRest() PASSED

CharacterisationTest > theCancellationPathZeroesTheOutputAndClosesEveryTest() PASSED

CharacterisationTest > theLogIsStampedInSimulatedTimeRatherThanWallClock() PASSED

CharacterisationTest > everyRoutineMovedWhatItMeasures() PASSED

CharacterisationTest > theAnalyserFindsFourTestsInEveryRoutinesLog() PASSED

CharacterisationTest > theRotationRoutineLogsAContinuousRobotAngle() PASSED

CharacterisationTest > theThreeRoutinesEntriesDoNotInterleave() PASSED

BUILD SUCCESSFUL in 17s
5 actionable tasks: 4 executed, 1 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html