### PR TITLE
Fail a deploy whose MRC API does not match the image (#100)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -382,6 +382,11 @@ The index of the ADRs themselves is
   build must agree on. A mismatch is a crash loop, not a message, so the
   bench stays on the image the checkout expects
   ([ADR 0013](docs/adr/0013-ci-and-test-strategy.md)).
+- **The preflight** — `mrcApiPreflight`, the Gradle task every deploy
+  depends on. It reads the image's MRC API ceiling over the deploy's own
+  ssh session and fails with both numbers rather than letting the pair
+  disagree on the device
+  ([ADR 0003](docs/adr/0003-project-and-package-structure.md)).
 - **The bench Pi** — the single SystemCore-image Raspberry Pi at
   `192.168.1.202` that measurements and hardware CI run on. There is
   one of it, which is why it can never gate anything

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.wpilib.deployutils.deploy.artifact.ArtifactDeployTask
+import org.wpilib.deployutils.deploy.target.discovery.TargetDiscoveryTask
+
 plugins {
     id "java"
     id "application"
@@ -61,6 +64,90 @@ deploy {
             }
         }
     }
+}
+
+// Departs from the template: the SystemCore image ships /usr/lib/libMrcLib.so and the HAL calls
+// MRC_CHECK_API_VERSION() before it prints anything, so an image older than the WPILib being
+// deployed aborts into a three-second crash loop that nothing warns about at build time. The image
+// and the WPILib are a version pair, and this is the only place the two numbers meet.
+def mrcLibVersion = wpi.versions.mrcLibVersion.get()
+
+// MRC_API_VERSION is in the mrclib headers, so the requested number is whatever the WPILib on the
+// build classpath was compiled against rather than a table this file would have to keep current.
+def mrcHeaders = configurations.detachedConfiguration(
+    dependencies.create("org.wpilib.mrclib:mrclib-cpp:${mrcLibVersion}:headers@zip"))
+
+def discoverSystemcore = tasks.named('discoversystemcore', TargetDiscoveryTask)
+
+tasks.register('mrcApiPreflight') {
+    group = 'wpilib'
+    description = 'Checks the SystemCore image accepts the MRC API version this build requires'
+    dependsOn discoverSystemcore
+
+    doLast {
+        def requested = null
+        try {
+            new java.util.zip.ZipFile(mrcHeaders.singleFile).withCloseable { zip ->
+                def header = zip.getInputStream(zip.getEntry('mrclib/ApiVersion.h')).getText('UTF-8')
+                def define = header =~ /(?m)^#define\s+MRC_API_VERSION\s+(\d+)/
+                if (define) {
+                    requested = define[0][1] as int
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("MRC preflight skipped: mrclib ${mrcLibVersion} headers unreadable (${e.message}).")
+            return
+        }
+        if (requested == null) {
+            logger.warn("MRC preflight skipped: mrclib ${mrcLibVersion} declares no MRC_API_VERSION.")
+            return
+        }
+
+        // isAvailable(), not the getter: getActiveContext() throws rather than answering null,
+        // which would fail a deploy the check could not run against.
+        def discovery = discoverSystemcore.get()
+        if (!discovery.available) {
+            logger.warn('MRC preflight skipped: the SystemCore was not discovered.')
+            return
+        }
+
+        // `accepts` is exactly the HAL's own check, MRC_CheckApiVersion(MRC_API_VERSION), so this
+        // asks no more than the robot program will. `ceiling` is only there to name a number in
+        // the failure, which is why it need not look above what we asked for. MRC_Bool is uint8_t.
+        // stderr is folded in because a box that cannot answer says why only on stderr.
+        def probe = 'python3 -c \'import ctypes; ' +
+            'f = ctypes.CDLL("/usr/lib/libMrcLib.so").MRC_CheckApiVersion; ' +
+            'f.argtypes = [ctypes.c_uint32]; f.restype = ctypes.c_uint8; ' +
+            "print(\"mrc-api accepts=%d ceiling=%d\" % (f(${requested}), " +
+            "max([v for v in range(${requested}) if f(v)], default=-1)))' 2>&1"
+        def answer = discovery.activeContext.execute(probe)?.result ?: ''
+        def reply = answer =~ /mrc-api accepts=(\d) ceiling=(-?\d+)/
+        if (!reply) {
+            // A check that could not run must not block a deploy that would otherwise work.
+            logger.warn("MRC preflight skipped: ${discovery.activeContext.friendlyString()} did not " +
+                "answer the probe. It said: ${answer.trim()}")
+            return
+        }
+
+        if (reply[0][1] == '1') {
+            logger.lifecycle("MRC API ${requested} requested, and the image accepts it.")
+            return
+        }
+        def ceiling = reply[0][2] as int
+        throw new GradleException(
+            "MRC API mismatch: this build needs ${requested} (mrclib ${mrcLibVersion}) and the " +
+            (ceiling < 0 ? 'image accepts no version at all' : "image accepts up to ${ceiling}") +
+            '. Nothing was deployed. The OS image and WPILib are a pair — reflash the SystemCore ' +
+            'from LimelightVision/systemcore-os-public, or move the WPILib pin back to an alpha ' +
+            'the image accepts.')
+    }
+}
+
+// Every file copy and every remote command on the deploy path is an ArtifactDeployTask, the program
+// kill included, so gating the type is what puts the failure before anything on the device is
+// touched. An unreachable bench never gets this far: discovery fails first, as it already did.
+tasks.withType(ArtifactDeployTask).configureEach {
+    dependsOn 'mrcApiPreflight'
 }
 
 // Departs from the template: REVLib alpha-6's native imports two symbols no WPILib this project

--- a/docs/adr/0003-project-and-package-structure.md
+++ b/docs/adr/0003-project-and-package-structure.md
@@ -9,7 +9,10 @@ the ground that the stock template built one. GradleRIO alpha-7 dropped
 the shadow plugin for `application`, so the template now produces the
 classpath deploy this ADR listed under *Rejected*, and the two sections
 swap. The reasoning is untouched — the deploy artifact is whatever the
-generator produces, and opmode discovery has to work inside it.
+generator produces, and opmode discovery has to work inside it. Amended
+2026-09-06 by #100: *Which WPILib we build against* called the image ↔
+allwpilib ↔ MRC API pairing a habit rather than a tool, and #100 built
+the tool. The passage names it; nothing about the decision changed.
 
 Claim tags are defined in the index. `[source]` claims here were read
 at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -234,9 +237,13 @@ release. Only the artifact source changes — the GradleRIO deploy path is
 identical either way. **[decided]**
 
 Three things move together: OS image build ↔ allwpilib version and
-commit ↔ MRC API number. The discipline is a habit, not a tool: **read
-the device's `MRC_CheckApiVersion` before bumping anything**, and keep
-the bench on the image the checkout expects. A mismatch is not a build
+commit ↔ MRC API number. **Amended 2026-09-06 by #100: the discipline
+is a tool now.** `mrcApiPreflight` in `build.gradle` asks the device
+the same `MRC_CheckApiVersion` question the HAL asks, for the
+`MRC_API_VERSION` declared by the mrclib headers GradleRIO pins. Every
+`ArtifactDeployTask` depends on it, so a mismatched pair fails the
+deploy with both numbers in the message before anything is copied.
+Keep the bench on the image the checkout expects. A mismatch is not a build
 error — the HAL calls `std::terminate()` at startup, and
 `robot.service` is `Restart=always` with `RestartSec=3`
 **[source — `docs/research/systemcore-deploy.md`]**, so it becomes a

--- a/docs/adr/0013-ci-and-test-strategy.md
+++ b/docs/adr/0013-ci-and-test-strategy.md
@@ -17,6 +17,10 @@ alpha-7 moved the project-wide year to `2027_alpha7`, so
 `CommandsV3.json` is back to upstream's value and the three third-party
 JSONs are the edited side. The section and its table are rewritten to
 the state that actually holds; nothing about the decision changed.
+Amended 2026-09-06 by #100: *A pre-flight ABI probe* stays rejected as a
+CI assertion and has been built on the deploy path, where the audience
+is different. The entry says which is which, and names the one thing it
+moves — the nightly's designed red now lands on the deploy step.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -804,12 +808,26 @@ cannot already write, and the natives it avoids are already on the test
 JVM's path. *Re-raise only* if the HAL being up makes a Tier 1 test slow
 or flaky — which is a measurement, not an opinion.
 
-### A pre-flight ABI probe
+### A pre-flight ABI probe *in CI*
 
 Reading the image's ceiling over ssh with `ctypes` on
 `MRC_CheckApiVersion` was offered and declined — *"don't over engineer a
 system that is going stable shortly."* Observation plus the literal
-`grep` in assertion (4) gets the same sentence in front of a student.
+`grep` in assertion (4) gets the same sentence in front of a student,
+and assertion (1) already catches the abort without parsing anything.
+
+**Still rejected here, and built elsewhere.** #100 put the probe on the
+*deploy* path instead, as `mrcApiPreflight` in `build.gradle`: CI is not
+where this hazard is met, because a student clicking the VSCode deploy
+button never sees a workflow. The decision above is unchanged, but one
+consequence of it is. Job 1 deploys through the same `deploy` task, so
+**the nightly's designed red now lands on the Gradle step rather than on
+assertion (1)**. That is the better failure of the two — the exception
+names both version numbers and the remedy, where `NRestarts=1` named
+neither, and the Step Summary rule is satisfied by the exception text
+itself. Assertion (1) keeps its other half, every startup exception that
+is not an ABI mismatch, and assertion (4) keeps being the cheap literal
+`grep` for the case where an image somehow gets past the preflight.
 
 ### Putting a SPARK and a Pigeon2 on the bench to make ADR 0004's config path assertable
 


### PR DESCRIPTION
The SystemCore OS image and the WPILib build are a version **pair**. The image ships
`/usr/lib/libMrcLib.so`, the HAL calls `MRC_CHECK_API_VERSION()` before it prints anything, and a
mismatch is a three-second crash loop with nothing said at build time. #18 decided the check and it
was never built; the margin today is **zero** (requested 12, image accepts 12), so the next mrclib
bump is the one that breaks.

## What this adds

`mrcApiPreflight`, a Gradle task every `ArtifactDeployTask` depends on.

- **Requested half** — resolves `org.wpilib.mrclib:mrclib-cpp:<wpi.versions.mrcLibVersion>:headers@zip`
  and reads `#define MRC_API_VERSION` out of `mrclib/ApiVersion.h`. No table to keep current, no
  allwpilib checkout. Confirmed `v2027.0.0-alpha-7:gradle/libs.versions.toml` pins mrclib
  `…-116-g5288562`, exactly the plugin's constant, so this tracks the WPILib actually on the classpath.
- **Image half** — asks the device the same `MRC_CheckApiVersion` question the HAL asks, over
  **the deploy's own ssh session** (`TargetDiscoveryTask`), not a separate `ssh`. That is what makes
  it reach the student clicking the VSCode deploy button, who has no key installed.
- **Placement** — every file copy *and* the program-kill command is an `ArtifactDeployTask`, so
  gating the type puts the failure before anything on the device is touched.

## The two decisions #100 left open

- **Unreachable bench** — needs no handling of its own. Verified by pointing the target at
  `192.0.2.1`: `discoversystemcore` already fails first with GradleRIO's own "Are you connected to
  the robot, and is it on?", and the preflight never runs. What *is* guarded is the narrower case —
  the box answers but the probe cannot (no `python3`, no `libMrcLib.so`, not a SystemCore): that
  warns and proceeds, because a check that could not run must not block a deploy that would work.
- **`sim-hitl`** — no. That path deploys a `linuxarm64` sim build, which links no `libMrcLib` at all.

## Verified on the bench, all three branches

```
MRC API 12 requested, and the image accepts it.

> MRC API mismatch: this build needs 64 (mrclib 2027.1.0-alpha-1-116-g5288562) and the image
  accepts up to 12. Nothing was deployed. ...

MRC preflight skipped: systemcore@192.168.1.202:22 did not answer the probe. It said:
  Traceback (most recent call last): ...        # and the deploy proceeded
```

In the failing run only `generateBuildMetadata`, `compileJava`, `discoversystemcore` and the empty
`BeforeProgramKill` stage marker ran — no artifact task, `systemctl show robot` untouched.

## Documents

ADR 0013 listed a pre-flight ABI probe under *Rejected*. It stays rejected **as a CI assertion** and
the entry now says so, names where it was built instead, and records the one thing it moves: the
nightly's designed red lands on the Gradle step rather than on assertion (1), which is the better
failure of the two. ADR 0003's "the discipline is a habit, not a tool" was made false by this ticket
and is amended. `CONTEXT.md` gains the term.

## Not done

No automated test. A Gradle deploy-path task has no test seam in this repo — `src/test` is robot
code — and standing up `buildSrc` with its own suite to cover ~60 lines of build script is more
machinery than the check. Verified by execution against real hardware on all three branches instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1cJWYNBuAGEtHJM1n5RWS
