### PR TITLE
Let go of the button to stop a characterisation ramp

### DIFF
--- a/docs/adr/0009-characterisation-and-tuning.md
+++ b/docs/adr/0009-characterisation-and-tuning.md
@@ -9,7 +9,9 @@ steer decision. The routines are also enumerated now that there are
 four of them, and a wheel-radius measurement joins them. Amended again
 2026-08-29, on building the frame raise: the voltage column is the
 applied output rather than the request, and it is honest under a stated
-condition rather than unconditionally.
+condition rather than unconditionally. Amended again 2026-08-30: the
+four ramps are held rather than pressed, so a release ends the run — the
+supervision requirement below gains a stop the supervisor can reach.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -384,6 +386,19 @@ explicitly as supervised-on-ground. A rule with an exception beside it
 is a rule with two meanings. **[decided]** ADR 0006 and the house-style
 document are amended to match.
 
+**The button is the stop.** Supervision is only worth the name if the
+supervisor can end a run without waiting for it, so every ramp is bound
+`whileTrue` and a release cancels it — the same binding the wheel-radius
+measurement already used, for a different reason. The cancellation path
+is the one that zeroes the output and drops the raised frame, and it was
+already the only path that ran (see *Traps*), so a release ends a run
+exactly the way the timeout does. **[decided]**
+
+The cost is that a release before the timeout truncates the dataset, and
+a truncated test is one the analyser may refuse to fit. That is the
+right way round: a shortened test is repeated, and a run that cannot be
+stopped is not.
+
 ### There is no `/tune` skill
 
 The test #18 set was *process with a completion bar → skill; reference →
@@ -540,10 +555,11 @@ in Traps.
 - **Cleanup goes in `whenCanceled`, and for these commands it is the
   only path that ever runs.** `Command.withTimeout` is implemented as
   `race(this, waitFor(timeout))` (`Command.java:218-222`) **[source]**,
-  and the quasistatic and dynamic bodies loop forever — so the timeout
-  always wins and the command is always **cancelled**. v2's `finallyDo`
-  ran on both the end and the interrupt path (`SysIdRoutine.java:230-235,
-  269-273`) **[source]**; a v3 port that puts the zero-volt write and the
+  and the quasistatic and dynamic bodies loop forever — so the body never
+  ends on its own and the command is always **cancelled**, by the timeout
+  or by the release that beats it. v2's `finallyDo` ran on both the end
+  and the interrupt path (`SysIdRoutine.java:230-235, 269-273`)
+  **[source]**; a v3 port that puts the zero-volt write and the
   `State.NONE` record after the loop in the coroutine body compiles clean
   and never runs them. The symptom is a drive base that keeps its last
   ramp voltage after the test ends, on the ground, with people around

--- a/src/main/java/first/robot/opmode/Bindings.java
+++ b/src/main/java/first/robot/opmode/Bindings.java
@@ -16,12 +16,6 @@ import org.wpilib.command3.Trigger;
 final class Bindings {
   private final List<Trigger> bound = new ArrayList<>();
 
-  Bindings onPress(Trigger button, Command command) {
-    button.onTrue(command);
-    bound.add(button);
-    return this;
-  }
-
   Bindings whileHeld(Trigger button, Command command) {
     button.whileTrue(command);
     bound.add(button);

--- a/src/main/java/first/robot/opmode/DriveCharacterisationCheck.java
+++ b/src/main/java/first/robot/opmode/DriveCharacterisationCheck.java
@@ -12,16 +12,16 @@ import org.wpilib.opmode.Utility;
 @Utility(
     group = "Characterisation",
     description =
-        "Straight-line module ramps, wheels locked forward. Run supervised, on the ground")
+        "Straight-line module ramps, wheels locked forward. Hold to run, supervised, on the ground")
 public class DriveCharacterisationCheck implements OpMode {
   private final Bindings bindings = new Bindings();
 
   public DriveCharacterisationCheck(Robot robot) {
     bindings
-        .onPress(robot.driver.faceUp(), robot.drive.driveQuasistatic(Direction.FORWARD))
-        .onPress(robot.driver.faceDown(), robot.drive.driveQuasistatic(Direction.REVERSE))
-        .onPress(robot.driver.faceLeft(), robot.drive.driveDynamic(Direction.FORWARD))
-        .onPress(robot.driver.faceRight(), robot.drive.driveDynamic(Direction.REVERSE));
+        .whileHeld(robot.driver.faceUp(), robot.drive.driveQuasistatic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceDown(), robot.drive.driveQuasistatic(Direction.REVERSE))
+        .whileHeld(robot.driver.faceLeft(), robot.drive.driveDynamic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceRight(), robot.drive.driveDynamic(Direction.REVERSE));
   }
 
   @Override

--- a/src/main/java/first/robot/opmode/RotationCharacterisationCheck.java
+++ b/src/main/java/first/robot/opmode/RotationCharacterisationCheck.java
@@ -11,16 +11,17 @@ import org.wpilib.opmode.Utility;
 
 @Utility(
     group = "Characterisation",
-    description = "Whole-robot rotation ramps, spinning on the spot. Run supervised, on the ground")
+    description =
+        "Whole-robot rotation ramps, spinning on the spot. Hold to run, supervised, on the ground")
 public class RotationCharacterisationCheck implements OpMode {
   private final Bindings bindings = new Bindings();
 
   public RotationCharacterisationCheck(Robot robot) {
     bindings
-        .onPress(robot.driver.faceUp(), robot.drive.rotationQuasistatic(Direction.FORWARD))
-        .onPress(robot.driver.faceDown(), robot.drive.rotationQuasistatic(Direction.REVERSE))
-        .onPress(robot.driver.faceLeft(), robot.drive.rotationDynamic(Direction.FORWARD))
-        .onPress(robot.driver.faceRight(), robot.drive.rotationDynamic(Direction.REVERSE));
+        .whileHeld(robot.driver.faceUp(), robot.drive.rotationQuasistatic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceDown(), robot.drive.rotationQuasistatic(Direction.REVERSE))
+        .whileHeld(robot.driver.faceLeft(), robot.drive.rotationDynamic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceRight(), robot.drive.rotationDynamic(Direction.REVERSE));
   }
 
   @Override

--- a/src/main/java/first/robot/opmode/SteerCharacterisationCheck.java
+++ b/src/main/java/first/robot/opmode/SteerCharacterisationCheck.java
@@ -11,16 +11,16 @@ import org.wpilib.opmode.Utility;
 
 @Utility(
     group = "Characterisation",
-    description = "Steer ramps on one module. Run supervised, on the ground")
+    description = "Steer ramps on one module. Hold to run, supervised, on the ground")
 public class SteerCharacterisationCheck implements OpMode {
   private final Bindings bindings = new Bindings();
 
   public SteerCharacterisationCheck(Robot robot) {
     bindings
-        .onPress(robot.driver.faceUp(), robot.drive.steerQuasistatic(Direction.FORWARD))
-        .onPress(robot.driver.faceDown(), robot.drive.steerQuasistatic(Direction.REVERSE))
-        .onPress(robot.driver.faceLeft(), robot.drive.steerDynamic(Direction.FORWARD))
-        .onPress(robot.driver.faceRight(), robot.drive.steerDynamic(Direction.REVERSE));
+        .whileHeld(robot.driver.faceUp(), robot.drive.steerQuasistatic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceDown(), robot.drive.steerQuasistatic(Direction.REVERSE))
+        .whileHeld(robot.driver.faceLeft(), robot.drive.steerDynamic(Direction.FORWARD))
+        .whileHeld(robot.driver.faceRight(), robot.drive.steerDynamic(Direction.REVERSE));
   }
 
   @Override


### PR DESCRIPTION
The three ramp opmodes started their routines on a press, which left the only way to end one early as reaching for the disable. Every ramp is now bound `whileTrue`, so a release cancels it — the binding `WheelRadiusCheck` already used, for a different reason.

## Why the release is safe, not just different

It lands on the path the timeout already used rather than a new one. `Scheduler.cancel` recurses into child commands (`removeOrphanedChildren`, `Scheduler.java:1117`), so cancelling the `instrumented` wrapper cancels the awaited `sysid-*` command and runs its `whenCanceled` — zero volts and `State.NONE` — while the wrapper's own hook drops the raised Status0 frame. Drive's default command is `idle()`, which is `stopModules`. `CharacterisationTest > theCancellationPathZeroesTheOutputAndClosesEveryTest` covers exactly this.

## The tradeoff

A release before the 10 s timeout truncates the dataset, and the analyser filters hard enough that a short run may not fit. That is the right way round: a shortened test is repeated, and a run that cannot be stopped is not. Written into the ADR as an accepted cost rather than left as a surprise at the bench.

## Also here

- `@Utility` descriptions say "Hold to run" — that string is what the operator reads on the dashboard.
- ADR 0009's supervision decision carries the stop, and its Traps entry no longer claims the timeout is the only thing that cancels these commands.
- `Bindings.onPress` had no callers left.

`./gradlew spotlessApply compileJava` and `./gradlew test` both green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)