### PR TITLE
Log only the robot signals the platform can actually source

### DIFF
--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -9,7 +9,10 @@ under *Consequences*. Amended 2026-08-28: the signal list gains
 `/Check`, the opmode-scoped root the utility checks report under.
 Amended 2026-08-30 by #76: the signal list gains `/Match/Mirrored`, and
 the *Open* item on how `/Tunables` reaches the file records its first
-instance.
+instance. Amended 2026-08-30 by #107: a HAL read the platform does not
+implement is probed once and then not logged, `/Robot/InputVoltage` is
+deleted as a duplicate, and `/Robot/Rail3V3/Voltage` is logged only
+beside its fault count.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -122,14 +125,13 @@ habits below.
 | Signal | Source |
 |---|---|
 | `/Robot/LoopDelta` | wake-to-wake delta, ours to compute — ADR 0002 |
-| `/Robot/BatteryVoltage` | `RobotController.getBatteryVoltage()` (`:117`) |
+| `/Robot/BatteryVoltage` † | `RobotController.getBatteryVoltage()` (`:117`) |
 | `/Robot/BrownedOut` | `RobotController.isBrownedOut()` (`:145`) |
-| `/Robot/CommsDisableCount` | `RobotController.getCommsDisableCount()` (`:155`) |
-| `/Robot/CpuTemp` | `RobotController.getCPUTemp()` (`:296`) |
-| `/Robot/Can/Bus0/{Utilization,ReceiveErrors,TransmitErrors,BusOff,TxFull}` | `RobotController.getCANStatus(CANBus)` (`:315`), fields on `CANStatus` (`:10-22`) |
-| `/Robot/InputVoltage` | `RobotController.getInputVoltage()` (`:182`) |
-| `/Robot/SysActive` | `RobotController.isSysActive()` (`:136`) |
-| `/Robot/Rail3V3/{Voltage,Current,FaultCount}` | `RobotController.getVoltage3V3()` (`:200`), `getCurrent3V3()` (`:218`), `getFaultCount3V3()` (`:255`) |
+| `/Robot/CommsDisableCount` † | `RobotController.getCommsDisableCount()` (`:155`) |
+| `/Robot/CpuTemp` † | `RobotController.getCPUTemp()` (`:296`) |
+| `/Robot/Can/Bus0/{Utilization,ReceiveErrors,TransmitErrors,BusOff,TxFull}` † | `RobotController.getCANStatus(CANBus)` (`:315`), fields on `CANStatus` (`:10-22`) |
+| `/Robot/SysActive` † | `RobotController.isSysActive()` (`:136`) |
+| `/Robot/Rail3V3/{Voltage,Current,FaultCount}` † | `RobotController.getVoltage3V3()` (`:200`), `getCurrent3V3()` (`:218`), `getFaultCount3V3()` (`:255`) |
 | `/Robot/Pdh/{Current,Voltage,TotalCurrent,SwitchableChannel}` | `PowerDistribution.logTo` (`PowerDistribution.java:248-254`) |
 | `/Robot/Pdh/{Temperature,TotalEnergy}` | `getTemperature()` (`:108`), `getTotalEnergy()` (`:158`) |
 | `/Robot/Radio/{Connected,Status}` | the radio's own HTTP status page, at 0.2 Hz |
@@ -141,6 +143,11 @@ habits below.
 **[source]** for the accessors, all in
 `wpilibj/src/main/java/org/wpilib/system/RobotController.java` and
 `hal/src/main/java/org/wpilib/hardware/hal/can/CANStatus.java`.
+
+**†** — present only where the platform implements the read. Every one
+of these is absent on the SystemCore image ADR 0002 records and present
+in simulation. See *A HAL read the platform does not implement is not
+logged*, below.
 
 `LoopDelta` is the one signal in that table nothing in the framework
 provides. `Tracer` publishes nothing — it has no telemetry and no
@@ -198,6 +205,73 @@ in real units, and a tick count is only interpretable with a conversion
 factor the git SHA already pins. A per-loop echo of config values —
 ADR 0004 rules that fixed config is recoverable from the SHA and only
 tunables are logged. Vision internals — ADR 0012.
+
+### A HAL read the platform does not implement is not logged
+
+The SystemCore's HAL stubs the reads it has not implemented: the body
+sets `*status = HAL_HANDLE_ERROR` — `-1098` — and returns, which the
+JNI turns into a `HalHandleException` (`HALUtil.cpp:101-104`)
+**[source]**. It is a not-implemented sentinel, not a bad handle, and
+there is no handle to go and fix. Six of the always-on signals above
+are stubs on the image ADR 0002 records, plus the whole
+`/Robot/Can/Bus0` block — while the same reads are implemented in the
+simulation HAL (`sim/HAL.cpp:183,191`, `sim/Power.cpp:31,37,99`,
+`sim/CAN.cpp:54`) **[source]**. So which signals a log contains depends
+on where it was recorded, and the table marks that with a †.
+
+**The rule: probe each one once at startup, and log only what
+answered.** The HAL exposes no capability query — there is no
+`isSupported()` — so a read is discoverable only by making it. Whether
+it is implemented is fixed for the session, so a per-loop `try`/`catch`
+would pay every iteration for an answer that cannot change.
+**[decided]**
+
+Probing rather than branching on `RobotBase.isSimulation()`, which
+would be right for the wrong reason: these reads work in simulation
+because the simulation HAL implements them, not because it is
+simulation. An image that implements `HAL_GetCPUTemp` next month
+restores the signal on its own under a probe, and stays suppressed
+forever under the branch — silently, which is the failure mode this ADR
+exists to avoid.
+
+**The absence is announced, not inferred.** A `hal-unimplemented` alert
+at `Level.LOW` names the rejected signals once at startup, so it
+reaches `/Robot/Alerts` and the Driver Station rather than leaving a
+reader to work out why a name is missing from a file.
+
+**The rule covers HAL reads and nothing else.** A mechanism signal
+comes from REVLib and fails differently: ADR 0004 rules that config
+errors alert and never block, and every mechanism logs `Faults`.
+Reaching for a probe there would be the wrong habit learned from the
+right rule.
+
+Two rows in the table are corrections rather than instances of it:
+
+- **`/Robot/InputVoltage` is deleted, on every platform.**
+  `RobotController.getInputVoltage()` (`:182`) and
+  `getBatteryVoltage()` (`:117`) are both `PowerJNI.getVinVoltage()`
+  **[source]** — one call under two names. It was a duplicate row from
+  the day it was written, and the SystemCore only made it visible.
+  **[decided]**
+- **`/Robot/Rail3V3/Voltage` is logged only when `FaultCount` is.**
+  `HAL_GetUserVoltage3V3` returns a literal `3.3` and never writes
+  status (`systemcore/Power.cpp:42-47`) **[source]**, so no probe can
+  catch it — it succeeds and lies. The group is here for the fault
+  count, which separates a sensor that failed from a rail that browned
+  out under it; without it the voltage is a constant that reads as a
+  measurement. **[decided]**
+
+`/Robot/BatteryVoltage` is a third case again — implemented, and
+failing at runtime on this image with `HAL_INCOMPATIBLE_STATE` (`1015`)
+rather than the stub's sentinel. A positive status does not throw: the
+JNI walks the Java stack, formats it and prints it
+(`HALUtil.cpp:109-118`) **[source]**, which at ADR 0002's 5 ms period
+is a stack walk and a console line two hundred times a second, folded
+into this same WPILOG by `DataLogManager`. A failing signal would
+flood the log it exists to inform. So it is probed too, by its value
+rather than by an exception: a robot far enough along to run the probe
+is never at 0 V. Why the read fails is #108's, not this ADR's.
+**[decided]**
 
 ### Names are PascalCase, and units are never in the name
 

--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -273,6 +273,18 @@ rather than by an exception: a robot far enough along to run the probe
 is never at 0 V. Why the read fails is #108's, not this ADR's.
 **[decided]**
 
+**A boolean read cannot be probed at all, and one is outstanding.**
+`HAL_GetBrownedOut` fails the same way on this image, and returns
+`false` when it does (`systemcore/HAL.cpp:191-201`) **[source]** —
+which is also a valid reading. There is no value to probe by and no
+Java-side route to the status, because `DriverStationErrors` reports
+errors and never exposes them. So `/Robot/BrownedOut` still logs, and
+what it logs is `false` whether or not the robot browned out. #94
+recorded this as the one always-on read that worked; that was true of
+the console call and not of the loop, where the `-1098` throws in front
+of it were masking it. This rule names the case it cannot reach rather
+than implying it covers it. What to do about it is #118.
+
 ### Names are PascalCase, and units are never in the name
 
 PascalCase segments, no spaces, no abbreviations that need expanding,

--- a/docs/adr/0014-ai-log-analysis-contract.md
+++ b/docs/adr/0014-ai-log-analysis-contract.md
@@ -5,7 +5,9 @@
 Accepted — 2026-08-27. Corrects #16's ground for vendoring the WPILOG
 parser: `robotpy-wpilog` **does** exist for 2027 and works. The decision
 is unchanged and the reason is now coupling rather than absence — see
-*Rejected* and *Source*.
+*Rejected* and *Source*. Amended 2026-08-30 by #107: a class-1 anchor
+the platform could not source is reported as *unavailable*, never as
+*clear*.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -288,6 +290,19 @@ answers a why*.
 Silence is indistinguishable from not having looked, and the realistic
 failure is not a wrong diagnosis — it is finding one brownout, reporting
 it, and never opening pose error at all.
+
+**A missing anchor is reported as *unavailable*, never as *clear*.**
+ADR 0005 lets the platform decide whether a HAL-sourced signal exists
+at all, and class 1 is where that bites: on the SystemCore image ADR
+0002 records, `/Robot/Can/Bus0/*` and `/Robot/BatteryVoltage` are both
+absent, which is two of that class's five anchors. `list` is what makes
+this legible — step 2 of every run exists to stop the agent querying
+signals the log does not have — but a signal that was never recorded
+and a signal that recorded no problem are the same nothing at query
+time. Reporting "clear" for the first is reporting the absence of a
+signal as the absence of a fault. `/Robot/Alerts` carries a
+`hal-unimplemented` entry naming what the platform could not source, so
+the distinction is in the file. **[decided]**
 
 ### The skill points at ADR 0005. It never restates it
 

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -14,6 +14,7 @@ import first.robot.mechanisms.Drive;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +26,7 @@ import org.wpilib.driverstation.DriverStation;
 import org.wpilib.driverstation.MatchState;
 import org.wpilib.driverstation.RobotState;
 import org.wpilib.framework.OpModeRobot;
+import org.wpilib.hardware.hal.util.HalHandleException;
 import org.wpilib.hardware.power.PowerDistribution;
 import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.trajectory.HolonomicTrajectory;
@@ -84,6 +86,16 @@ public class Robot extends OpModeRobot {
 
   private long lastWakeUs;
 
+  // The HAL exposes no capability query, so a read it does not implement is discoverable only by
+  // making it. Whether it is implemented is fixed for the session, so these are probed once here
+  // rather than caught every loop.
+  private final boolean hasBatteryVoltage;
+  private final boolean hasCommsDisableCount;
+  private final boolean hasCpuTemp;
+  private final boolean hasSysActive;
+  private final boolean hasRail3V3;
+  private final boolean hasCanStatus;
+
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.
@@ -115,6 +127,38 @@ public class Robot extends OpModeRobot {
     railLog = robotLog.getTable("Rail3V3");
     pdhLog = robotLog.getTable("Pdh");
     pdh = openPdh();
+
+    var unavailable = new ArrayList<String>();
+    // getVinVoltage warns and returns 0 rather than throwing, so it is probed by its value. A
+    // robot far enough along to run this line is never at 0 V.
+    hasBatteryVoltage = RobotController.getBatteryVoltage() > 0;
+    if (!hasBatteryVoltage) {
+      unavailable.add("BatteryVoltage");
+    }
+    hasCommsDisableCount =
+        implemented(unavailable, "CommsDisableCount", RobotController::getCommsDisableCount);
+    hasCpuTemp = implemented(unavailable, "CpuTemp", RobotController::getCPUTemp);
+    hasSysActive = implemented(unavailable, "SysActive", RobotController::isSysActive);
+    hasCanStatus =
+        implemented(
+            unavailable, "Can/Bus0/*", () -> RobotController.getCANStatus(Constants.CAN_BUS));
+
+    // The fault count is what this group is for: it separates a sensor that failed from a rail
+    // that browned out under it. The voltage alone is a hardcoded constant on some platforms, so
+    // it is logged only alongside the count that makes it worth reading.
+    boolean railCurrent =
+        implemented(unavailable, "Rail3V3/Current", RobotController::getCurrent3V3);
+    boolean railFaults =
+        implemented(unavailable, "Rail3V3/FaultCount", RobotController::getFaultCount3V3);
+    hasRail3V3 = railCurrent && railFaults;
+
+    if (!unavailable.isEmpty()) {
+      new Alert(
+              "hal-unimplemented",
+              "Signals this platform cannot source: " + String.join(", ", unavailable),
+              Level.LOW)
+          .set(true);
+    }
 
     // A brownout that held for the whole match and a brownout signal that stopped being written
     // are otherwise the same bytes on disk.
@@ -183,6 +227,18 @@ public class Robot extends OpModeRobot {
         FieldConstants.forCurrentAlliance(trajectories.get(name)));
   }
 
+  // An unimplemented read reports -1098, which is the HAL's not-implemented sentinel rather than
+  // a bad handle. Naming the signal here is what puts it in the startup alert.
+  private static boolean implemented(List<String> unavailable, String name, Runnable read) {
+    try {
+      read.run();
+      return true;
+    } catch (HalHandleException e) {
+      unavailable.add(name);
+      return false;
+    }
+  }
+
   private static PowerDistribution openPdh() {
     try {
       return new PowerDistribution(Constants.CAN_BUS);
@@ -199,18 +255,26 @@ public class Robot extends OpModeRobot {
     robotLog.log("LoopDelta", Microseconds.of(wake - lastWakeUs));
     lastWakeUs = wake;
 
-    robotLog.log("BatteryVoltage", RobotController.getMeasureBatteryVoltage());
+    if (hasBatteryVoltage) {
+      robotLog.log("BatteryVoltage", RobotController.getMeasureBatteryVoltage());
+    }
     robotLog.log("BrownedOut", RobotController.isBrownedOut());
-    robotLog.log("CommsDisableCount", RobotController.getCommsDisableCount());
-    robotLog.log("CpuTemp", RobotController.getMeasureCPUTemp());
-    robotLog.log("InputVoltage", RobotController.getMeasureInputVoltage());
-    robotLog.log("SysActive", RobotController.isSysActive());
+    if (hasCommsDisableCount) {
+      robotLog.log("CommsDisableCount", RobotController.getCommsDisableCount());
+    }
+    if (hasCpuTemp) {
+      robotLog.log("CpuTemp", RobotController.getMeasureCPUTemp());
+    }
+    if (hasSysActive) {
+      robotLog.log("SysActive", RobotController.isSysActive());
+    }
 
-    // The 3.3 V rail feeds the sensors. Its fault count is what separates a sensor that failed
-    // from a rail that browned out under it.
-    railLog.log("Voltage", RobotController.getMeasureVoltage3V3());
-    railLog.log("Current", RobotController.getMeasureCurrent3V3());
-    railLog.log("FaultCount", RobotController.getFaultCount3V3());
+    // The 3.3 V rail feeds the sensors.
+    if (hasRail3V3) {
+      railLog.log("Voltage", RobotController.getMeasureVoltage3V3());
+      railLog.log("Current", RobotController.getMeasureCurrent3V3());
+      railLog.log("FaultCount", RobotController.getFaultCount3V3());
+    }
 
     if (pdh != null) {
       robotLog.log("Pdh", pdh);
@@ -247,12 +311,14 @@ public class Robot extends OpModeRobot {
     // OpModeRobot does not run the Commands v3 scheduler.
     Scheduler.getDefault().run();
 
-    var can = RobotController.getCANStatus(Constants.CAN_BUS);
-    canLog.log("Utilization", can.percentBusUtilization);
-    canLog.log("ReceiveErrors", can.receiveErrorCount);
-    canLog.log("TransmitErrors", can.transmitErrorCount);
-    canLog.log("BusOff", can.busOffCount);
-    canLog.log("TxFull", can.txFullCount);
+    if (hasCanStatus) {
+      var can = RobotController.getCANStatus(Constants.CAN_BUS);
+      canLog.log("Utilization", can.percentBusUtilization);
+      canLog.log("ReceiveErrors", can.receiveErrorCount);
+      canLog.log("TransmitErrors", can.transmitErrorCount);
+      canLog.log("BusOff", can.busOffCount);
+      canLog.log("TxFull", can.txFullCount);
+    }
   }
 
   @Override

--- a/src/test/java/first/robot/WiringTest.java
+++ b/src/test/java/first/robot/WiringTest.java
@@ -76,6 +76,7 @@ class WiringTest {
 
     double displacement;
     List<String> raised;
+    boolean halUnimplemented;
     try {
       thread.start();
       SimHooks.waitForProgramStart();
@@ -108,6 +109,10 @@ class WiringTest {
       displacement = robot.poseEstimator.getEstimatedPose().getTranslation().getNorm();
       raised = new ArrayList<>(highAlerts());
       raised.removeAll(before);
+
+      // The simulation HAL implements every read the startup probe makes, so a rejection here is
+      // the probe being wrong rather than the platform being thin.
+      halUnimplemented = alertActive("hal-unimplemented");
     } finally {
       robot.endCompetition();
       thread.join((long) SHUTDOWN.in(Milliseconds));
@@ -119,6 +124,7 @@ class WiringTest {
     // Before the displacement, which a robot whose thread died also fails, and less usefully.
     assertNull(failure.get());
     assertEquals(List.of(), raised);
+    assertFalse(halUnimplemented, "the probe rejected a signal simulation implements");
     assertTrue(
         displacement > MOVED.in(Meters),
         "expected displacement > " + MOVED.in(Meters) + ", was " + displacement);
@@ -135,6 +141,11 @@ class WiringTest {
 
   private static List<String> names(OpModeOption[] options) {
     return Arrays.stream(options).map(o -> o.name).toList();
+  }
+
+  private static boolean alertActive(String id) {
+    return Arrays.stream(AlertDataJNI.getAlerts())
+        .anyMatch(a -> a.activeStartTime != 0 && id.equals(a.id));
   }
 
   private static List<String> highAlerts() {


### PR DESCRIPTION
Resolves #107. Amends ADR 0005 and ADR 0014.

#94 established that six of ADR 0005's always-on signals are HAL stubs on this
image — `-1098`, WPILib's not-implemented sentinel — plus the whole
`/Robot/Can/Bus0` block, and that five of them threw and took the JVM with them
on the first `robotPeriodic` pass.

## The rule

**Probe each HAL read once at startup; log only what answered.** The HAL exposes
no `isSupported()`, so a read is discoverable only by making it, and whether it
is implemented is fixed for the session — a per-loop `try`/`catch` would pay
every iteration for an answer that cannot change.

Probing rather than branching on `RobotBase.isSimulation()`, which would be right
for the wrong reason: these reads work in simulation because the simulation HAL
implements them, not because it is simulation. A later image that implements
`HAL_GetCPUTemp` restores the signal on its own under a probe, and stays
suppressed forever under the branch.

A `hal-unimplemented` alert names the rejected set once at startup, so the
absence reaches `/Robot/Alerts` and the Driver Station rather than being inferred
from a missing name.

The rule is scoped to HAL reads. A mechanism signal comes from REVLib and fails
differently — ADR 0004 already rules that config errors alert and never block.

## Two schema corrections, not platform gaps

- **`/Robot/InputVoltage` deleted, on every platform.** `getInputVoltage()`
  (`:182`) and `getBatteryVoltage()` (`:117`) are both `PowerJNI.getVinVoltage()`
  — one call under two names. A duplicate row from the day it was written; the
  SystemCore only made it visible.
- **`/Robot/Rail3V3/Voltage` logged only beside its fault count.**
  `HAL_GetUserVoltage3V3` returns a literal `3.3` and never writes status
  (`systemcore/Power.cpp:42-47`), so no probe can catch it — it succeeds and
  lies. The group exists for the fault count, which separates a sensor that
  failed from a rail that browned out under it.

## `BatteryVoltage` is a third case

Implemented, failing at runtime with `HAL_INCOMPATIBLE_STATE` (`1015`), which
does not throw — so it is probed by its value instead. A robot far enough along
to run the probe is never at 0 V.

Worth calling out: on a positive status the JNI walks the Java stack, formats it
and prints it (`HALUtil.cpp:109-118`). At ADR 0002's 5 ms period that is a stack
walk and a console line **200 times a second**, folded into the same WPILOG by
`DataLogManager` — the failing signal was flooding the log it exists to inform.
#94 called this non-fatal; it is non-fatal and not cheap.

Why the read fails stays #108's.

## ADR 0014

Class 1 loses two of its five anchors on this image. A missing anchor is now
reported as **unavailable**, never as **clear** — otherwise the sweep reports the
absence of a signal as the absence of a fault.

## Verification

`./gradlew build` green. `WiringTest` gains an assertion that
`hal-unimplemented` does **not** fire in simulation — the simulation HAL
implements every probed read (`sim/HAL.cpp:183,191`, `sim/Power.cpp:31,37,99`,
`sim/CAN.cpp:54`), so a rejection there is the probe being wrong rather than the
platform being thin.

Hardware verification on `192.168.1.202` to follow on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)