### PR TITLE
Reconcile the ADRs with the alpha-7 build model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,13 +73,13 @@ The index of the ADRs themselves is
 - **Vendordep** — the JSON file in `vendordeps/` that pulls in a
   vendor library. Committing it *is* the version pin.
 - **The year gate** — GradleRIO's check that every vendordep's
-  `wpilibYear` matches one project-wide string. It is why
-  `vendordeps/CommandsV3.json` carries an edited year, and the edit
-  inverts when GradleRIO ships alpha-7
-  ([ADR 0013](docs/adr/0013-ci-and-test-strategy.md)).
-- **alpha-7** — the local allwpilib checkout at commit `cafb0cc79`,
-  366 commits past `v2027.0.0-alpha-6`. No alpha-7 has been tagged; it
-  is called that because its vendordeps say `2027_alpha7`
+  `wpilibYear` matches one project-wide string. GradleRIO alpha-7 moved
+  that string to `2027_alpha7`, so the edit inverted: `CommandsV3.json`
+  is upstream's again and the three third-party JSONs carry the edited
+  year ([ADR 0013](docs/adr/0013-ci-and-test-strategy.md)).
+- **alpha-7** — `v2027.0.0-alpha-7`, a real tag, dated 2026-08-25. The
+  ADRs' `[source]` reads were taken at commit `cafb0cc79`, ten commits
+  before it, which is why they name a commit rather than the tag
   ([ADR 0003](docs/adr/0003-project-and-package-structure.md)).
 
 ## Writing robot code
@@ -401,8 +401,11 @@ The index of the ADRs themselves is
 - **Brownout** — the battery sagging far enough that devices reset.
   A SPARK that browns out comes back configured but at default frame
   rates, silently.
-- **Fat jar** — the single deployed jar with every dependency inside
-  it, which is what the stock template already builds.
+- **Classpath deploy** — what the stock template builds and what we
+  ship: our own jar plus WPILib's on a `-cp` line, rather than the
+  single **fat jar** with every dependency inside it that the template
+  built through GradleRIO alpha-6
+  ([ADR 0003](docs/adr/0003-project-and-package-structure.md)).
 
 ## Testing and CI
 
@@ -432,5 +435,5 @@ The index of the ADRs themselves is
   not a red.
 - **`sim-hitl`** — the bench job that runs a `linuxarm64` sim build on
   the Pi, so the robot drives around in simulation on real hardware.
-  `real-hal-boot` is its sibling, which deploys the actual fat jar
-  against an empty CAN bus.
+  `real-hal-boot` is its sibling, which deploys the actual robot
+  artifact against an empty CAN bus.

--- a/docs/adr/0001-opmoderobot-and-commands-v3.md
+++ b/docs/adr/0001-opmoderobot-and-commands-v3.md
@@ -314,7 +314,7 @@ should start a thread near a command either.
   `javacPlugin/.../WPILibJavacPlugin.java` declares `autoStart()`
   (`:33-34`), so no `-Xplugin` flag is needed — but only
   if the plugin jar is on the annotation processor path, and the single
-  thing that puts it there is `build.gradle:60`:
+  thing that puts it there is `build.gradle:83`:
 
   ```groovy
   annotationProcessor wpi.java.deps.wpilibAnnotations()

--- a/docs/adr/0003-project-and-package-structure.md
+++ b/docs/adr/0003-project-and-package-structure.md
@@ -3,13 +3,23 @@
 ## Status
 
 Accepted — 2026-08-26. The `SparkSim` breakage that stood under *Open*
-is resolved by ADR 0010 and now sits under *Consequences*.
+is resolved by ADR 0010 and now sits under *Consequences*. Corrects
+2026-09-06 by #121: *Build, deploy and console* chose the fat jar on
+the ground that the stock template built one. GradleRIO alpha-7 dropped
+the shadow plugin for `application`, so the template now produces the
+classpath deploy this ADR listed under *Rejected*, and the two sections
+swap. The reasoning is untouched — the deploy artifact is whatever the
+generator produces, and opmode discovery has to work inside it.
 
 Claim tags are defined in the index. `[source]` claims here were read
 at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
-`v2027.0.0-alpha-6`. No alpha-7 has been tagged; the checkout is called
-alpha-7 because its vendordeps say `2027_alpha7`. An unqualified path is
-a file in this repo.
+`v2027.0.0-alpha-6` — except the build claims, re-read on 2026-09-06 in
+`GradleRIO-2027.0.0-alpha-7` and against this repo's own `build.gradle`.
+**That checkout is what this project calls alpha-7**, and the other ADRs
+name it by pointing here. This ADR added that no alpha-7 had been
+tagged, which was wrong: `v2027.0.0-alpha-7` is a real tag, dated
+2026-08-25, ten commits after `cafb0cc79`. An unqualified path is a file
+in this repo.
 
 ## Context
 
@@ -189,15 +199,22 @@ harder to follow.
 
 ### Build, deploy and console
 
-**Fat jar**, which is what the stock template already does: it applies
-`com.gradleup.shadow` and points the deploy artifact at it
-(`build.gradle:104`). Choosing the ordinary VSCode or Gradle deploy *is*
-choosing the fat jar. The shadow config also stashes `src/`,
-`vendordeps/` and `build.gradle` inside the jar under `backup/`
-(`build.gradle:96-98`). **[source]**
+**Whatever the stock template builds**, which since GradleRIO alpha-7
+is a **classpath deploy**: the template applies the `application` plugin
+and hands it to both the deploy artifact and GradleRIO
+(`deployArtifact.configureApplication(application)`,
+`wpi.java.configureApplication(application)`, `build.gradle:141-142`).
+`WPILibJavaArtifact.generateArgFile` writes a `-cp` line over
+`/home/systemcore/wpilib/classpath` plus our own jar into
+`robotCommand.args`, and the plain `jar` task still stashes `src/`,
+`vendordeps/` and `build.gradle` under `backup/` (`build.gradle:152-156`).
+**[source]** Choosing the ordinary VSCode or Gradle deploy *is* choosing
+that, exactly as it used to mean choosing the fat jar the shadow plugin
+built.
 
-Opmode discovery survives the fat jar: the scanner handles `jar:` URLs
-as well as `file:` ones (`OpModeRobot.java:438-459` for `jar:`, `:460-466` for `file:`).
+Opmode discovery survives it either way, because our classes still ship
+in a jar: the scanner handles `jar:` URLs as well as `file:` ones
+(`OpModeRobot.java:438-459` for `jar:`, `:460-466` for `file:`).
 **[source]**
 
 `vendordeps/` JSONs are committed, and committing them *is* the pin.
@@ -258,7 +275,7 @@ in GradleRIO's deploy plugin — so output is `journalctl -u robot -f`.
   maintain.
 - **The compile-time safety net is one line in `build.gradle`.**
   `annotationProcessor wpi.java.deps.wpilibAnnotations()`
-  (`build.gradle:60`) is what supplies the Commands v3 checks. See Traps.
+  (`build.gradle:83`) is what supplies the Commands v3 checks. See Traps.
 
 - **`SparkSim` does not run against the pinned checkout, and the
   no-seam decision does not depend on it.** `SparkSim` reaches
@@ -292,12 +309,16 @@ in GradleRIO's deploy plugin — so output is `journalctl -u robot -f`.
   **[source]**
 
 - **Renaming `Main`'s package silently breaks the deploy.**
-  `build.gradle:12` names the launcher as the *string* `"first.Main"`,
-  and that string is what goes into the jar manifest
-  (`build.gradle:99`). **[source]** Nothing checks it, so the build is
-  clean and the robot fails to start. Renaming `Robot`'s package is
-  safe by comparison — `Main.java` names it as a class literal, which
-  the compiler does check.
+  `build.gradle:15` names the launcher as the *string* `"first.Main"`,
+  and that string is what `application.mainClass` carries
+  (`build.gradle:139`) into the `-cp` line the deploy writes into
+  `robotCommand.args`. **[source]** The jar manifest
+  names nothing — under the `application` plugin it is empty of
+  `Main-Class` **[executed]** — so there is no second place the name is
+  checked either. Nothing checks it at all: the build is clean and the
+  robot fails to start. Renaming `Robot`'s package is safe by
+  comparison — `Main.java` names it as a class literal, which the
+  compiler does check.
 
 - **A test that builds a mechanism without a `RobotBase` logs every
   `Measure` as its `toString()`.** The `Measure` type handler is
@@ -422,10 +443,16 @@ A mentor convenience with a different deploy layout
 (`wpilib/allwpilibclasspath/`) and a different GC default. Not our
 deploy path.
 
-### Classpath (non-fat) deploy
+### Fat jar
 
-Never on the table — the stock template's shadow jar is the deploy
-artifact, and opmode discovery is verified to work inside it.
+**Was the decision; is now the rejected option**, and only because the
+template moved. Through GradleRIO alpha-6 it applied
+`com.gradleup.shadow` and pointed the deploy artifact at the shadow jar,
+so the fat jar was what *"stock template, unmodified"* meant and the
+classpath deploy sat in this slot. alpha-7 removed the shadow plugin.
+Keeping the fat jar would now mean re-adding it to a `build.gradle` this
+ADR commits to leaving stock — which is the same test that chose it
+before, returning the opposite answer.
 
 ### `m_` field prefix
 
@@ -460,11 +487,15 @@ Source read for this ADR, in `~/dev/allwpilib` at `cafb0cc79` (alpha-7):
 the generated
 `wpilibjExamples/build/generated/sources/annotationProcessor/java/main/org/wpilib/examples/rebuiltcmdv3/mechanisms/SwerveDriveLogger.java`.
 
+Re-read for #121, in `GradleRIO-2027.0.0-alpha-7` by `javap`:
+`org.wpilib.gradlerio.wpi.java.WPIJavaExtension` and
+`org.wpilib.gradlerio.deploy.systemcore.WPILibJavaArtifact`.
+
 ### Departure from #12
 
 #12 names the root package `frc.robot` and the opmode package
 `opmodes/`. The generator writes `first.robot` and `opmode/`
-(`src/main/java/first/robot/opmode/`; `build.gradle:12`). **[source]**
+(`src/main/java/first/robot/opmode/`; `build.gradle:15`). **[source]**
 This ADR follows the generator, on #12's own stronger commitment to the
 stock template unmodified. Nothing else in #12 is affected: the root
 package is the scan root whatever it is called, and opmodes are flat by

--- a/docs/adr/0004-config-as-code.md
+++ b/docs/adr/0004-config-as-code.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted — 2026-08-26.
+Accepted — 2026-08-26. Amended 2026-09-06 by #121: WPILib's CAN bus
+enum is `CANPort`, not `CANBus`. Same five S-buses, same values, and
+CTRE's `CANBus` did not rename; ADR 0007 carries what that did to the
+two-types trap.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -272,10 +275,12 @@ disk-pressure handling **[source — `docs/research/vendordeps.md`
 ### One project constant per CAN bus
 
 `Constants` holds one constant per physical bus, converted at each call
-site: `CANBus.CAN_S0.value` for REVLib's `int busId`,
+site: `CANPort.CAN_S0.value` for REVLib's `int busId`,
 `CANBus.systemcore(0)` for CTRE's object. The two vendors' numbering
 agrees for the same index **[source — `docs/research/vendordeps.md`
-§3.3]**. **Never `new CANBus()`** — see Traps.
+§3.3]**. `CANPort` is WPILib's enum and `CANBus` is CTRE's class; alpha-7
+renamed the WPILib half, and §3.3 predates that. **Never `new CANBus()`**
+— see Traps.
 
 ### `Robot` logs the active alert set at ~4 Hz
 

--- a/docs/adr/0005-telemetry-and-log-schema.md
+++ b/docs/adr/0005-telemetry-and-log-schema.md
@@ -14,11 +14,17 @@ implement is probed once and then not logged, `/Robot/InputVoltage` is
 deleted as a duplicate, and `/Robot/Rail3V3/Voltage` is logged only
 beside its fault count. Amended 2026-08-30 by #118: `/Robot/BrownedOut`
 is gated on the battery voltage probe, because the two are one MRC
-power interface and only the voltage has a value to probe by.
+power interface and only the voltage has a value to probe by. Amended
+2026-09-06 by #121: alpha-7's clock is nanoseconds, so `SchedulerEvent`
+carries `timestampNanos` and `/Robot/LoopDelta` is computed from a
+nanosecond `getLoopStartTime()`. The signal is unchanged — see *The
+clock moved under `LoopDelta`; the file did not*.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
-`v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. `[measured]`
+`v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7 — except the
+three files #121 re-read on 2026-09-06 at `d44da0dfb`, listed under
+*Source*. `[measured]`
 claims are the Pi runs recorded in `docs/research/loop-rate.md` and
 `docs/research/jvm-tuning.md`. An unqualified path is a file in this
 repo.
@@ -131,7 +137,7 @@ habits below.
 | `/Robot/BrownedOut` † | `RobotController.isBrownedOut()` (`:145`) |
 | `/Robot/CommsDisableCount` † | `RobotController.getCommsDisableCount()` (`:155`) |
 | `/Robot/CpuTemp` † | `RobotController.getCPUTemp()` (`:296`) |
-| `/Robot/Can/Bus0/{Utilization,ReceiveErrors,TransmitErrors,BusOff,TxFull}` † | `RobotController.getCANStatus(CANBus)` (`:315`), fields on `CANStatus` (`:10-22`) |
+| `/Robot/Can/Bus0/{Utilization,ReceiveErrors,TransmitErrors,BusOff,TxFull}` † | `RobotController.getCANStatus(CANPort)` (`:315`), fields on `CANStatus` (`:10-22`) |
 | `/Robot/SysActive` † | `RobotController.isSysActive()` (`:136`) |
 | `/Robot/Rail3V3/{Voltage,Current,FaultCount}` † | `RobotController.getVoltage3V3()` (`:200`), `getCurrent3V3()` (`:218`), `getFaultCount3V3()` (`:255`) |
 | `/Robot/Pdh/{Current,Voltage,TotalCurrent,SwitchableChannel}` | `PowerDistribution.logTo` (`PowerDistribution.java:248-254`) |
@@ -207,6 +213,33 @@ in real units, and a tick count is only interpretable with a conversion
 factor the git SHA already pins. A per-loop echo of config values —
 ADR 0004 rules that fixed config is recoverable from the SHA and only
 tunables are logged. Vision internals — ADR 0012.
+
+### The clock moved under `LoopDelta`; the file did not
+
+alpha-7 changed `RobotController.getLoopStartTime()` and its neighbours
+from microseconds to nanoseconds **without changing a signature**
+**[source — `c65465b00`]**, so a `Microseconds.of(...)` written against
+alpha-6 still compiles and is wrong by a factor of a thousand. `Robot`
+computes the delta and wraps it as
+`Nanoseconds.of(wake - lastWakeNanos)` (`Robot.java:257-258`), and
+the same base applies to `activeStartTime` and to `SchedulerEvent`'s
+`timestampNanos`.
+
+**The signal in the log is unchanged**, and that is the point worth
+recording. `UnitTelemetry.log` writes `value.baseUnitMagnitude()` and
+stamps the *base* unit's symbol (`UnitTelemetry.java:74-78`)
+**[source]**, and `Time`'s base unit is the second either way — so
+`/Robot/LoopDelta` was seconds under `Microseconds.of(...)` and is
+seconds under `Nanoseconds.of(...)`. ADR 0014 reads exactly what it read
+before. What the base change could have done is make the *number* wrong
+by a thousand while the unit metadata went on saying `s`, which is
+precisely the failure that does not announce itself.
+
+**The WPILOG file itself did not move either.** It still stores
+microseconds; `DataLog` divides the nanoseconds it is handed and
+`DataLogReader` multiplies them back (`DataLogReader.java:129`)
+**[source]**, so the Java API is nanoseconds in both directions and only
+a hand-rolled parser ever sees the microseconds on disk.
 
 ### A HAL read the platform does not implement is not logged
 
@@ -458,7 +491,7 @@ the ids. It is **blind to one-shots** — see Traps.
 **`/Commands/Events`** — a listener registered with
 `Scheduler.addEventListener`. `SchedulerEvent` is a sealed interface over
 `Scheduled`, `Mounted`, `Yielded`, `Completed`, `CompletedWithError`,
-`Canceled` and `Interrupted`, each carrying `timestampMicros`
+`Canceled` and `Interrupted`, each carrying `timestampNanos`
 (`SchedulerEvent.java:33-88`) **[source]**. It sees every lifecycle
 event including one-shots, and carries no tree.
 
@@ -866,3 +899,8 @@ Source read for this ADR, in `~/dev/allwpilib` at `cafb0cc79` (alpha-7):
 `commandsv3/src/main/java/org/wpilib/command3/Scheduler.java`,
 `commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java`,
 `commandsv3/src/main/java/org/wpilib/command3/proto/CommandProto.java`.
+
+Re-read for #121 at `d44da0dfb`:
+`wpilibj/src/main/java/org/wpilib/internal/UnitTelemetry.java`,
+`commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java` and
+`datalog/src/main/java/org/wpilib/datalog/DataLogReader.java`.

--- a/docs/adr/0007-can-topology-and-frames.md
+++ b/docs/adr/0007-can-topology-and-frames.md
@@ -4,11 +4,16 @@
 
 Accepted — 2026-08-26. Amended 2026-08-29: the characterisation raise
 ADR 0009 decided is now budgeted here, beside the tuning one it is
-smaller than.
+smaller than. Amended 2026-09-06 by #121: WPILib's bus enum is `CANPort`
+as of alpha-7. Every claim below survives the rename — same five
+S-buses, same values — but CTRE's `CANBus` did *not* rename, so the
+two-types trap under *Traps* got sharper rather than going away.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
-`v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. REVLib
+`v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7 — except
+`CANPort.java`, re-read on 2026-09-06 at `d44da0dfb` because the rename
+below landed after `cafb0cc79`. REVLib
 `[source]` claims were read in `REVLib-java 2027.0.0-alpha-6`, the
 version `vendordeps/REVLib.json` pins, from its sources jar; paths are
 given as `com/revrobotics/...`. Phoenix 6 `[source]` claims were read in
@@ -34,7 +39,7 @@ was wrong, is in Rejected under *#28's frame table as written*.
 
 Eight SPARK Flexes and one Pigeon2 have to reach SystemCore. SystemCore
 offers five native CAN buses, `can_s0` through `can_s4`
-(`wpilibj/src/main/java/org/wpilib/hardware/bus/CANBus.java:12-62`)
+(`wpilibj/src/main/java/org/wpilib/hardware/bus/CANPort.java:12-22`)
 **[source]**, so the wiring is a choice rather than a constraint.
 
 A CAN bus is not a pipe you pour bytes into. It carries discrete
@@ -239,7 +244,7 @@ new Pigeon2(deviceId, CANBus.systemcore(0))            // a CTRE CANBus object
 **[source, via #5]**
 
 So `Constants` holds **one constant per physical bus**, typed as
-WPILib's `org.wpilib.hardware.bus.CANBus`, and each call site converts:
+WPILib's `org.wpilib.hardware.bus.CANPort`, and each call site converts:
 `.value` for REVLib, `CANBus.systemcore(n)` for Phoenix. **[decided]**
 The numbering agrees exactly across the two vendors — `CAN_S0(0)`
 through `CAN_S4(4)`, and CTRE's `systemcore(int)` validates 0–4
@@ -250,9 +255,9 @@ and our gyro.
 The constant exists so that *"which bus is the drive base on"* has one
 answer in the repository rather than nine literals. It is deliberately
 not a wrapper type over the two vendor types, because the thing most
-worth seeing at a call site is that CTRE's `CANBus` and WPILib's
-`CANBus` are different types that share a simple name — and a wrapper
-is exactly what would let somebody stop noticing that.
+worth seeing at a call site is that WPILib's `CANPort` and CTRE's
+`CANBus` are two unrelated types for the same physical thing — and a
+wrapper is exactly what would let somebody stop noticing that.
 
 ## Consequences
 
@@ -344,13 +349,20 @@ is exactly what would let somebody stop noticing that.
   that is wrong. Always pass the bus. The failure mode is a device that
   constructs cleanly and never answers, on a bus with nothing on it.
 
-- **`CANBus` is two different types with the same simple name.**
-  `org.wpilib.hardware.bus.CANBus` is an enum carrying an `int value`;
-  `com.ctre.phoenix6.CANBus` is a class with `systemcore(int)` and
-  `motioncore(int)` factories. **[source]** A file cannot import both,
-  and the one that compiles is not necessarily the one that was meant —
-  `CANBus.CAN_S0.value` and `CANBus.systemcore(0)` are both valid
-  expressions in their own file.
+- **The two bus types no longer even share a name, and that is worse
+  than it sounds.** `org.wpilib.hardware.bus.CANPort` is an enum
+  carrying an `int value`; `com.ctre.phoenix6.CANBus` is a class with
+  `systemcore(int)` and `motioncore(int)` factories. **[source]**
+  Through alpha-6 both were called `CANBus`, a file could not import
+  both, and the collision was its own warning: `CANBus.CAN_S0.value`
+  and `CANBus.systemcore(0)` were each valid in their own file and
+  neither was valid in the other's. alpha-7 renamed the WPILib half to
+  `CANPort` **[source — `c9c73f34a`]**, so both now import cleanly into
+  one file and nothing objects. Every 2026-era sample and every model
+  completion still writes WPILib's half as `CANBus`, and in a file that
+  imports Phoenix that name now resolves — to CTRE's class, silently.
+  What used to be a compile error the collision forced is now a working
+  `new CANBus()` on the wrong bus.
 
 - **`CANBus.motioncore(n)` compiles, validates and does not work.**
   CTRE's known-issue list: *"Motioncore CAN buses are not supported.
@@ -566,7 +578,10 @@ naming, the SPI-pairing measurements, Phoenix's diagnostic server and
 the CAN timestamp defect.
 
 Source read for this ADR, in `~/dev/allwpilib` at `cafb0cc79`
-(alpha-7): `wpilibj/src/main/java/org/wpilib/hardware/bus/CANBus.java`.
+(alpha-7): `wpilibj/src/main/java/org/wpilib/hardware/bus/CANBus.java`,
+re-read for #121 at `d44da0dfb` as
+`wpilibj/src/main/java/org/wpilib/hardware/bus/CANPort.java` — the same
+five S-buses, the same values and the same `public final int value`.
 
 In REVLib `2027.0.0-alpha-6` (sources jar):
 `com/revrobotics/spark/config/SignalsConfig.java`,

--- a/docs/adr/0010-simulation-architecture.md
+++ b/docs/adr/0010-simulation-architecture.md
@@ -20,7 +20,13 @@ reported against the rail it was clamped against. A regenerating motor is
 credited as no load rather than as a full one.
 
 The *Open* item asking whether CI runs a headless robot program is
-answered by ADR 0013 and now sits under *Consequences*.
+answered by ADR 0013 and now sits under *Consequences*. Amended
+2026-09-06 by #121: the sim task is `./gradlew run`, and the deploy
+artifact is no longer a fat jar — see ADR 0003. Neither changes what is
+simulated or where the seam is. Those two GradleRIO `[source]` claims
+were read in `GradleRIO-2027.0.0-alpha-7`, the version `build.gradle:4`
+pins, from the plugin jar by `javap`:
+`org.wpilib.gradlerio.wpi.java.WPIJavaExtension`.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -320,11 +326,13 @@ is five sub-steps to a 5 ms period — four times as many sub-steps per
 second — so call it **~6.4 µs per 20 ms of wall clock**, which is three
 hundredths of a percent of a desktop's budget.
 
-### Sim ships in the fat jar, behind `isSimulation()`
+### Sim ships in the deploy artifact, behind `isSimulation()`
 
 Same source set, `RobotBase.isSimulation()` (`RobotBase.java:316`)
-**[source]** guarding construction, shipped in the shadow jar the
-template already builds (`build.gradle:94, 104`). **[source]**
+**[source]** guarding construction, shipped in whatever jar the template
+builds — the shadow jar through GradleRIO alpha-6, the plain `jar` on the
+deployed classpath since alpha-7 (`build.gradle:152-156`, ADR 0003).
+**[source]**
 
 **No `src/sim/java`.** A separate source set means editing the stock
 template's `build.gradle`, which ADR 0003 ruled against, and it buys
@@ -413,11 +421,14 @@ actually needs to sweep them. **[decided]**
 
 ### Running it
 
-`./gradlew simulateJava` brings up the WPILib sim GUI, which the
-template already enables (`build.gradle:88-89`) **[source]**, alongside
-AdvantageScope. A scripted `@Utility` opmode that drives a path and
-reports odometry error is the repeatable version of the same thing. The
-numbered recipe belongs in the README, not here.
+`./gradlew run` brings up the WPILib sim GUI, which the template already
+enables (`build.gradle:136-137`) **[source]**, alongside AdvantageScope.
+GradleRIO alpha-7 registers no `simulateJava`: simulation is the
+`application` plugin's `run` task, which `wpi.java.configureApplication`
+configures with the desktop natives. **[source]** A scripted `@Utility`
+opmode that drives a path and reports odometry error is the repeatable
+version of the same thing. The numbered recipe belongs in the README,
+not here.
 
 ## Consequences
 
@@ -714,8 +725,8 @@ third, at a different bar.
 It would need an edit to the stock template's `build.gradle`, which ADR
 0003 ruled against, and it buys nothing over an `isSimulation()` guard:
 the sim classes are already inert on the robot, because nothing
-constructs them. The fat jar carrying a few unreferenced classes is not
-a cost anybody can measure.
+constructs them. A deploy artifact carrying a few unreferenced classes
+is not a cost anybody can measure.
 
 ### A first-order slew for the steer azimuth
 

--- a/docs/adr/0012-pose-estimation-and-vision.md
+++ b/docs/adr/0012-pose-estimation-and-vision.md
@@ -708,7 +708,7 @@ older spellings appears anywhere.
   identity for ever in simulation.** The evidence is under *Decision*.
   What it looks like is a robot whose odometry translates and never
   turns, and whose field-relative driving never rotates its frame —
-  under `simulateJava`, which is the only place most of this project is
+  under `./gradlew run`, which is the only place most of this project is
   ever run. Nothing throws, and every quaternion signal reports `OK`
   while reading `0.0`. Read the heading off yaw, pitch and roll.
   *Re-raise* when a Phoenix release drives the quaternion in

--- a/docs/adr/0013-ci-and-test-strategy.md
+++ b/docs/adr/0013-ci-and-test-strategy.md
@@ -11,13 +11,18 @@ It was dormant in fact if not in principle until ADR 0015's shim let a
 SPARK be constructed; `WiringTest` is green, and the test task forks a
 JVM per class because the HAL, the alert table and the data log are all
 process-wide and a Tier 2 class claims the data log for the rest of the
-JVM.
+JVM. Corrects 2026-09-06 by #121: *The year-gate edit, and what inverts
+it* named its own revert condition and the condition fired. GradleRIO
+alpha-7 moved the project-wide year to `2027_alpha7`, so
+`CommandsV3.json` is back to upstream's value and the three third-party
+JSONs are the edited side. The section and its table are rewritten to
+the state that actually holds; nothing about the decision changed.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
 `v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. GradleRIO
-`[source]` claims were read in `GradleRIO-2027.0.0-alpha-6`, the version
-`build.gradle:3` pins, from the plugin jar by `javap`; paths are given
+`[source]` claims were read in `GradleRIO-2027.0.0-alpha-7`, the version
+`build.gradle:4` pins, from the plugin jar by `javap`; paths are given
 as class names. An unqualified path is a file in this repo.
 
 ## Context
@@ -42,9 +47,13 @@ Three constraints shape the answer and none of them are ours to choose:
   module, no `tunables` module and no `mrclib`/SystemCore HAL — so it
   cannot compile ADR 0005's logging and cannot deploy to the Pi.
   **[source, via #19]**
-- **The vendordep year gate is out of step with itself.** GradleRIO's
-  project-wide requirement is `2027_alpha5` while allwpilib's own
-  first-party JSONs already declare `2027_alpha7`. **[source]**
+- **The vendordep year gate is out of step with somebody, always.**
+  GradleRIO's project-wide requirement is `2027_alpha7` and allwpilib's
+  own first-party JSONs match it, but no third-party vendor has
+  published against alpha-7, so every one of theirs still declares
+  `2027_alpha5`. It was the other way round when this ADR was written.
+  Whichever way it sits, some JSON in `vendordeps/` is wrong for the
+  plugin that reads it. **[source]**
 - **There is exactly one bench Pi.** Anything that runs on hardware
   queues on a single physical box that may be unplugged.
 
@@ -150,7 +159,7 @@ carries `setOpMode(long)` (`DriverStationSim.java:288`),
 (`wpilibj/src/test/java/org/wpilib/framework/OpModeRobotTest.java:20-21,
 97-105, 144, 244-278`). **[source]** The JUnit extension that wires it
 is auto-detected by `junit.jupiter.extensions.autodetection.enabled`,
-which the template already sets (`build.gradle:84`). **[source]** All of
+which the template already sets (`build.gradle:116`). **[source]** All of
 #22's uinput, Xvfb and spacebar apparatus exists to drive the *real* DS,
 which this tier does not have and does not want.
 
@@ -159,7 +168,7 @@ It needs no extra build configuration either.
 which sets `LD_LIBRARY_PATH` and `java.library.path` from the extracted
 desktop natives **[source]**, fed by the template's unconditional
 `nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)`
-(`build.gradle:74`). **[source]**
+(`build.gradle:97`). **[source]**
 
 It drives **ADR 0010's scripted `@Utility` drive-a-path opmode** — one
 artifact, two audiences. A test-only opmode would be a second thing to
@@ -306,8 +315,9 @@ dependency-resolution error with no earlier version to fall back to.
 caused by upstream — which is a cost we accept, because the alternative
 is a red we cannot fix at all.
 
-**Pin to alpha-7 the moment it is tagged.** It is visibly imminent: six
-vendordep JSONs on allwpilib `main` already declare `2027_alpha7`.
+**Pinned to alpha-7 since 2026-09-06**, which is what `build.gradle:4`
+names. The prediction that made this a decision — six vendordep JSONs
+on allwpilib `main` already declaring `2027_alpha7` — is spent.
 **[source]**
 
 A daily scheduled run of `main` on the gated workflow was considered —
@@ -318,33 +328,46 @@ hardware nightly, which exists for a different reason, stays.
 ### The year-gate edit, and what inverts it
 
 The gate is `WPIVendorDepsExtension.validateDependencies()` in
-`wpilibsuite/native-utils`, and it compares each `vendordeps/*.json`'s
+`org.wpilib:native-utils`, and it compares each `vendordeps/*.json`'s
 `wpilibYear` against one project-wide value whose convention GradleRIO
-sets to the string `2027_alpha5`
+sets, as of alpha-7, to the string `2027_alpha7`
 (`org.wpilib.gradlerio.wpi.WPIExtension`). **[source]**
 
-| vendordep | declares | vs `2027_alpha5` |
+| vendordep | declares | vs `2027_alpha7` |
 |---|---|---|
-| REVLib `2027.0.0-alpha-6` | `2027_alpha5` | passes |
-| Phoenix 6 `26.50.0-alpha-1` | `2027_alpha5` | passes |
-| photonlib `v2027.0.0-alpha-2` | `2027_alpha5` | passes |
-| `CommandsV3.json` from allwpilib `main` | `2027_alpha7` | **rejected** |
+| REVLib `2027.0.0-alpha-6` | `2027_alpha5` upstream | **rejected**, so edited |
+| Phoenix 6 `26.50.0-alpha-1` | `2027_alpha5` upstream | **rejected**, so edited |
+| photonlib `v2027.0.0-alpha-2` | `2027_alpha5` upstream | **rejected**, so edited |
+| `CommandsV3.json` from allwpilib `main` | `2027_alpha7` | passes |
 
 **[source — `vendordeps/*.json`, `~/dev/allwpilib/commandsv3/CommandsV3.json`]**
 
-So the gate never blocked REVLib. It blocks Commands v3, and the fix is
-one word: **`vendordeps/CommandsV3.json` carries `2027_alpha5`**, edited
-down from upstream's `2027_alpha7`. It is checked in, `git diff` shows
-it, and `shadowJar` already copies `vendordeps/` into the deployed jar
-under `backup/vendordeps` (`build.gradle:97`). **[source]**
+So the gate no longer blocks Commands v3 — every field in that file is
+upstream's again, the importer's indentation aside. It blocks all three
+third-party vendordeps instead, and the fix is one word in each:
+**`REVLib.json`, `Phoenix6-26.50.0-alpha-1.json` and `photonlib.json`
+carry `2027_alpha7`**, edited up from the `2027_alpha5` their vendors
+publish. The edits are checked in, `git diff` shows them, and the `jar`
+task already copies `vendordeps/` into the deployed jar under
+`backup/vendordeps` (`build.gradle:154`). **[source]**
 
-**The revert condition is the string itself.** When GradleRIO publishes
-an alpha-7 its convention flips to `2027_alpha7`, and the edit inverts:
-`CommandsV3.json` goes back untouched and REVLib becomes the file we
-edit, until REV republishes. No separate note anywhere — the gate throws
-at configuration time with a message naming the year, so CI catches an
-overwritten JSON loudly and immediately, and a second copy of a fact
-`git diff` already shows is a second copy that can drift.
+Note what the edit now asserts. Editing `CommandsV3.json` down claimed
+nothing: the artifact it names is built from the same checkout GradleRIO
+was, so the year was the only thing out of step. Editing a third-party
+JSON up claims that a binary compiled against alpha-5 links against
+alpha-7, and that is a compatibility the tests have to carry rather than
+a formality — ADR 0015 exists because one of those three did not.
+
+**The revert condition is still the string itself, and it fires in both
+directions.** Each vendor that republishes against alpha-7 takes its own
+file back to untouched; the next GradleRIO bump puts every file that has
+not moved back out of step. No separate note anywhere — the gate throws
+at plugin-apply time with a message naming the year, from
+`WPIExtension`'s own constructor, before any build script line can reach
+`wpi.wpilibYear` and before any task runs **[source]**, so there is
+nothing to bypass and CI catches an overwritten JSON loudly and
+immediately. A second copy of a fact `git diff` already shows is a
+second copy that can drift.
 
 ### The bench Pi is a second workflow, and it is never a required check
 
@@ -373,7 +396,7 @@ block anything has not earned a second delivery mechanism.
 
 ### Job 1 — `real-hal-boot`, and it is four assertions
 
-Deploys the **real fat jar** (`linuxsystemcore`) against an **empty CAN
+Deploys the **real artifact** (`linuxsystemcore`) against an **empty CAN
 bus**, waits 30 s, and asserts:
 
 1. **`systemctl show robot -p NRestarts` unchanged.** Since the MRC ABI
@@ -452,8 +475,8 @@ what makes `linuxarm64` the *sim* artifact rather than a cross-compiled
 real one. **[source, via #23 — artifact listing at
 `2027.0.0-alpha-6-370-gb448d64f3`; the guard read locally]**
 
-So the Pi runs the real fat jar as a simulation: real aarch64, real
-PREEMPT_RT kernel, real JDK 25, real Notifier scheduling under real
+So the Pi runs the real deploy artifact as a simulation: real aarch64,
+real PREEMPT_RT kernel, real JDK 25, real Notifier scheduling under real
 contention, physics loop closed, nothing plugged in — driven by the real
 Driver Station from a second box, with #22's Xvfb, uinput keyboard,
 spacebar gate and `xwininfo`-derived click targets.
@@ -684,17 +707,19 @@ covers, or general code-quality opinion.
   **[executed — `docs/research/ds-headless-control.md:34, 188`]** Any
   `sim-hitl` harness sends Space first, before anything else.
 
-- **Re-importing `CommandsV3.json` from allwpilib breaks the build
-  twice.** Upstream's copy declares `2027_alpha7`, which the year gate
-  rejects, *and* names the artifact `commandsv3-java` where the artifact
-  that actually resolves is `commands3-java`. **[source — diff against
+- **Re-importing a *third-party* vendordep from its vendor URL breaks
+  the build.** It reverts `wpilibYear` to `2027_alpha5` and the gate
+  refuses to configure the project. `CommandsV3.json` is the one file
+  this is now safe on: upstream's copy declares `2027_alpha7` and names
+  the artifact `commandsv3-java`, which is what resolves. Both halves of
+  this trap used to point at that file and both are spent — the artifact
+  was `commands3-java` through alpha-6. **[source — diff against
   `~/dev/allwpilib/commandsv3/CommandsV3.json`; the resolved artifact in
-  the Gradle cache]** The gate failure is loud and names the year. The
-  artifact-id failure is a resolution error that names neither. Take the
-  checked-in file as the source of truth.
+  the Gradle cache]** The gate failure is loud and names the year. Take
+  the checked-in files as the source of truth.
 
 - **`def includeDesktopSupport` gates nothing.** It is declared at
-  `build.gradle:55` and referenced exactly nowhere in the file.
+  `build.gradle:78` and referenced exactly nowhere in the file.
   **[source]** Flipping it to fix a desktop-natives problem changes no
   behaviour at all; the natives come from the unconditional
   `nativeRelease` lines.
@@ -826,7 +851,7 @@ mechanism. Step Summary, plus a journal artifact on failure.
 The option #25 was written around, and it is strictly worse than it
 looks. It does skip the year gate, which lives in the vendordep loader
 rather than in maven. But the template wires vendor natives through
-`wpi.java.vendor.jniRelease(...)` (`build.gradle:68, 75`) **[source]**, and
+`wpi.java.vendor.jniRelease(...)` (`build.gradle:91, 98`) **[source]**, and
 REVLib ships **three** — `REVLib-driver`, `RevLibBackendDriver`,
 `RevLibWpiBackendDriver`, each valid for `linuxsystemcore` as well as
 the desktop platforms (`vendordeps/REVLib.json`, `jniDependencies`).
@@ -837,11 +862,18 @@ says as much — *"Attempting to modify an existing dependency will break
 at runtime, and will result in loss of support from the WPILib team."*
 *Do not re-raise* without new evidence about the natives.
 
-### Setting `wpi { wpilibYear = "2027_alpha7" }` and editing the vendordeps up
+### Setting `wpi { wpilibYear = ... }` to move the gate
 
-Two edits — REVLib and Phoenix — instead of one, and `wpilibYear` also
-feeds `wpilibHome`, repointing the install-folder path at a directory
-that does not exist. **[source, via #25]**
+Half of this option — editing the third-party vendordeps up — is the
+decision now, and it arrived by upstream's hand rather than ours. The
+half still rejected is overriding the project-wide year from
+`build.gradle`, and it is rejected harder than #25 rejected it.
+`wpilibYear` feeds `wpilibHome`, so an override repoints the
+install-folder path at a directory that does not exist **[source, via
+#25]** — and, on alpha-7, it does not reach the gate at all:
+`WPIExtension`'s constructor sets the year, loads the vendordeps and
+validates them before any line of `build.gradle` can assign to it.
+**[source]**
 
 ### Pinning an exact `frcmaven/development` build
 
@@ -852,9 +884,9 @@ to. **[source, via #19]**
 ### A daily scheduled run of `main` on the gated workflow
 
 It would cheaply separate *WPILib broke us* from *your PR broke us*, and
-it is machinery for a condition that ends when alpha-7 is tagged. The
-bench nightly stays, because it detects something a push trigger
-structurally cannot.
+it was machinery for a condition that ended when alpha-7 was tagged and
+pinned. The bench nightly stays, because it detects something a push
+trigger structurally cannot.
 
 ### A build matrix
 

--- a/docs/adr/0015-binding-revlibs-native.md
+++ b/docs/adr/0015-binding-revlibs-native.md
@@ -17,6 +17,13 @@ argument is on
 [#87](https://github.com/Drew-Robotics/2027beta/issues/87) and
 [#92](https://github.com/Drew-Robotics/2027beta/issues/92).
 
+**Amended — 2026-09-06** by #121: GradleRIO alpha-7 registers no
+`simulateJava` task, so the second of the three preload sites is
+`tasks.withType(JavaExec)`. Still three JVMs, still the same shim. That
+claim was read in `GradleRIO-2027.0.0-alpha-7`, the version
+`build.gradle:4` pins, from the plugin jar by `javap`:
+`org.wpilib.gradlerio.wpi.java.WPIJavaExtension`.
+
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
 `v2027.0.0-alpha-6`, the checkout ADR 0003 calls alpha-7. Native
@@ -46,7 +53,7 @@ two platforms are identical: same names, same count.
 
 This is a dynamic-linker abort, not an exception, so nothing catches or
 contains it. `Robot`'s constructor builds eight SPARKs, so **nothing
-that stands up `Robot` ran anywhere** — not `simulateJava`, not ADR
+that stands up `Robot` ran anywhere** — not the sim `run` task, not ADR
 0013's Tier 2, not a deploy, and not a student selecting an opmode,
 since the framework only constructs opmodes after that constructor
 returns. Tier 1 was unaffected, because ADR 0010 keeps vendor types out
@@ -241,9 +248,11 @@ from Java is invisible to libraries loaded after it. Preloading from
 fix therefore cannot live in Java.
 
 `build.gradle` sets `LD_PRELOAD` in the three places a JVM meets
-REVLib: `tasks.withType(Test)`, `JavaSimulationTask`, and the robot's
-own start command, through `WPILibJavaArtifact.setJavaCommand` — a
-public, supported hook whose value is echoed into
+REVLib: `tasks.withType(Test)`, `tasks.withType(JavaExec)` — which is
+the `run` task GradleRIO alpha-7 simulates through, in place of the
+`simulateJava` alpha-6 registered — and the robot's own start
+command, through `WPILibJavaArtifact.setJavaCommand`, a public,
+supported hook whose value is echoed into
 `/home/systemcore/robotCommand`. **[source]**
 
 **On the Pi, `libwpiutil.so` is preloaded ahead of the shim.** The shim
@@ -298,7 +307,7 @@ enforces running both, and nothing should. **[decided]**
 
 ## Consequences
 
-`simulateJava` runs. A student picks an opmode and drives. `first.Main`
+Simulation runs. A student picks an opmode and drives. `first.Main`
 was run headless for twenty seconds with the shim preloaded: full
 startup, Phoenix CAN bus up, telemetry logging, zero crashes, and
 `simulationPeriodic(): 0.009247s` — which is `Drive.updateSim()`,
@@ -473,7 +482,8 @@ argument descriptor — a second ABI dependency on a library WPILib has
 already stopped using, bought for fidelity in a string nothing reads.
 
 **Waiting for REVLib to publish against a current WPILib.** The honest
-estimate is weeks-to-never; there is no alpha-7 and no announced date.
+estimate is weeks-to-never; there is no alpha-7 REVLib and no announced
+date.
 Meanwhile the simulation, Tier 2 and the deploy are all down. The console
 gap did not change this: a month after that one published version,
 `maven-metadata.xml` is unmoved. **[executed]**


### PR DESCRIPTION
Closes #121.

Documentation only. `./gradlew check` is green.

## The four ADRs

**ADR 0003 — the fat jar and the classpath deploy swap sections.** The test that chose the fat jar — *whatever the stock template produces* — never moved; the template moved under it. `Corrects` note in *Status*, following the precedent ADR 0014 set on itself. Renaming `Main` now breaks the deploy through `application.mainClass` and the deployed `-cp` line, not through a jar manifest: the built jar's manifest is `Manifest-Version: 1.0` and nothing else.

**ADR 0013 — the year-gate table inverts**, exactly as the ADR's own revert condition predicted. `CommandsV3.json` is upstream's again; `REVLib.json`, `Phoenix6-*.json` and `photonlib.json` carry the hand-edit. New paragraph on what that edit now *asserts* — an alpha-5-built binary linking against alpha-7 — because the old edit asserted nothing and this one is the reason ADR 0015 exists.

**ADR 0007 and 0004 — `CANPort`.** Every claim survives (same five S-buses, same values), but CTRE's `CANBus` did not rename, so the trap got worse rather than going away: the name collision that used to force a compile error is gone, and a file that imports Phoenix now resolves a bare `CANBus` silently to CTRE's class.

**ADR 0005 — the clock.** New section. The signal really is unchanged, and the mechanism is worth recording: `UnitTelemetry.log` writes `baseUnitMagnitude()` and stamps the *base* unit, and `Time`'s base is the second either way — so µs and ns both land as seconds and only the *number* was ever at risk. The WPILOG file still stores microseconds. **ADR 0014 needs no change**; its units claim already rests on the metadata property.

## Three departures from the ticket, all verified

- **The gate was already fatal.** native-utils 2027.7.1 (alpha-6) has the identical `String.equals` + `throw`, invoked from the same `WPIExtension` constructor. What alpha-7 changed is the required string. The unbypassable half is kept and tagged: validation runs before any `build.gradle` line can assign to `wpi.wpilibYear`, which also makes ADR 0013's *Rejected* entry on setting `wpilibYear` a harder rejection than it was.
- **`CommandsV3.json` is not byte-for-byte upstream** — every field matches; indentation and the trailing newline do not. Written as "every field … the importer's indentation aside".
- **No `[executed]` claim for the alpha-7 boot.** Not run here, so ADR 0003 rests opmode discovery on the source anchor instead.

## Also reconciled

`v2027.0.0-alpha-7` **is** tagged (2026-08-25, ten commits after the `cafb0cc79` the ADRs read at); ADR 0003 and `CONTEXT.md` both said otherwise. `CONTEXT.md`'s `wpilibYear` and `Fat jar` glossary entries, ADR 0013's spent `commands3-java` trap, `simulateJava` → `run` in ADRs 0010/0012/0015, and every stale `build.gradle:N` anchor the alpha-7 commit broke — including one in ADR 0001, twin to the one in ADR 0003.

`docs/research/` is left alone as dated snapshots, including the `simulateJava` in `choreo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1cJWYNBuAGEtHJM1n5RWS