### PR TITLE
Update to WPILib 2027 alpha-7

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
     "enableCppIntellisense": false,
     "currentLanguage": "java",
-    "projectYear": "2027_alpha5",
+    "projectYear": "2027_alpha7",
     "teamNumber": 8852
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,21 @@ examples.
 - `SwerveModuleState` is now `SwerveModuleVelocity`.
 - `vxMetersPerSecond` and `vyMetersPerSecond` are now `vx` and `vy`.
 - `MathUtil` is now `math.util`; `LinearSystemId` is now `Models`.
+- `CANBus` is now `CANPort`; the maven artifact `commands3-java` is now
+  `commandsv3-java`. The `org.wpilib.command3` package name did not change.
+- Geometry constants lost the `k` prefix: `Rotation2d.kZero` is `ZERO`, `kPi` is
+  `PI`, `kCCW_Pi_2` is `CCW_PI_2`.
 - `Sendable`, `SmartDashboard`, `RobotContainer`, `Subsystem`, and several old
   command classes are gone. Mechanisms are fields on `Robot`; opmodes own
   bindings.
 
 Field hazards that still compile:
 
+- The WPI clock is nanoseconds, not microseconds. `RobotController.getTime()`,
+  `getMonotonicTime()`, `getLoopStartTime()`, `wpi::Now()`, an alert's
+  `activeStartTime` and DataLog record stamps all changed base in alpha-7 with
+  no change of signature, so a stale `Microseconds.of(...)` is off by 1000 and
+  still compiles. `Timer` still answers seconds.
 - `Rotation2d` uses `[-0.5, 0.5]` rotations; the steer sensor uses `[0, 1)`.
 - Use the two-argument `ChassisAccelerations.toWheelAccelerations()` so it keeps
   the centripetal term.
@@ -35,6 +44,16 @@ Field hazards that still compile:
 - Getters return `Signal<T>`, not plain doubles.
 - `configure()` can throw or return an error. Check for both.
 - Analog sensors have no zero offset. Apply the module offset to the setpoint.
+
+## Vendor deps
+
+GradleRIO refuses to configure if a vendordep's `wpilibYear` is not the exact
+year string of the WPILib being built against, and no third-party vendor has
+published an alpha-7 build yet. `wpilibYear` is edited to `2027_alpha7` by hand
+in `REVLib.json`, `Phoenix6-*.json` and `photonlib.json`; the pinned artifact
+versions are untouched, so this asserts a compatibility the tests have to carry.
+Re-importing any of them from its vendor URL reverts the field and the next
+build fails on the year rather than on anything real.
 
 ## Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,14 @@ examples.
 Field hazards that still compile:
 
 - The WPI clock is nanoseconds, not microseconds. `RobotController.getTime()`,
-  `getMonotonicTime()`, `getLoopStartTime()`, `wpi::Now()`, an alert's
-  `activeStartTime` and DataLog record stamps all changed base in alpha-7 with
-  no change of signature, so a stale `Microseconds.of(...)` is off by 1000 and
-  still compiles. `Timer` still answers seconds.
+  `getMonotonicTime()`, `getLoopStartTime()`, `wpi::Now()` and an alert's
+  `activeStartTime` all changed base in alpha-7 with no change of signature, so
+  a stale `Microseconds.of(...)` is off by 1000 and still compiles. `Timer`
+  still answers seconds.
+- The WPILOG *file* still stores microseconds. `DataLog` divides the
+  nanoseconds it is given, and `DataLogRecord.getTimestamp()` multiplies them
+  back, so the Java API is nanoseconds in both directions and only a
+  hand-rolled parser sees the microseconds on disk.
 - `Rotation2d` uses `[-0.5, 0.5]` rotations; the steer sensor uses `[0, 1)`.
 - Use the two-argument `ChassisAccelerations.toWheelAccelerations()` so it keeps
   the centripetal term.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Read these before changing code:
 
 1. Install JDK 25 and the WPILib 2027 VSCode extension.
 2. Clone the repository and open it in VSCode.
-3. Run `./gradlew simulateJava` to start the simulation.
+3. Run `./gradlew run` to start the simulation.
 4. Run `./gradlew test` to run tests without hardware.
 5. Run `./gradlew sysidLog` when working on SysId. Its log describes the
    simulation, not the real robot.

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,11 @@
 plugins {
     id "java"
-    id "org.wpilib.GradleRIO" version "2027.0.0-alpha-6"
-    id "com.gradleup.shadow" version "9.3.0"
+    id "application"
+    id "org.wpilib.GradleRIO" version "2027.0.0-alpha-7"
     // Departs from the template: the analyzers wired at the end of this file.
     id "com.diffplug.spotless" version "8.4.0"
     id "com.github.spotbugs" version "6.4.12"
 }
-
-// Departs from the template: 2027 has no stable release line yet, and a pinned development build
-// is evicted from that repository's rolling window within days.
-wpi.maven.useDevelopment = true
-wpi.versions.wpilibVersion = '2027.+'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_25
@@ -39,6 +34,9 @@ deploy {
                 // getTargetTypeClass is a shortcut to get the class type using a string
 
                 wpilibJava(getArtifactTypeClass('WPILibJavaArtifact')) {
+                    // Set to true to use debug including JNI, which will drastically impact performance.
+                    debugJni = false
+
                     // Departs from the template: see src/main/native/revshim. wpiutil comes
                     // first because the shim forwards a symbol into it and the JVM loads it
                     // RTLD_LOCAL, where a preloaded library cannot see it; this is the copy on
@@ -73,24 +71,14 @@ def revShimDesktop = file('src/main/native/revshim/linuxx86-64/librevshim.so').a
 
 def deployArtifact = deploy.targets.systemcore.artifacts.wpilibJava
 
-// Set to true to use debug for all targets including JNI, which will drastically impact
-// performance.
-wpi.java.debugJni = false
+// Set to true to use debug for simulation including JNI
+wpi.java.runSimWithDebugJni = false
 
 // Set this to true to enable desktop support.
 def includeDesktopSupport = true
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
-// Departs from the template: the two natives GradleRIO's JNI list omits, for the configuration
-// blocks below.
-def wpilibNatives = { String platform, boolean debug ->
-    def classifier = debug ? "${platform}debug" : platform
-    ['org.wpilib.telemetry:telemetry-cpp', 'org.wpilib.tunables:tunables-cpp'].collect {
-        "${it}:${wpi.versions.wpilibVersion.get()}:${classifier}@zip"
-    }
-}
-
 dependencies {
     annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
@@ -110,21 +98,6 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    // Departs from the template: wpilibj's telemetry and tunable APIs live in their own artifacts,
-    // and GradleRIO's wpilib() list carries neither, so classes RobotBase itself uses are absent
-    // from the compile classpath. Delete when wpilib() includes them.
-    implementation "org.wpilib.telemetry:telemetry-java:${wpi.versions.wpilibVersion.get()}"
-    implementation "org.wpilib.tunables:tunables-java:${wpi.versions.wpilibVersion.get()}"
-
-    // Departs from the template for the same omission one layer down: libwpimath.so declares
-    // libtelemetry.so and libtunables.so as NEEDED, and GradleRIO's JNI list carries neither, so
-    // loading wpimathjni throws. Anything that discretizes a plant hits it. Delete when
-    // wpilibJniRelease includes them.
-    systemcoreDebug wpilibNatives(wpi.platforms.systemcore, true)
-    systemcoreRelease wpilibNatives(wpi.platforms.systemcore, false)
-    nativeDebug wpilibNatives(wpi.platforms.desktop, true)
-    nativeRelease wpilibNatives(wpi.platforms.desktop, false)
-
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -141,12 +114,6 @@ tasks.withType(Test).configureEach {
     // the JVM, and the next class to want its own gets the first one's.
     forkEvery = 1
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
-    // Departs from the template: GradleRIO adds these to the sim and deploy JVMs but not to test.
-    // Commands v3 privateLookupIn's jdk.internal.vm.Continuation(Scope) and java.lang.Thread, and
-    // scheduling loadLibrary's the HAL. Delete when configureTestTasks supplies the flags.
-    jvmArgs '--add-opens', 'java.base/jdk.internal.vm=ALL-UNNAMED',
-            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
-            '--enable-native-access=ALL-UNNAMED'
 }
 
 // The characterisation harness, pointed at a file a human can drag into the SysId analyser rather
@@ -166,29 +133,27 @@ tasks.register('sysidLog', Test) {
 }
 
 // Simulation configuration (e.g. environment variables).
-tasks.withType(org.wpilib.gradlerio.simulation.JavaSimulationTask).configureEach {
-    environment 'LD_PRELOAD', revShimDesktop
-}
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-// Setting up my Jar File. In this case, adding all libraries into the main jar ('fat/shaded jar')
-// in order to make them all available at runtime and merging service files to make JSON work.
-// Also adding the manifest so WPILib knows where to look for our Robot Class.
-shadowJar {
-    mergeServiceFiles()
+application.mainClass = ROBOT_MAIN_CLASS
+
+deployArtifact.configureApplication(application)
+wpi.java.configureApplication(application)
+wpi.java.configureTestTasks(test)
+wpi.java.configureTestTasks(tasks.named('sysidLog').get())
+
+// Departs from the template: simulation runs through the application plugin's JavaExec tasks now,
+// and they need the same preload as the tests.
+tasks.withType(JavaExec).configureEach {
+    environment 'LD_PRELOAD', revShimDesktop
+}
+
+jar {
     from('src') { into 'backup/src' }
     from('vendordeps') { into 'backup/vendordeps' }
     from('build.gradle') { into 'backup' }
-    manifest org.wpilib.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
-
-// Configure jar and deploy tasks
-deployArtifact.jarTask = shadowJar
-wpi.java.configureExecutableTasks(shadowJar)
-wpi.java.configureTestTasks(test)
-wpi.java.configureTestTasks(tasks.named('sysidLog').get())
 
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ import org.gradle.internal.os.OperatingSystem
 
 pluginManagement {
     repositories {
-        String wpilibYear = '2027_alpha5'
+        String wpilibYear = '2027_alpha7'
         File wpilibHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')

--- a/src/main/java/first/robot/Constants.java
+++ b/src/main/java/first/robot/Constants.java
@@ -8,7 +8,7 @@ import static org.wpilib.units.Units.Milliseconds;
 import static org.wpilib.units.Units.Seconds;
 
 import java.net.URI;
-import org.wpilib.hardware.bus.CANBus;
+import org.wpilib.hardware.bus.CANPort;
 import org.wpilib.units.measure.Time;
 
 public final class Constants {
@@ -19,7 +19,7 @@ public final class Constants {
   public static final Time ALERT_LOG_PERIOD = Milliseconds.of(250);
 
   // Every device is on this one bus. REVLib wants its .value, Phoenix wants CANBus.systemcore(n).
-  public static final CANBus CAN_BUS = CANBus.CAN_S0;
+  public static final CANPort CAN_BUS = CANPort.CAN_S0;
 
   public static final int DRIVER_PORT = 0;
 

--- a/src/main/java/first/robot/FieldConstants.java
+++ b/src/main/java/first/robot/FieldConstants.java
@@ -63,7 +63,7 @@ public final class FieldConstants {
   }
 
   public static Pose2d flip(Pose2d pose) {
-    return new Pose2d(-pose.getX(), -pose.getY(), pose.getRotation().rotateBy(Rotation2d.kPi));
+    return new Pose2d(-pose.getX(), -pose.getY(), pose.getRotation().rotateBy(Rotation2d.PI));
   }
 
   // Reflect across the field's long axis (y = 0).

--- a/src/main/java/first/robot/PoseEstimator.java
+++ b/src/main/java/first/robot/PoseEstimator.java
@@ -55,7 +55,7 @@ public final class PoseEstimator {
         kinematics,
         gyroHeading,
         modulePositions,
-        Pose3d.kZero,
+        Pose3d.ZERO,
         DriveConstants.STATE_STD_DEVS,
         UNSET_VISION_STD_DEVS);
   }

--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -6,8 +6,8 @@ package first.robot;
 
 import static org.wpilib.units.Units.Celsius;
 import static org.wpilib.units.Units.Joules;
-import static org.wpilib.units.Units.Microseconds;
 import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Nanoseconds;
 import static org.wpilib.units.Units.Seconds;
 
 import first.robot.mechanisms.Drive;
@@ -84,7 +84,7 @@ public class Robot extends OpModeRobot {
           .build();
   private CompletableFuture<HttpResponse<String>> radioStatus;
 
-  private long lastWakeUs;
+  private long lastWakeNanos;
 
   // The HAL exposes no capability query, so a read it does not implement is discoverable only by
   // making it. Whether it is implemented is fixed for the session, so these are probed once here
@@ -209,7 +209,7 @@ public class Robot extends OpModeRobot {
     // they have to know idle() would have defaulted to.
     drive.setDefaultCommand(drive.idle());
 
-    lastWakeUs = RobotController.getMonotonicTime();
+    lastWakeNanos = RobotController.getMonotonicTime();
     // The first sendAsync costs ~8 ms while the client starts its machinery, which is over the
     // whole loop period. Paid here, where nothing is timing anything.
     radioStatus = request();
@@ -255,8 +255,8 @@ public class Robot extends OpModeRobot {
   @Override
   public void robotPeriodic() {
     long wake = getLoopStartTime();
-    robotLog.log("LoopDelta", Microseconds.of(wake - lastWakeUs));
-    lastWakeUs = wake;
+    robotLog.log("LoopDelta", Nanoseconds.of(wake - lastWakeNanos));
+    lastWakeNanos = wake;
 
     if (hasMrcPower) {
       robotLog.log("BatteryVoltage", RobotController.getMeasureBatteryVoltage());
@@ -378,7 +378,7 @@ public class Robot extends OpModeRobot {
     alertLog.log("Levels", active.stream().map(Robot::levelName).toArray(String[]::new));
     alertLog.log(
         "StartTimes",
-        active.stream().mapToDouble(a -> Microseconds.of(a.activeStartTime).in(Seconds)).toArray());
+        active.stream().mapToDouble(a -> Nanoseconds.of(a.activeStartTime).in(Seconds)).toArray());
   }
 
   private static String levelName(AlertInfo alert) {

--- a/src/main/java/first/robot/mechanisms/Drive.java
+++ b/src/main/java/first/robot/mechanisms/Drive.java
@@ -400,7 +400,7 @@ public class Drive implements Mechanism {
 
   private void characteriseDrive(Voltage volts) {
     for (var module : modules) {
-      module.characteriseDrive(Rotation2d.kZero, volts);
+      module.characteriseDrive(Rotation2d.ZERO, volts);
     }
   }
 

--- a/src/main/java/first/robot/opmode/DrivePathCheck.java
+++ b/src/main/java/first/robot/opmode/DrivePathCheck.java
@@ -28,7 +28,7 @@ public class DrivePathCheck implements OpMode {
   private static final LinearVelocity LEG_SPEED = MetersPerSecond.of(1);
   private static final Time LEG_DURATION = Seconds.of(1.5);
   private static final Time SETTLE = Seconds.of(0.5);
-  private static final Pose2d START = Pose2d.kZero;
+  private static final Pose2d START = Pose2d.ZERO;
 
   // The square closes, so whatever pose the estimator reports at the end is the whole of the
   // odometry error. Nothing here needs a ground truth, which is what makes it the same check on

--- a/src/main/java/first/robot/sim/SwerveDriveSim.java
+++ b/src/main/java/first/robot/sim/SwerveDriveSim.java
@@ -34,7 +34,7 @@ public final class SwerveDriveSim {
   private final double[] driveAppliedVolts = new double[MODULES];
   private final double[] steerAppliedVolts = new double[MODULES];
 
-  private Pose2d pose = Pose2d.kZero;
+  private Pose2d pose = Pose2d.ZERO;
   private ChassisVelocities velocity = new ChassisVelocities();
   private double batteryVolts = BatterySim.calculateDefaultBatteryLoadedVoltage();
   private double appliedRailVolts = batteryVolts;

--- a/src/test/java/first/robot/HolonomicPathFollowerTest.java
+++ b/src/test/java/first/robot/HolonomicPathFollowerTest.java
@@ -38,7 +38,7 @@ class HolonomicPathFollowerTest {
 
   private MockTelemetryBackend backend;
   private TelemetryTable log;
-  private Pose2d pose = Pose2d.kZero;
+  private Pose2d pose = Pose2d.ZERO;
   private double now;
 
   @BeforeEach
@@ -82,9 +82,9 @@ class HolonomicPathFollowerTest {
 
   @Test
   void aRobotSittingOnThePathIsHandedTheSamplesOwnVelocity() {
-    pose = new Pose2d(0, 0, Rotation2d.kZero);
+    pose = new Pose2d(0, 0, Rotation2d.ZERO);
 
-    var velocities = follower(straightAlongX(Rotation2d.kZero)).nextFieldRelativeVelocities();
+    var velocities = follower(straightAlongX(Rotation2d.ZERO)).nextFieldRelativeVelocities();
 
     assertEquals(SPEED, velocities.vx, TOLERANCE);
     assertEquals(0, velocities.vy, TOLERANCE);
@@ -95,9 +95,9 @@ class HolonomicPathFollowerTest {
   // rather than in the robot's. A robot facing +y that is a metre to the field's left needs -y.
   @Test
   void theCorrectionIsInFieldTermsRatherThanTheRobots() {
-    pose = new Pose2d(0, 0.1, Rotation2d.kCCW_Pi_2);
+    pose = new Pose2d(0, 0.1, Rotation2d.CCW_PI_2);
 
-    var velocities = follower(straightAlongX(Rotation2d.kCCW_Pi_2)).nextFieldRelativeVelocities();
+    var velocities = follower(straightAlongX(Rotation2d.CCW_PI_2)).nextFieldRelativeVelocities();
 
     assertEquals(SPEED, velocities.vx, TOLERANCE);
     assertEquals(-0.5, velocities.vy, TOLERANCE);
@@ -107,9 +107,9 @@ class HolonomicPathFollowerTest {
   void poseErrorIsReportedAlongAndAcrossTheTrackRatherThanInXAndY() {
     // Behind the sample in field +x, with the robot facing field +y: that is a whole rotation
     // away from being a lag, and x/y error alone cannot say so.
-    pose = new Pose2d(-0.3, 0, Rotation2d.kCCW_Pi_2);
+    pose = new Pose2d(-0.3, 0, Rotation2d.CCW_PI_2);
 
-    follower(straightAlongX(Rotation2d.kCCW_Pi_2)).nextFieldRelativeVelocities();
+    follower(straightAlongX(Rotation2d.CCW_PI_2)).nextFieldRelativeVelocities();
 
     assertEquals(0, backend.getLastValue("/AlongTrackError", Double.class), TOLERANCE);
     assertEquals(-0.3, backend.getLastValue("/CrossTrackError", Double.class), TOLERANCE);
@@ -117,28 +117,28 @@ class HolonomicPathFollowerTest {
 
   @Test
   void aPathWhoseClockRanOutSomewhereElseIsNotDone() {
-    var follower = follower(straightAlongX(Rotation2d.kZero));
-    pose = new Pose2d(0.5, 0, Rotation2d.kZero);
+    var follower = follower(straightAlongX(Rotation2d.ZERO));
+    pose = new Pose2d(0.5, 0, Rotation2d.ZERO);
 
     now = LENGTH / SPEED + 1;
 
     assertFalse(follower.isFinished(), "a robot half a path short of the end reported done");
 
-    pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
+    pose = new Pose2d(LENGTH, 0, Rotation2d.ZERO);
     assertTrue(follower.isFinished(), "a robot at the end of a finished path did not report done");
   }
 
   @Test
   void aPathThatHasNotRunItsDurationIsNotDoneEvenSittingOnTheEndPose() {
-    var follower = follower(straightAlongX(Rotation2d.kZero));
-    pose = new Pose2d(LENGTH, 0, Rotation2d.kZero);
+    var follower = follower(straightAlongX(Rotation2d.ZERO));
+    pose = new Pose2d(LENGTH, 0, Rotation2d.ZERO);
 
     assertFalse(follower.isFinished(), "a path reported done before it had run");
   }
 
   @Test
   void theTimeoutIsAMarginOverTheTrajectoryDurationRatherThanAnAbsolute() {
-    var follower = follower(straightAlongX(Rotation2d.kZero));
+    var follower = follower(straightAlongX(Rotation2d.ZERO));
 
     assertEquals(
         LENGTH / SPEED + CONFIG.timeoutMargin().in(Seconds),
@@ -153,12 +153,12 @@ class HolonomicPathFollowerTest {
             List.of(
                 new HolonomicSample(
                     0,
-                    Pose2d.kZero,
+                    Pose2d.ZERO,
                     new ChassisVelocities(),
                     new ChassisAccelerations(2.5, 0, 0.75)),
                 new HolonomicSample(
                     1,
-                    new Pose2d(1.25, 0, Rotation2d.kZero),
+                    new Pose2d(1.25, 0, Rotation2d.ZERO),
                     new ChassisVelocities(2.5, 0, 0.75),
                     new ChassisAccelerations(2.5, 0, 0.75))));
     var follower = follower(accelerating);

--- a/src/test/java/first/robot/PoseEstimatorTest.java
+++ b/src/test/java/first/robot/PoseEstimatorTest.java
@@ -141,7 +141,7 @@ class PoseEstimatorTest {
     advance(SETTLE);
 
     estimator.visionUpdate(
-        new Pose3d(new Pose2d(1, 0, Rotation2d.kZero)),
+        new Pose3d(new Pose2d(1, 0, Rotation2d.ZERO)),
         captured,
         VecBuilder.fill(0.1, 0.1, 0.1, 0.1));
 

--- a/src/test/java/first/robot/mechanisms/DriveSchedulingTest.java
+++ b/src/test/java/first/robot/mechanisms/DriveSchedulingTest.java
@@ -7,8 +7,8 @@ package first.robot.mechanisms;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.wpilib.units.Units.Microseconds;
 import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Nanoseconds;
 
 import first.robot.Constants;
 import first.robot.DriveConstants;
@@ -40,7 +40,7 @@ import org.wpilib.units.measure.Time;
 // of what the injection buys: a mechanism is testable with no RobotBase around it.
 //
 // Standing a v3 command up is also what loads the HAL and what calls privateLookupIn on
-// jdk.internal.vm, so a JVM without the --add-opens block in build.gradle fails here.
+// jdk.internal.vm, so a JVM without the --add-opens flags configureTestTasks supplies fails here.
 class DriveSchedulingTest {
   private static final Time STEP = Constants.LOOP_PERIOD;
   private static final Time HOLD = Milliseconds.of(100);
@@ -95,7 +95,7 @@ class DriveSchedulingTest {
     now = Milliseconds.zero();
     // Coroutine.wait and every scheduler event timestamp read RobotController.getTime(), whose
     // default source is a JNI call to a clock this test cannot move.
-    RobotController.setTimeSource(() -> (long) now.in(Microseconds));
+    RobotController.setTimeSource(() -> (long) now.in(Nanoseconds));
     EVENTS.clear();
     // The scheduler outlives each test, so what a test scheduled or bound is dropped here. A
     // default command is the one thing this cannot drop — there is no call that unregisters one —

--- a/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
+++ b/src/test/java/first/robot/mechanisms/SwerveModuleTest.java
@@ -53,16 +53,16 @@ class SwerveModuleTest {
   // way is braking and its share has to come back negative.
   @Test
   void aWheelDrivenAgainstTheAccelerationBrakesAgainstIt() {
-    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.kZero);
+    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.ZERO);
 
-    assertEquals(4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kZero), TOLERANCE);
-    assertEquals(-4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kPi), TOLERANCE);
+    assertEquals(4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.ZERO), TOLERANCE);
+    assertEquals(-4.0, SwerveModule.accelerationAlong(acceleration, Rotation2d.PI), TOLERANCE);
   }
 
   @Test
   void aWheelTurnedAcrossTheAccelerationTakesNoneOfIt() {
-    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.kZero);
+    var acceleration = new SwerveModuleAcceleration(4.0, Rotation2d.ZERO);
 
-    assertEquals(0, SwerveModule.accelerationAlong(acceleration, Rotation2d.kCCW_Pi_2), TOLERANCE);
+    assertEquals(0, SwerveModule.accelerationAlong(acceleration, Rotation2d.CCW_PI_2), TOLERANCE);
   }
 }

--- a/src/test/java/first/robot/sysid/CharacterisationTest.java
+++ b/src/test/java/first/robot/sysid/CharacterisationTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wpilib.units.Units.Amps;
 import static org.wpilib.units.Units.Meters;
 import static org.wpilib.units.Units.MetersPerSecond;
-import static org.wpilib.units.Units.Microseconds;
 import static org.wpilib.units.Units.Milliseconds;
+import static org.wpilib.units.Units.Nanoseconds;
 import static org.wpilib.units.Units.Radians;
 import static org.wpilib.units.Units.RadiansPerSecond;
 import static org.wpilib.units.Units.RotationsPerSecond;
@@ -122,7 +122,7 @@ class CharacterisationTest {
   private SimModuleState[] state;
   private double azimuthRate;
   private double yawRadians;
-  private Rotation2d lastRotation = Rotation2d.kZero;
+  private Rotation2d lastRotation = Rotation2d.ZERO;
   private Time now = Seconds.zero();
   private Log log;
 
@@ -488,7 +488,7 @@ class CharacterisationTest {
   // A reader of only what the analyser reads: the entry names, the numbers under them, and the
   // test-state strings.
   private record Log(List<String> entryNames, List<Sample> samples) {
-    private record Sample(String name, long timestampMicros, double value, String text) {}
+    private record Sample(String name, long timestampNanos, double value, String text) {}
 
     static Log read(Path file) throws IOException {
       var names = new ArrayList<String>();
@@ -551,7 +551,7 @@ class CharacterisationTest {
           samples.stream()
               .filter(sample -> sample.name.equals("sysid-test-state-" + logName))
               .filter(sample -> test.equals(sample.text))
-              .mapToLong(Sample::timestampMicros)
+              .mapToLong(Sample::timestampNanos)
               .summaryStatistics();
       if (stamps.getCount() == 0) {
         throw new AssertionError(test + " never ran on " + logName);
@@ -564,8 +564,8 @@ class CharacterisationTest {
       var window = window(logName, test);
       return samples.stream()
           .filter(sample -> sample.name.equals(entry))
-          .filter(sample -> sample.timestampMicros >= window.getMin())
-          .filter(sample -> sample.timestampMicros <= window.getMax())
+          .filter(sample -> sample.timestampNanos >= window.getMin())
+          .filter(sample -> sample.timestampNanos <= window.getMax())
           .map(Sample::value)
           .toList();
     }
@@ -575,16 +575,16 @@ class CharacterisationTest {
       long start = window(logName, test).getMin();
       return samples.stream()
           .filter(sample -> sample.name.equals(entry))
-          .filter(sample -> sample.timestampMicros >= start)
+          .filter(sample -> sample.timestampNanos >= start)
           .mapToDouble(Sample::value)
           .findFirst()
           .orElseThrow(() -> new AssertionError("no " + entry + " after " + test));
     }
 
     Time span() {
-      var stamps = samples.stream().mapToLong(Sample::timestampMicros);
+      var stamps = samples.stream().mapToLong(Sample::timestampNanos);
       var summary = stamps.summaryStatistics();
-      return Microseconds.of(summary.getMax() - summary.getMin());
+      return Nanoseconds.of(summary.getMax() - summary.getMin());
     }
 
     Set<String> motorEntries() {

--- a/vendordeps/CommandsV3.json
+++ b/vendordeps/CommandsV3.json
@@ -3,7 +3,7 @@
     "name": "Commands v3",
     "version": "1.0.0",
     "uuid": "4decdc05-a056-46cf-9561-39449bbb0130",
-    "wpilibYear": "2027_alpha5",
+    "wpilibYear": "2027_alpha7",
     "mavenUrls": [],
     "jsonUrl": "",
     "conflictsWith": [
@@ -16,7 +16,7 @@
     "javaDependencies": [
         {
             "groupId": "org.wpilib",
-            "artifactId": "commands3-java",
+            "artifactId": "commandsv3-java",
             "version": "wpilib"
         }
     ],

--- a/vendordeps/Phoenix6-26.50.0-alpha-1.json
+++ b/vendordeps/Phoenix6-26.50.0-alpha-1.json
@@ -2,7 +2,7 @@
     "fileName": "Phoenix6-26.50.0-alpha-1.json",
     "name": "CTRE-Phoenix (v6)",
     "version": "26.50.0-alpha-1",
-    "wpilibYear": "2027_alpha5",
+    "wpilibYear": "2027_alpha7",
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
         "https://maven.ctr-electronics.com/release/"

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -2,7 +2,7 @@
     "fileName": "REVLib.json",
     "name": "REVLib",
     "version": "2027.0.0-alpha-6",
-    "wpilibYear": "2027_alpha5",
+    "wpilibYear": "2027_alpha7",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
         "https://maven.revrobotics.com/"

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -3,7 +3,7 @@
     "name": "photonlib",
     "version": "v2027.0.0-alpha-2",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
-    "wpilibYear": "2027_alpha5",
+    "wpilibYear": "2027_alpha7",
     "mavenUrls": [
         "https://maven.photonvision.org/repository/internal",
         "https://maven.photonvision.org/repository/snapshots"


### PR DESCRIPTION
Updates the project to WPILib `2027.0.0-alpha-7` and deletes three of the four build departures it makes redundant.

## Vendor deps

No third-party vendor has published anything new — REVLib `2027.0.0-alpha-6`, Phoenix 6 `26.50.0-alpha-1` and photonlib `v2027.0.0-alpha-2` are still the latest each vendor serves, checked against their own metadata URLs rather than the pinned files. The one vendordep change is Commands v3: the artifact was renamed `commands3-java` → `commandsv3-java`. The `org.wpilib.command3` package is unchanged.

## Why the plugin version is the unlock

Bumping `wpilibVersion` alone cannot reach alpha-7. GradleRIO alpha-6 hardcodes `artifactory/release-2027`, which never received alpha-7 and still tops out at alpha-6; GradleRIO alpha-7 reads the unsuffixed `artifactory/release`, where alpha-7 actually lives.

## Departures deleted

| Departure | Why it can go |
|---|---|
| `wpi.maven.useDevelopment` + `2027.+` | alpha-7 is a real release and is what GradleRIO defaults to, so the rolling pin that guarded against development-repo eviction has nothing to guard |
| `telemetry-java`/`tunables-java` and the `wpilibNatives` JNI closure | alpha-7's `wpilib()` and JNI lists carry all four artifacts |
| test `--add-opens` / `--enable-native-access` | `configureTestTasks` supplies all three; verified by dumping the effective `allJvmArgs` |

**`src/main/native/revshim` stays.** `./gradlew test --tests first.robot.WiringTest -PnoRevShim` still exits 127 on `fmt::v12::vformat`, and the SystemCore journal still prints `[revshim] translating REVLib's pre-MrcLib HAL console calls`. All three ABI assumptions in `revshim.cpp` were re-checked against alpha-7 — `HAL_SendError` and `HAL_SendConsoleLine` take `WPI_String*`, `WPI_Handle` is still `int32_t`, and alpha-7's wpiutil still exports `_ZN3wpi4util13WaitForObjectEi` — so the prebuilt binaries are still correct and need no rebuild.

## One departure added

alpha-7 added a hard `wpilibYear` equality check in `org.wpilib:native-utils` that throws at plugin-apply time with no bypass property. With no vendor shipping an alpha-7 build, `wpilibYear` is edited to `2027_alpha7` in the three third-party vendordeps. Artifact versions are untouched, so this asserts a compatibility the tests carry rather than changing what is resolved. Documented in `CLAUDE.md`, including that re-importing a vendordep from its vendor URL silently reverts it.

## Source changes alpha-7 forced

- `CANBus` → `CANPort` (CTRE's identically-named `com.ctre.phoenix6.CANBus` did **not** rename, and `Drive.java` still uses it).
- Geometry constants lost the `k` prefix: `kZero` → `ZERO`, `kPi` → `PI`, `kCCW_Pi_2` → `CCW_PI_2`.
- **The WPI clock moved from microseconds to nanoseconds with identical signatures.** This broke `DriveSchedulingTest` outright — an injected `setTimeSource` fed microseconds, so a 100 ms timeout never fired. More importantly it made a SysId assertion **vacuous**: `span()` read nanosecond stamps as `Microseconds`, came out 1000x too large, and `gte(expected * 0.8)` passed trivially. A green suite was not evidence, and the fix restores a real assertion rather than silencing one.

The WPILOG *file* is unaffected — `DataLog` divides the nanoseconds it is given and `DataLogReader` multiplies them back, so only a hand-rolled parser sees microseconds. Verified against a 150 s robot log; the requirement is recorded on #104.

## Verification

- `./gradlew clean check` green from scratch: spotless, checkstyle, PMD, SpotBugs and 96 tests.
- Deployed to `robot.local`, image `limelightosr-2027.0.0-beta14`: `NRestarts=0`, service active, full `Robot program startup complete`, no MRC ABI mismatch and no `status=134`. The CAN errors in the journal are the empty bench bus, and the PDH half of them is #120, which reproduces unchanged.

## Follow-up

#121 reconciles the ADRs with the alpha-7 build model — the fat jar ADR 0003 chose is gone, and ADR 0013's vendordep year table inverts. Not done here; this PR keeps the code and `CLAUDE.md` correct and leaves the decision records to a pass of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1cJWYNBuAGEtHJM1n5RWS