### PR TITLE
Gate BrownedOut on the battery voltage probe (#118)

### DIFF
--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -12,7 +12,9 @@ the *Open* item on how `/Tunables` reaches the file records its first
 instance. Amended 2026-08-30 by #107: a HAL read the platform does not
 implement is probed once and then not logged, `/Robot/InputVoltage` is
 deleted as a duplicate, and `/Robot/Rail3V3/Voltage` is logged only
-beside its fault count.
+beside its fault count. Amended 2026-08-30 by #118: `/Robot/BrownedOut`
+is gated on the battery voltage probe, because the two are one MRC
+power interface and only the voltage has a value to probe by.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -126,7 +128,7 @@ habits below.
 |---|---|
 | `/Robot/LoopDelta` | wake-to-wake delta, ours to compute — ADR 0002 |
 | `/Robot/BatteryVoltage` † | `RobotController.getBatteryVoltage()` (`:117`) |
-| `/Robot/BrownedOut` | `RobotController.isBrownedOut()` (`:145`) |
+| `/Robot/BrownedOut` † | `RobotController.isBrownedOut()` (`:145`) |
 | `/Robot/CommsDisableCount` † | `RobotController.getCommsDisableCount()` (`:155`) |
 | `/Robot/CpuTemp` † | `RobotController.getCPUTemp()` (`:296`) |
 | `/Robot/Can/Bus0/{Utilization,ReceiveErrors,TransmitErrors,BusOff,TxFull}` † | `RobotController.getCANStatus(CANBus)` (`:315`), fields on `CANStatus` (`:10-22`) |
@@ -144,9 +146,9 @@ habits below.
 `wpilibj/src/main/java/org/wpilib/system/RobotController.java` and
 `hal/src/main/java/org/wpilib/hardware/hal/can/CANStatus.java`.
 
-**†** — present only where the platform implements the read. Every one
-of these is absent on the SystemCore image ADR 0002 records and present
-in simulation. See *A HAL read the platform does not implement is not
+**†** — present only where the platform's read answers. Every one of
+these is absent on the SystemCore image ADR 0002 records and present in
+simulation. See *A HAL read the platform does not implement is not
 logged*, below.
 
 `LoopDelta` is the one signal in that table nothing in the framework
@@ -273,17 +275,41 @@ rather than by an exception: a robot far enough along to run the probe
 is never at 0 V. Why the read fails is #108's, not this ADR's.
 **[decided]**
 
-**A boolean read cannot be probed at all, and one is outstanding.**
-`HAL_GetBrownedOut` fails the same way on this image, and returns
-`false` when it does (`systemcore/HAL.cpp:191-201`) **[source]** —
-which is also a valid reading. There is no value to probe by and no
-Java-side route to the status, because `DriverStationErrors` reports
-errors and never exposes them. So `/Robot/BrownedOut` still logs, and
-what it logs is `false` whether or not the robot browned out. #94
-recorded this as the one always-on read that worked; that was true of
-the console call and not of the loop, where the `-1098` throws in front
-of it were masking it. This rule names the case it cannot reach rather
-than implying it covers it. What to do about it is #118.
+**A boolean read cannot be probed at all, so one signal is gated on
+another.** `HAL_GetBrownedOut` fails the same way on this image and
+returns `false` when it does (`systemcore/HAL.cpp:191-201`)
+**[source]** — which is also a valid reading. There is no value to
+probe by: a boolean has no invalid one, and there is no Java-side route
+to the status. `DriverStationErrors` reports errors and never exposes
+them (`DriverStationErrors.java:19-59`) **[source]**, `HAL_GetLastError`
+has no Java binding at all, and `ControlWord` carries no brownout bit
+**[executed]**.
+
+So `/Robot/BrownedOut` is gated on the `/Robot/BatteryVoltage` probe
+rather than probed for itself, and named in the `hal-unimplemented`
+alert when that probe fails. The two are one interface —
+`MRC_Systemcore_GetBatteryVoltage` (`systemcore/Power.cpp:33`) and
+`MRC_Systemcore_GetBrownedOut` (`systemcore/HAL.cpp:194`) **[source]**
+— and on this image they fail together, in the same loop, where #94 saw
+both succeed on the console. Only the voltage has a value to probe by,
+so the voltage answers for both. **[decided]**
+
+This is the one signal in the list whose availability is *inferred*
+rather than measured, and calling it a coupling rather than a probe is
+the point: the field is `hasMrcPower`, not `hasBatteryVoltage`, because
+one flag now gates two signals and the narrower name would lie at the
+second use site. It keeps the property the probe rule is for — an image
+that fixes the MRC power reads restores both signals with no code
+change, and #108 owns why they fail. If one recovers without the other,
+this inference is what will be wrong, and the alert naming both is where
+that shows up.
+
+The alternative was to keep logging `false`. #94 recorded `BrownedOut`
+as the one always-on read that worked; that was true of the console call
+and not of the loop, where the `-1098` throws in front of it were
+masking it. A boolean safety signal reading *not browned out* when the
+truth is unknown is worse than the `Rail3V3/Voltage` constant above,
+which at least never claimed to be a fault indicator. **[decided]**
 
 ### Names are PascalCase, and units are never in the name
 
@@ -782,6 +808,22 @@ path to the same fact carrying less information.
 A tick count needs a conversion factor to mean anything, and the SHA
 already pins the conversion factor. We log the derived value in real
 units.
+
+### Deriving `BrownedOut` from the power distribution hub
+
+The PDH reaches the SystemCore over CAN and not through MRC —
+`HAL_GetPowerDistributionVoltage` dispatches to `HAL_GetREVPDHVoltage`
+(`systemcore/PowerDistribution.cpp:139-146`) **[source]** — so
+`/Robot/Pdh/Voltage` is a battery voltage that works on the image where
+`/Robot/BatteryVoltage` does not, and a brownout threshold over it would
+restore both. There is a PDH on the robot, so this was available.
+
+Rejected because the MRC power reads are a beta artifact, not a property
+of the platform. A probe restores the real signals for free the day the
+image is fixed; a derived brownout would still be there, on a different
+bus, with a threshold we chose, diverging from what every other team's
+log means by the same name. Routing around a temporary bug is not worth
+a permanent departure. **[decided]**
 
 ## Source
 

--- a/docs/adr/0014-ai-log-analysis-contract.md
+++ b/docs/adr/0014-ai-log-analysis-contract.md
@@ -7,7 +7,10 @@ parser: `robotpy-wpilog` **does** exist for 2027 and works. The decision
 is unchanged and the reason is now coupling rather than absence — see
 *Rejected* and *Source*. Amended 2026-08-30 by #107: a class-1 anchor
 the platform could not source is reported as *unavailable*, never as
-*clear*.
+*clear*. Amended 2026-08-30 by #118: `/Robot/BrownedOut` joins that
+set, taking class 1 to three unavailable anchors of five on this image;
+the rule composes over three as it did over two, and there is no
+class-level verdict.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -294,8 +297,9 @@ it, and never opening pose error at all.
 **A missing anchor is reported as *unavailable*, never as *clear*.**
 ADR 0005 lets the platform decide whether a HAL-sourced signal exists
 at all, and class 1 is where that bites: on the SystemCore image ADR
-0002 records, `/Robot/Can/Bus0/*` and `/Robot/BatteryVoltage` are both
-absent, which is two of that class's five anchors. `list` is what makes
+0002 records, `/Robot/Can/Bus0/*`, `/Robot/BatteryVoltage` and
+`/Robot/BrownedOut` are all absent, which is three of that class's five
+anchors — leaving `/Robot/LoopDelta` and `/Robot/Alerts`. `list` is what makes
 this legible — step 2 of every run exists to stop the agent querying
 signals the log does not have — but a signal that was never recorded
 and a signal that recorded no problem are the same nothing at query

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -89,7 +89,7 @@ public class Robot extends OpModeRobot {
   // The HAL exposes no capability query, so a read it does not implement is discoverable only by
   // making it. Whether it is implemented is fixed for the session, so these are probed once here
   // rather than caught every loop.
-  private final boolean hasBatteryVoltage;
+  private final boolean hasMrcPower;
   private final boolean hasCommsDisableCount;
   private final boolean hasCpuTemp;
   private final boolean hasSysActive;
@@ -129,11 +129,14 @@ public class Robot extends OpModeRobot {
     pdh = openPdh();
 
     var unavailable = new ArrayList<String>();
-    // getVinVoltage warns and returns 0 rather than throwing, so it is probed by its value. A
-    // robot far enough along to run this line is never at 0 V.
-    hasBatteryVoltage = RobotController.getBatteryVoltage() > 0;
-    if (!hasBatteryVoltage) {
+    // BatteryVoltage and BrownedOut are the same MRC power interface, and only the voltage has a
+    // value to probe by: getVinVoltage warns and returns 0 rather than throwing, and a robot far
+    // enough along to run this line is never at 0 V. A failing brownout read returns false, which
+    // is also a valid reading, so it is gated on the voltage rather than probed for itself.
+    hasMrcPower = RobotController.getBatteryVoltage() > 0;
+    if (!hasMrcPower) {
       unavailable.add("BatteryVoltage");
+      unavailable.add("BrownedOut");
     }
     hasCommsDisableCount =
         implemented(unavailable, "CommsDisableCount", RobotController::getCommsDisableCount);
@@ -255,10 +258,10 @@ public class Robot extends OpModeRobot {
     robotLog.log("LoopDelta", Microseconds.of(wake - lastWakeUs));
     lastWakeUs = wake;
 
-    if (hasBatteryVoltage) {
+    if (hasMrcPower) {
       robotLog.log("BatteryVoltage", RobotController.getMeasureBatteryVoltage());
+      robotLog.log("BrownedOut", RobotController.isBrownedOut());
     }
-    robotLog.log("BrownedOut", RobotController.isBrownedOut());
     if (hasCommsDisableCount) {
       robotLog.log("CommsDisableCount", RobotController.getCommsDisableCount());
     }


### PR DESCRIPTION
Closes #118.

`/Robot/BrownedOut` logged 18,603 samples of `false` on the SystemCore while the journal repeated `Incompatible State` from `HAL.getBrownedOut`. `HAL_GetBrownedOut` returns `false` when its MRC read fails (`systemcore/HAL.cpp:191-201`), so the signal was reporting *not browned out* whenever the truth was unknown — the failure mode ADR 0005 exists to prevent, in every log we record.

#107's probe rule cannot reach it. A boolean has no invalid value, and there is no Java-side route to the status: `HAL_GetLastError` has no Java binding anywhere in `hal/src/main/java` or `wpilibj/src/main/java`, `DriverStationErrors` only reports, and `ControlWord` carries no brownout bit.

**So it is gated rather than probed.** `MRC_Systemcore_GetBatteryVoltage` (`systemcore/Power.cpp:33`) and `MRC_Systemcore_GetBrownedOut` (`systemcore/HAL.cpp:194`) are one interface, failing together in the same loop; only the voltage has a value to probe by, so the voltage answers for both. The field is `hasMrcPower`, not `hasBatteryVoltage`, because one flag now gates two signals.

This is the only signal whose availability is *inferred*, and the ADR says so. It keeps what the probe rule is for: a fixed image restores both with no code change.

### Rejected: deriving brownout from the PDH

The PDH reaches the board over CAN rather than MRC (`systemcore/PowerDistribution.cpp:139-146`), and there is one on the robot, so this was available. The MRC reads are a beta artifact; a derived brownout would outlive the bug, on another bus, with a threshold we chose, meaning something different from every other team's signal of the same name. Recorded in ADR 0005's *Rejected*.

### ADRs

- **ADR 0005** — the outstanding-boolean paragraph becomes the coupling rule; `/Robot/BrownedOut` gains its †; the PDH rejection is recorded.
- **ADR 0014** — class 1 goes to three unavailable anchors of five on this image, leaving `LoopDelta` and `Alerts`. The per-anchor *unavailable, never clear* rule composes over three as it did over two; no class-level verdict was added.

### Verified on hardware

`192.168.1.202`, image `932ee883`, 2026-08-30.

- **`NRestarts=0`**, startup complete reached.
- **One** `Incompatible State`, at `Robot.java:136` — the constructor probe — instead of 200 a second from `robotPeriodic`.
- `/Telemetry/Robot/BrownedOut` **absent from the log entirely**; no entry declared, not a zero.
- The alert, read back out of the WPILOG: `Signals this platform cannot source: BatteryVoltage, BrownedOut, CommsDisableCount, CpuTemp, SysActive, Can/Bus0/*, Rail3V3/Current, Rail3V3/FaultCount`.
- `/Telemetry/Robot/LoopDelta` carries 6,313 samples, so the loop runs at rate.

`WiringTest` already covers the simulation side: the sim HAL implements `getVinVoltage`, so the coupling never fires there and `assertFalse(halUnimplemented, ...)` catches it if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)