### PR TITLE
Add the bench workflow: real-hal-boot and sim-hitl (#101)

### DIFF
--- a/.github/bench/ds-harness.py
+++ b/.github/bench/ds-harness.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Drives the FIRST Driver Station with nobody at it. Runs on the bench runner.
+
+Control is synthetic input and nothing else. The DS reads keyboards from evdev directly, which
+is why its hotkeys work even when it is not focused, and its NetworkTables mirror on 6767
+accepts writes that reach neither the DS nor the robot. So this creates a uinput keyboard of
+its own and sends the documented hotkeys to it.
+
+The opmode is chosen by writing the DS's settings file before it starts rather than by clicking
+it: an opmode id is (mode << 56) | (name.hashCode() & 0x00FFFFFFFFFFFFFF), which is
+OpModeOption.makeId, so it is computable from the name here. Nothing then depends on where a
+control sits in a window.
+
+The startup gate is undocumented and never times out — the DS asks for the spacebar to verify
+the E-stop before it will do anything at all — so Space goes first, always.
+
+Every part of this is exercised and the robot still does not enable, because the Driver Station
+attaches to no simulation but the one on its own machine. See docs/bench-runner.md.
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import shutil
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+EV_SYN, EV_KEY, SYN_REPORT = 0x00, 0x01, 0x00
+
+KEYS = {
+    "esc": 1,
+    "i": 23,
+    "enter": 28,
+    "space": 57,
+    "leftbrace": 26,
+    "rightbrace": 27,
+    "backslash": 43,
+}
+
+MODES = {"autonomous": 1, "teleoperated": 2, "utility": 3}
+STORAGE_KEY = {"autonomous": "AutoOpModeHash", "teleoperated": "TeleOpModeHash",
+               "utility": "UtilOpModeHash"}
+
+DS_HTTP_PORT = 6768
+
+
+def opmode_id(mode, name):
+    digest = 0
+    for char in name:
+        digest = (31 * digest + ord(char)) & 0xFFFFFFFF
+    if digest >= 2**31:
+        digest -= 2**32
+    return ((MODES[mode] & 0x3) << 56) | (digest & 0x00FFFFFFFFFFFFFF)
+
+
+class Keyboard:
+    """A uinput keyboard. The DS enumerates evdev at startup, so create it before launching."""
+
+    def __init__(self):
+        self.fd = os.open("/dev/uinput", os.O_WRONLY | os.O_NONBLOCK)
+        fcntl.ioctl(self.fd, UI_SET_EVBIT, EV_KEY)
+        for code in KEYS.values():
+            fcntl.ioctl(self.fd, UI_SET_KEYBIT, code)
+        name = b"bench-ds-harness"
+        device = struct.pack("80sHHHHi" + "i" * 256, name.ljust(80, b"\0"),
+                             0x03, 0x0001, 0x0001, 1, 0, *([0] * 256))
+        os.write(self.fd, device)
+        fcntl.ioctl(self.fd, UI_DEV_CREATE)
+        # udev has to publish the event node with the group the DS can read before it is useful.
+        time.sleep(1.0)
+
+    def _event(self, kind, code, value):
+        os.write(self.fd, struct.pack("qqHHi", 0, 0, kind, code, value))
+
+    def _sync(self):
+        self._event(EV_SYN, SYN_REPORT, 0)
+
+    def chord(self, *names, hold=0.08):
+        for name in names:
+            self._event(EV_KEY, KEYS[name], 1)
+            self._sync()
+        time.sleep(hold)
+        for name in reversed(names):
+            self._event(EV_KEY, KEYS[name], 0)
+            self._sync()
+        time.sleep(0.15)
+
+    def close(self):
+        fcntl.ioctl(self.fd, UI_DEV_DESTROY)
+        os.close(self.fd)
+
+
+class Display:
+    """The runner has no screen, so the DS gets an Xvfb. An existing DISPLAY is used as it is."""
+
+    def __init__(self, number=":99"):
+        self.process = None
+        self.name = os.environ.get("DISPLAY")
+        if self.name:
+            return
+        if not shutil.which("Xvfb"):
+            raise SystemExit("no DISPLAY and no Xvfb; see docs/bench-runner.md")
+        self.name = number
+        self.process = subprocess.Popen(
+            ["Xvfb", number, "-screen", "0", "1280x1024x24", "-nolisten", "tcp"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(2.0)
+
+    def close(self):
+        if self.process:
+            self.process.terminate()
+
+
+def select_opmode(storage, mode, name):
+    """Writes the selection into the DS's settings file and returns the previous contents."""
+    original = storage.read_text() if storage.exists() else None
+    settings = json.loads(original) if original else {}
+    settings[STORAGE_KEY[mode]] = opmode_id(mode, name)
+    storage.parent.mkdir(parents=True, exist_ok=True)
+    storage.write_text(json.dumps(settings, indent=2))
+    return original
+
+
+def wait_for_ds(deadline):
+    while time.time() < deadline:
+        with socket.socket() as probe:
+            probe.settimeout(0.5)
+            if probe.connect_ex(("127.0.0.1", DS_HTTP_PORT)) == 0:
+                return True
+        time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--opmode", default="DefaultTeleop")
+    parser.add_argument("--mode", default="teleoperated", choices=sorted(MODES))
+    parser.add_argument("--enable-seconds", type=float, default=40.0)
+    parser.add_argument("--ds-home", default=os.path.expanduser("~/ds"))
+    parser.add_argument("--storage", default=os.path.expanduser(
+        "~/.local/share/FIRSTDriverStation/DriverStationStorage.json"))
+    args = parser.parse_args()
+
+    storage = Path(args.storage)
+    binary = Path(args.ds_home) / "FirstDriverStation"
+    if not binary.exists():
+        raise SystemExit(f"no Driver Station at {binary}; see docs/bench-runner.md")
+
+    original = select_opmode(storage, args.mode, args.opmode)
+    display = None
+    keyboard = None
+    ds = None
+
+    status = 0
+    try:
+        display = Display()
+        keyboard = Keyboard()
+
+        environment = dict(os.environ)
+        environment.update(DISPLAY=display.name, NO_AT_BRIDGE="1", LIBGL_ALWAYS_SOFTWARE="1")
+        environment.pop("SESSION_MANAGER", None)
+        ds = subprocess.Popen([str(binary)], cwd=args.ds_home, env=environment,
+                              stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+        if not wait_for_ds(time.time() + 60):
+            raise SystemExit("the Driver Station never came up")
+        time.sleep(5.0)
+
+        keyboard.chord("space")            # the startup gate
+        time.sleep(2.0)
+        keyboard.chord("leftbrace", "rightbrace", "backslash")   # enable
+        print(f"enabled for {args.enable_seconds:.0f}s", flush=True)
+        time.sleep(args.enable_seconds)
+        keyboard.chord("enter")            # disable
+        time.sleep(1.0)
+    except SystemExit as failure:
+        print(failure, file=sys.stderr)
+        status = 1
+    finally:
+        if ds is not None:
+            ds.send_signal(signal.SIGTERM)
+            try:
+                ds.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                ds.kill()
+        if keyboard is not None:
+            keyboard.close()
+        if display is not None:
+            display.close()
+        # A box whose Driver Station had never stored settings gets its clean state back, not
+        # this run's opmode selection.
+        if original is not None:
+            storage.write_text(original)
+        else:
+            storage.unlink(missing_ok=True)
+
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/bench/ds-relay.py
+++ b/.github/bench/ds-relay.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Puts the bench's simulation on the runner's own loopback, where a Driver Station looks.
+
+mrclib's sim system server binds loopback only — a desktop simulation and its Driver Station
+are normally the same machine — so a simulation on the bench is invisible to a Driver Station
+anywhere else. This bridges the three UDP ports of that link, one copy of this on each box,
+with TCP going through ssh -L alongside it.
+
+  bench:  ds-relay.py --role bench  --peer <runner>
+  runner: ds-relay.py --role runner --peer <bench>
+
+Both ends need the peer up front. The simulation announces itself to the station before the
+station has said anything, so a bench relay that waited to learn where to send would deadlock
+against a station waiting to be announced to.
+
+The packets do cross, in both directions, and the Driver Station still does not attach: it
+finds no robot it did not find locally. See docs/bench-runner.md — what is missing is upstream's
+rather than a port that was left out here.
+
+Nothing writes NetworkTables: port 6767 accepts writes, propagates none of them, and corrupts
+the view for every other reader.
+"""
+
+import argparse
+import select
+import socket
+import subprocess
+import sys
+
+TO_ROBOT = (1110, 1115)
+TO_STATION = 1135
+
+
+def lan_address(peer):
+    """The address this box reaches the peer from, which is the one the peer must answer on."""
+    route = subprocess.run(
+        ["ip", "route", "get", peer], capture_output=True, text=True
+    ).stdout.split()
+    if "src" not in route:
+        raise SystemExit(f"no route to {peer}; pass --bind")
+    return route[route.index("src") + 1]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--role", required=True, choices=("bench", "runner"))
+    parser.add_argument("--peer", required=True, help="the address of the other box")
+    parser.add_argument("--bind", default=None, help="this box's LAN address")
+    arguments = parser.parse_args()
+
+    lan = arguments.bind or lan_address(arguments.peer)
+    runner = arguments.role == "runner"
+
+    # Each end binds the side its local process is not already using: the simulation holds
+    # loopback on the bench, and the Driver Station holds loopback on the runner.
+    inbound = {}
+    for port in TO_ROBOT:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1" if runner else lan, port))
+        inbound[sock] = port
+
+    returning = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    returning.bind((lan if runner else "127.0.0.1", TO_STATION))
+
+    out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    print(f"relay up as {arguments.role} on {lan}, peer {arguments.peer}", flush=True)
+
+    while True:
+        ready, _, _ = select.select([*inbound, returning], [], [], 1.0)
+        for sock in ready:
+            data, _ = sock.recvfrom(65535)
+            if sock is returning:
+                # Robot to station: onto the wire from the bench, into loopback on the runner.
+                out.sendto(data, ("127.0.0.1" if runner else arguments.peer, TO_STATION))
+            else:
+                port = inbound[sock]
+                out.sendto(data, (arguments.peer if runner else "127.0.0.1", port))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/.github/bench/real-hal-boot.sh
+++ b/.github/bench/real-hal-boot.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# ADR 0013's Job 1. Deploys the real artifact to the bench Pi against an empty CAN bus, waits for
+# the program to settle, and asserts four things about it. The Markdown on stdout is what the
+# bench workflow puts in its step summary, so running this by hand gives the same report CI gives.
+#
+#   BENCH=systemcore@192.168.1.202 .github/bench/real-hal-boot.sh
+#
+# An unreachable bench is a skip and exits 0: there is one Pi, and a job that reddens because it
+# is unplugged teaches people to ignore CI.
+set -uo pipefail
+
+BENCH=${BENCH:-systemcore@192.168.1.202}
+SETTLE=${SETTLE:-30}
+OUT=${OUT:-build/bench}
+
+cd "$(dirname "$0")/../.."
+mkdir -p "$OUT"
+JOURNAL="$OUT/real-hal-boot-journal.txt"
+
+on_bench() { ssh -o BatchMode=yes -o ConnectTimeout=10 "$BENCH" "$@"; }
+
+if ! on_bench true 2>/dev/null; then
+  echo "### real-hal-boot skipped"
+  echo
+  echo "The bench (\`$BENCH\`) did not answer. Nothing was deployed and nothing is asserted."
+  exit 0
+fi
+
+# The journal is read from here rather than from the boot, so a second run in the same boot does
+# not assert on the first run's lines.
+since=$(on_bench date +%s)
+
+# NRestarts counts automatic restarts and nothing clears it on its own, so a crash three runs ago
+# would otherwise fail this one.
+on_bench sudo systemctl reset-failed robot
+
+echo "Deploying to $BENCH ..." >&2
+deploy_log="$OUT/real-hal-boot-deploy.txt"
+./gradlew deploy 2>&1 | tee "$deploy_log" >&2
+deploy_status=${PIPESTATUS[0]}
+
+if [ "$deploy_status" -ne 0 ]; then
+  echo "### real-hal-boot is red — the deploy failed"
+  echo
+  echo "Nothing was asserted, because nothing new is running. The Gradle output names the cause;"
+  echo "an MRC API mismatch is the expected one on a nightly, and its remedy is to reflash the"
+  echo "bench from LimelightVision/systemcore-os-public."
+  echo
+  echo '```'
+  tail -25 "$deploy_log"
+  echo '```'
+  exit 1
+fi
+
+sleep "$SETTLE"
+
+facts=$(on_bench 'sh -s' <<'REMOTE'
+main=$(systemctl show robot -p MainPID --value)
+pid=$main
+# The unit runs robotCommand through bash, so the JVM is its child rather than the main pid.
+if [ "$(cat /proc/$pid/comm 2>/dev/null)" != java ]; then
+  pid=$(awk '{print $1}' /proc/$main/task/$main/children 2>/dev/null)
+fi
+echo "NRESTARTS=$(systemctl show robot -p NRestarts --value)"
+echo "ACTIVESTATE=$(systemctl show robot -p ActiveState --value)"
+echo "STARTED=$(systemctl show robot -p ExecMainStartTimestamp --value)"
+echo "PID=$pid"
+if [ -r "/proc/$pid/status" ]; then
+  echo "RSS_KB=$(awk '/^VmRSS:/{print $2}' /proc/$pid/status)"
+  echo "THREADS=$(awk '/^Threads:/{print $2}' /proc/$pid/status)"
+  for task in /proc/$pid/task/*; do
+    tid=${task##*/}
+    line=$(chrt -p "$tid" 2>/dev/null | tr '\n' ' ')
+    case "$line" in
+      *SCHED_RR*) echo "RR=$tid:$(echo "$line" | sed -n 's/.*priority: \([0-9]*\).*/\1/p')" ;;
+    esac
+  done
+fi
+REMOTE
+)
+
+# An empty CAN bus floods the journal, so the two greps run over the whole window on the Pi and
+# only the artifact is trimmed to the last 500 lines.
+window="journalctl -u robot --since '@$since' -o short-iso-precise --no-pager"
+on_bench "$window | tail -500" > "$JOURNAL"
+started_ok=$(on_bench "$window | grep -c 'Robot program startup complete'")
+mrc_mismatch=$(on_bench "$window | grep -c 'MRC API version mismatch'")
+complete=$(on_bench "$window | grep -m1 'Robot program startup complete'" | cut -d' ' -f1)
+
+fact() { echo "$facts" | sed -n "s/^$1=//p" | head -1; }
+
+restarts=$(fact NRESTARTS)
+active=$(fact ACTIVESTATE)
+started=$(fact STARTED)
+rss_kb=$(fact RSS_KB)
+threads=$(fact THREADS)
+rr=$(echo "$facts" | sed -n 's/^RR=//p' | paste -sd', ' -)
+
+# Both timestamps are the Pi's, and only their difference is used, so the runner's clock and time
+# zone do not enter into it.
+startup=
+if [ -n "$complete" ] && [ -n "$started" ]; then
+  startup=$(date -u -d "$complete" +%s.%N 2>/dev/null | awk -v s="$(date -u -d "$started" +%s 2>/dev/null)" \
+    '{ if (s != "") printf "%.1f s", $1 - s }')
+fi
+
+fail=0
+report() { printf -- '- %s **%s** — %s\n' "$1" "$2" "$3"; }
+assert() {
+  if [ "$1" = pass ]; then
+    report '✅' "$2" "$3"
+  else
+    report '❌' "$2" "$3"
+    fail=1
+  fi
+}
+
+{
+  echo "### real-hal-boot"
+  echo
+  echo "The real artifact (\`linuxsystemcore\`) on \`$BENCH\`, ${SETTLE}s after the deploy, against an empty CAN bus."
+  echo
+
+  if [ "$restarts" = 0 ]; then
+    assert pass "the program did not restart" "\`NRestarts=0\`."
+  else
+    assert fail "the program restarted ${restarts}×" \
+      "systemd restarted it, so it died. The journal artifact holds the exception; \`Restart=always\` with \`RestartSec=3\` means it is still going round."
+  fi
+
+  if [ "$active" = active ]; then
+    assert pass "the unit is active" "\`ActiveState=active\`."
+  else
+    assert fail "the unit is \`$active\`" "The program exited, which a robot program never does on its own."
+  fi
+
+  if [ "${started_ok:-0}" -gt 0 ]; then
+    assert pass "the loop started" "\`Robot program startup complete\` is in the journal."
+  else
+    assert fail "the loop never started" \
+      "The program came up and hung before the first loop. The journal artifact holds the last 500 lines."
+  fi
+
+  if [ "${mrc_mismatch:-0}" -gt 0 ]; then
+    assert fail "the image and the library disagree" \
+      "\`MRC API version mismatch\` is in the journal. The OS image and WPILib are a pair: reflash the bench from LimelightVision/systemcore-os-public, or move the WPILib pin back to an alpha the image accepts."
+  else
+    assert pass "no MRC API mismatch" "The image accepts the API this build asks for."
+  fi
+
+  echo
+  echo "Four numbers, and they gate nothing. RSS creep, or a third \`SCHED_RR\` thread, is worth an eye."
+  echo
+  echo '| metric | this run | #10, on a heartbeat program |'
+  echo '|---|---|---|'
+  printf '| RSS | %s | 83 MB |\n' "${rss_kb:+$((rss_kb / 1024)) MB}"
+  printf '| Threads | %s | 36 |\n' "${threads:-—}"
+  printf '| `SCHED_RR` threads (tid:priority) | %s | two — 50 (CAN), 40 (Notifier) |\n' "${rr:-none}"
+  printf '| start → `startup complete` | %s | — |\n' "${startup:-—}"
+} > "$OUT/real-hal-boot-summary.md"
+
+cat "$OUT/real-hal-boot-summary.md"
+exit "$fail"

--- a/.github/bench/sim-hitl-baseline.env
+++ b/.github/bench/sim-hitl-baseline.env
@@ -1,0 +1,11 @@
+# The loop the bench holds with nothing enabled, measured by sim-hitl on 2026-09-07 across two
+# runs of a linuxarm64 build on the Raspberry Pi 5 the bench is today. Seconds, because that is
+# what the log stores.
+#
+# sim-hitl compares deltas against these, never absolute milliseconds. Rebaseline when the bench
+# hardware or ADR 0002's loop period changes — never to clear a red, which is the regression this
+# file exists to catch.
+BASELINE_DISABLED_P50=0.0050000
+BASELINE_DISABLED_P95=0.0050261
+BASELINE_DISABLED_P99=0.0050588
+BASELINE_TOLERANCE=0.0005

--- a/.github/bench/sim-hitl.sh
+++ b/.github/bench/sim-hitl.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# ADR 0013's Job 2. Runs a linuxarm64 simulation build on the bench Pi — real aarch64, real
+# PREEMPT_RT kernel, real JDK 25, real Notifier scheduling, nothing plugged in — and watches the
+# loop for a regression against a stored baseline. The Markdown on stdout is what the bench
+# workflow puts in its step summary.
+#
+#   BENCH=systemcore@192.168.1.202 .github/bench/sim-hitl.sh
+#
+# DS=on additionally brings up the Driver Station harness. It is off by default because the
+# Driver Station finds a simulation only on its own machine — see docs/bench-runner.md — so the
+# loop measured here is the disabled one.
+#
+# An unreachable bench is a skip and exits 0.
+set -uo pipefail
+
+BENCH=${BENCH:-systemcore@192.168.1.202}
+BENCH_HOST=${BENCH#*@}
+RUN=${RUN:-45}
+DS=${DS:-off}
+OPMODE=${OPMODE:-DefaultTeleop}
+OUT=${OUT:-build/bench}
+REMOTE=/home/systemcore/simhitl
+BASELINE=.github/bench/sim-hitl-baseline.env
+
+cd "$(dirname "$0")/../.."
+mkdir -p "$OUT"
+RUNLOG="$OUT/sim-hitl-run.log"
+WPILOG="$OUT/sim-hitl.wpilog"
+
+on_bench() { ssh -o BatchMode=yes -o ConnectTimeout=10 "$BENCH" "$@"; }
+
+# The address this box reaches the bench from, which is the one the bench must answer on. A
+# multi-homed runner has more than one and only this one is routable both ways.
+route_source() { ip route get "$1" | awk '{ for (i = 1; i < NF; i++) if ($i == "src") { print $(i + 1); exit } }'; }
+
+if ! on_bench true 2>/dev/null; then
+  echo "### sim-hitl skipped"
+  echo
+  echo "The bench (\`$BENCH\`) did not answer. Nothing ran and nothing is asserted."
+  exit 0
+fi
+
+held=
+restore() {
+  for pid in $held; do kill "$pid" 2>/dev/null; done
+  held=
+  # There is no pkill on the image and killall would take robot.service's JVM with it, so the
+  # sim and the relay leave their own pids behind: `exec` keeps the shell's, so it is the JVM's.
+  #
+  # The three services come back one at a time, and the last program has to be gone before the
+  # first of them starts: anything still registered on the system server makes the next program
+  # abort with "Multiple user programs detected", and robot.service would crash-loop on it.
+  on_bench "for f in $REMOTE/*.pid; do [ -f \"\$f\" ] && kill \$(cat \"\$f\") 2>/dev/null; done
+            rm -f $REMOTE/*.pid
+            sleep 2
+            sudo systemctl restart mrccomm && sleep 3
+            sudo systemctl restart limelight_diagnosticsprocess && sleep 3
+            sudo systemctl start robot" >/dev/null 2>&1
+}
+
+./gradlew simHitlStage >"$OUT/sim-hitl-stage.log" 2>&1 || {
+  echo "### sim-hitl is red — the linuxarm64 build did not stage"
+  echo
+  echo '```'
+  tail -20 "$OUT/sim-hitl-stage.log"
+  echo '```'
+  exit 1
+}
+
+# robot.service holds the CAN bus and the NT port; mrccomm holds UDP 1110; the diagnostics
+# service holds the system NetworkTables server on 6810. The sim wants all three, and it aborts
+# with "Multiple user programs detected" if a previous program is still registered on 6810.
+# Nothing above this line has touched the bench, and nothing below it may leave it stopped.
+trap restore EXIT INT TERM
+on_bench 'sudo systemctl stop robot mrccomm limelight_diagnosticsprocess'
+
+tar -C build/simhitl -czf - . |
+  on_bench "rm -rf $REMOTE && mkdir -p $REMOTE && tar xzf - -C $REMOTE" || {
+  echo "### sim-hitl is red — the bundle did not reach the bench"
+  exit 1
+}
+scp -q -o BatchMode=yes .github/bench/ds-relay.py "$BENCH:$REMOTE/"
+
+# The sim runs in the foreground of an ssh that stays open: busybox nohup and setsid are applets
+# of a setuid binary, and the loader strips LD_PRELOAD from anything it execs, which would take
+# the REVLib shim with it.
+: >"$RUNLOG"
+rm -f "$WPILOG"
+on_bench "cd $REMOTE && rm -rf logs && echo \$\$ > sim.pid \
+  && LD_PRELOAD=\$PWD/lib/libwpiutil.so:\$PWD/lib/librevshim.so \
+  LD_LIBRARY_PATH=\$PWD/lib HALSIM_EXTENSIONS=\$PWD/lib/libhalsim_ds_socket.so \
+  exec /usr/bin/java -Djava.library.path=\$PWD/lib \
+    --add-opens java.base/jdk.internal.vm=ALL-UNNAMED \
+    --add-opens java.base/java.lang=ALL-UNNAMED --enable-native-access=ALL-UNNAMED \
+    -cp 'classpath/*' first.Main" >"$RUNLOG" 2>&1 &
+held="$held $!"
+
+for _ in $(seq 60); do
+  grep -q 'Robot program startup complete' "$RUNLOG" && break
+  sleep 1
+done
+
+if ! grep -q 'Robot program startup complete' "$RUNLOG"; then
+  echo "### sim-hitl is red — the simulation never reached its loop"
+  echo
+  echo "60s after launch the program had not printed \`Robot program startup complete\`."
+  echo
+  echo '```'
+  tail -25 "$RUNLOG"
+  echo '```'
+  exit 1
+fi
+
+if [ "$DS" = on ]; then
+  runner=$(route_source "$BENCH_HOST")
+  bench_lan=$(on_bench "ip route get $runner" |
+    awk '{ for (i = 1; i < NF; i++) if ($i == "src") { print $(i + 1); exit } }')
+  on_bench "echo \$\$ > $REMOTE/relay.pid
+            exec python3 $REMOTE/ds-relay.py --role bench --peer $runner --bind $bench_lan" \
+    >"$OUT/sim-hitl-relay.log" 2>&1 &
+  held="$held $!"
+  python3 .github/bench/ds-relay.py --role runner --peer "$BENCH_HOST" --bind "$runner" \
+    >>"$OUT/sim-hitl-relay.log" 2>&1 &
+  held="$held $!"
+  ssh -o BatchMode=yes -N -L 6810:127.0.0.1:6810 -L 1740:127.0.0.1:1740 \
+    -L 1741:127.0.0.1:1741 -L 5810:127.0.0.1:5810 "$BENCH" &
+  held="$held $!"
+  sleep 3
+  python3 .github/bench/ds-harness.py --opmode "$OPMODE" --enable-seconds "$RUN" \
+    >"$OUT/sim-hitl-ds.log" 2>&1
+else
+  sleep "$RUN"
+fi
+
+restore
+sleep 2
+on_bench "ls $REMOTE/logs/*.wpilog" >"$OUT/sim-hitl-logs.txt" 2>/dev/null
+remote_log=$(tail -1 "$OUT/sim-hitl-logs.txt")
+[ -n "$remote_log" ] && scp -q -o BatchMode=yes "$BENCH:$remote_log" "$WPILOG"
+
+facts=
+[ -s "$WPILOG" ] && facts=$(python3 .github/bench/wpilog-stats.py "$WPILOG")
+fact() { echo "$facts" | sed -n "s/^$1=//p" | head -1; }
+
+# shellcheck source=/dev/null
+[ -f "$BASELINE" ] && . "$BASELINE"
+
+# The enabled loop is the one worth watching, and it is only measurable with a Driver Station
+# attached; without one this falls back to the disabled loop rather than reporting nothing.
+if [ -n "$(fact ENABLED_P50)" ]; then
+  state=enabled
+  p50=$(fact ENABLED_P50); p95=$(fact ENABLED_P95); p99=$(fact ENABLED_P99); max=$(fact ENABLED_MAX)
+  base_p50=${BASELINE_ENABLED_P50:-}; base_p95=${BASELINE_ENABLED_P95:-}; base_p99=${BASELINE_ENABLED_P99:-}
+else
+  state=disabled
+  p50=$(fact DISABLED_P50); p95=$(fact DISABLED_P95); p99=$(fact DISABLED_P99); max=$(fact DISABLED_MAX)
+  base_p50=${BASELINE_DISABLED_P50:-}; base_p95=${BASELINE_DISABLED_P95:-}; base_p99=${BASELINE_DISABLED_P99:-}
+fi
+tolerance=${BASELINE_TOLERANCE:-0.0005}
+
+ms() { awk -v v="${1:-}" 'BEGIN { if (v == "") print "—"; else printf "%.3f ms", v * 1000 }'; }
+delta() {
+  awk -v v="${1:-}" -v b="${2:-}" 'BEGIN {
+    if (v == "" || b == "") print "—"; else printf "%+.3f ms", (v - b) * 1000 }'
+}
+over() {
+  awk -v v="${1:-}" -v b="${2:-}" -v t="$tolerance" 'BEGIN {
+    print (v != "" && b != "" && v - b > t) ? "yes" : "no" }'
+}
+
+fail=0
+assert() {
+  if [ "$1" = pass ]; then
+    printf -- '- ✅ **%s** — %s\n' "$2" "$3"
+  else
+    printf -- '- ❌ **%s** — %s\n' "$2" "$3"
+    fail=1
+  fi
+}
+
+{
+  echo "### sim-hitl"
+  echo
+  echo "A \`linuxarm64\` simulation build on \`$BENCH\`: real aarch64, real kernel, real JDK, nothing plugged in."
+  echo
+
+  if grep -q 'HAL Extensions: Successfully loaded extension' "$RUNLOG"; then
+    assert pass "the sim HAL ran on the Pi" \
+      "\`halsim_ds_socket\` loaded, and the real HAL has no symbol for it."
+  else
+    assert fail "the sim HAL did not load" \
+      "\`linuxarm64\` is the sim HAL and \`linuxsystemcore\` the real one; this build linked neither usefully."
+  fi
+
+  assert pass "the loop started" "\`Robot program startup complete\` is in the console log."
+
+  if grep -qE 'Unhandled exception|quit unexpectedly' "$RUNLOG"; then
+    assert fail "the program threw" "The console log holds an unhandled exception."
+  else
+    assert pass "nothing threw" "No unhandled exception in the console log."
+  fi
+
+  if [ -z "$p50" ]; then
+    assert fail "no loop to measure" \
+      "No \`/Telemetry/Robot/LoopDelta\` came back, so either the log did not survive the run or it never reached this box."
+  elif [ -z "$base_p50" ]; then
+    assert pass "no $state baseline to regress against" \
+      "\`$BASELINE\` carries none, so this run reports numbers instead of asserting on them."
+  elif [ "$(over "$p95" "$base_p95")" = no ] && [ "$(over "$p50" "$base_p50")" = no ]; then
+    assert pass "the $state loop is where it was" \
+      "p50 $(delta "$p50" "$base_p50"), p95 $(delta "$p95" "$base_p95") against the baseline."
+  else
+    assert fail "the $state loop got slower" \
+      "p50 $(delta "$p50" "$base_p50"), p95 $(delta "$p95" "$base_p95"), past $(ms "$tolerance"). These are deltas, not a budget: rebaseline when the bench hardware changes, never to clear a red."
+  fi
+
+  # The bench belongs to whoever wants it next, and this job stopped three of its services.
+  if [ "$(on_bench 'systemctl is-active robot' 2>/dev/null)" != active ]; then
+    assert fail "the bench did not come back" \
+      "\`robot.service\` is not active after the run. Restart it by hand: stop it, restart \`mrccomm\` and \`limelight_diagnosticsprocess\` one at a time, then start it."
+  fi
+
+  echo
+  if [ "$state" = disabled ]; then
+    echo "No Driver Station is attached, so this is the **disabled** loop. The Driver Station"
+    echo "finds a simulation only on the machine it runs on; \`DS=on\` brings the harness up"
+    echo "anyway. See docs/bench-runner.md."
+    echo
+  fi
+
+  echo "| loop ($state) | this run | baseline | delta |"
+  echo '|---|---|---|---|'
+  printf '| p50 | %s | %s | %s |\n' "$(ms "$p50")" "$(ms "$base_p50")" "$(delta "$p50" "$base_p50")"
+  printf '| p95 | %s | %s | %s |\n' "$(ms "$p95")" "$(ms "$base_p95")" "$(delta "$p95" "$base_p95")"
+  printf '| p99 | %s | %s | %s |\n' "$(ms "$p99")" "$(ms "$base_p99")" "$(delta "$p99" "$base_p99")"
+  printf '| max | %s | — | — |\n' "$(ms "$max")"
+} > "$OUT/sim-hitl-summary.md"
+
+cat "$OUT/sim-hitl-summary.md"
+exit "$fail"

--- a/.github/bench/wpilog-stats.py
+++ b/.github/bench/wpilog-stats.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Prints the facts sim-hitl asserts on, as KEY=value lines, from a robot WPILOG.
+
+The record framing is parsed here rather than by a library because there is no released WPILOG
+reader for 2027 and the framing is a short parse. Timestamps on disk are microseconds: the Java
+API is nanoseconds in both directions and DataLog divides on the way in.
+
+`DS:controlWord` is one uint64 bitfield whose layout is in the log's own schema entry —
+opModeHash:56, robotMode:2, enabled:1, eStop:1, fmsAttached:1, dsAttached:1.
+"""
+
+import struct
+import sys
+
+LOOP = "/Telemetry/Robot/LoopDelta"
+CONTROL = "DS:controlWord"
+OPMODE = "DS:opMode"
+
+
+def records(data):
+    """Walks the file, stopping at the first partial record rather than reading past it.
+
+    The simulation is killed rather than closed, so a torn tail record is the normal ending.
+    """
+    extra = struct.unpack("<I", data[8:12])[0]
+    pos = 12 + extra
+    while pos < len(data):
+        header = data[pos]
+        id_len = (header & 0x3) + 1
+        size_len = ((header >> 2) & 0x3) + 1
+        stamp_len = ((header >> 4) & 0x7) + 1
+        pos += 1
+        if pos + id_len + size_len + stamp_len > len(data):
+            return
+        entry = int.from_bytes(data[pos : pos + id_len], "little")
+        pos += id_len
+        size = int.from_bytes(data[pos : pos + size_len], "little")
+        pos += size_len
+        stamp = int.from_bytes(data[pos : pos + stamp_len], "little")
+        pos += stamp_len
+        if pos + size > len(data):
+            return
+        yield entry, stamp, data[pos : pos + size]
+        pos += size
+
+
+def read(path):
+    data = open(path, "rb").read()
+    if data[:6] != b"WPILOG":
+        raise SystemExit(f"{path} is not a WPILOG")
+    names = {}
+    loop = []
+    control = []
+    opmodes = []
+    for entry, stamp, payload in records(data):
+        if entry == 0:
+            if len(payload) < 9 or payload[0] != 0:
+                continue
+            entry_id, length = struct.unpack("<II", payload[1:9])
+            if len(payload) < 9 + length:
+                continue
+            names[entry_id] = payload[9 : 9 + length].decode(errors="replace")
+        else:
+            name = names.get(entry)
+            if name == LOOP and len(payload) == 8:
+                loop.append((stamp, struct.unpack("<d", payload)[0]))
+            elif name == CONTROL and len(payload) == 8:
+                control.append((stamp, struct.unpack("<Q", payload)[0]))
+            elif name == OPMODE:
+                opmodes.append(payload.decode(errors="replace"))
+    return loop, control, opmodes
+
+
+def spans(control, bit, until):
+    """The [start, end) stamps over which the given control-word bit was set.
+
+    The control word is logged only when it changes, so a run that ends while still enabled has
+    its enable as the last record. Such a span runs to `until` — the end of the log — rather
+    than to itself, which would be empty and would put every enabled sample in the other bucket.
+    """
+    out = []
+    open_at = None
+    for stamp, word in control:
+        on = (word >> bit) & 1
+        if on and open_at is None:
+            open_at = stamp
+        elif not on and open_at is not None:
+            out.append((open_at, stamp))
+            open_at = None
+    if open_at is not None:
+        out.append((open_at, until + 1))
+    return out
+
+
+def stats(samples):
+    if not samples:
+        return {}
+    ordered = sorted(samples)
+    at = lambda q: ordered[min(len(ordered) - 1, int(len(ordered) * q))]
+    return {
+        "SAMPLES": len(ordered),
+        "P50": at(0.50),
+        "P95": at(0.95),
+        "P99": at(0.99),
+        "MAX": ordered[-1],
+    }
+
+
+def main():
+    loop, control, opmodes = read(sys.argv[1])
+    last = max((stamp for stamp, _ in loop + control), default=0)
+    enabled = spans(control, 58, last)
+    attached = spans(control, 61, last)
+
+    # The first loops after an enable are the opmode's construction and its first schedule, which
+    # are not the steady state this is watching for a regression.
+    settle = 1_000_000
+    inside = [
+        value
+        for stamp, value in loop
+        if any(start + settle <= stamp < end for start, end in enabled)
+    ]
+    outside = [
+        value
+        for stamp, value in loop
+        if not any(start <= stamp < end for start, end in enabled)
+    ]
+
+    print(f"DS_ATTACHED={1 if attached else 0}")
+    print(f"ENABLED_WINDOWS={len(enabled)}")
+    print(f"ENABLED_SECONDS={sum(end - start for start, end in enabled) / 1e6:.1f}")
+    print(f"OPMODE={opmodes[-1] if opmodes else ''}")
+    for key, value in stats(inside).items():
+        print(f"ENABLED_{key}={value}")
+    for key, value in stats(outside).items():
+        print(f"DISABLED_{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,110 @@
+name: Bench
+
+# The hardware jobs, and they are never a required check. There is one bench Pi: it can gate
+# nothing, and an unreachable bench is a skip rather than a red. Public repo plus a self-hosted
+# runner is why the triggers are trusted branches only and never `pull_request`.
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Nightly, and it is expected to go red on its own: the build floats against a moving WPILib
+    # while the bench stays on the image last flashed to it, so an mrclib bump lands here first.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+# Two jobs and one Pi. Job 1 deploys a real-HAL jar and Job 2 a sim jar to the same box, so the
+# group is the runner rather than the branch, and a superseded run queues instead of cancelling.
+concurrency:
+  group: bench
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BENCH: systemcore@192.168.1.202
+
+jobs:
+  reachable:
+    name: Is the bench up
+    runs-on: [self-hosted, linux, bench]
+    timeout-minutes: 5
+    outputs:
+      up: ${{ steps.probe.outputs.up }}
+    steps:
+      - name: Probe the bench
+        id: probe
+        shell: bash
+        run: |
+          if ssh -o BatchMode=yes -o ConnectTimeout=10 "$BENCH" true 2>/dev/null; then
+            echo "up=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### The bench is unreachable"
+              echo
+              echo "\`$BENCH\` did not answer, so both hardware jobs are skipped. This is not a"
+              echo "failure: there is one bench Pi and it is allowed to be unplugged."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  real-hal-boot:
+    name: real-hal-boot
+    needs: reachable
+    if: needs.reachable.outputs.up == 'true'
+    runs-on: [self-hosted, linux, bench]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # Deploys the real artifact against an empty CAN bus and asserts four things about it.
+      - name: Deploy and assert
+        shell: bash
+        run: .github/bench/real-hal-boot.sh | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the journal
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-hal-boot-${{ github.run_id }}
+          path: build/bench/real-hal-boot-*
+          if-no-files-found: ignore
+
+  sim-hitl:
+    name: sim-hitl
+    needs: [reachable, real-hal-boot]
+    # Serialised behind Job 1 rather than gated on it: they assert different things and one Pi
+    # cannot hold both jars at once.
+    if: ${{ !cancelled() && needs.reachable.outputs.up == 'true' }}
+    runs-on: [self-hosted, linux, bench]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # A linuxarm64 sim build on the Pi, enabled by the real Driver Station on this runner.
+      - name: Simulate on the bench
+        shell: bash
+        run: .github/bench/sim-hitl.sh | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the console log and the WPILOG
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-hitl-${{ github.run_id }}
+          path: |
+            build/bench/sim-hitl-*
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ compile_commands.json
 
 # Eclipse generated file for annotation processors
 .factorypath
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,5 +70,6 @@ needs a removal condition.
 
 - `docs/adr/` — architecture decisions.
 - `CONTEXT.md` — project glossary.
+- `docs/bench-runner.md` — the box the bench workflow runs on.
 - `docs/commands-v3-house-style.md` — command style.
 - `docs/research/` — sources and measurements.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -435,10 +435,15 @@ The index of the ADRs themselves is
 - **The gated workflow** — the one CI workflow that is a required
   check: lint, compile and test, on pull requests targeting `main` and
   on pushes to any branch.
-- **The bench workflow** — the hardware jobs on the bench Pi. It is
-  never required and blocks nothing; an unreachable bench is a skip,
-  not a red.
+- **The bench workflow** — the hardware jobs on the bench Pi,
+  `.github/workflows/bench.yml`. It is never required and blocks
+  nothing; an unreachable bench is a skip, not a red. The box it runs on
+  is [`docs/bench-runner.md`](docs/bench-runner.md)
+  ([ADR 0013](docs/adr/0013-ci-and-test-strategy.md)).
 - **`sim-hitl`** — the bench job that runs a `linuxarm64` sim build on
-  the Pi, so the robot drives around in simulation on real hardware.
-  `real-hal-boot` is its sibling, which deploys the actual robot
-  artifact against an empty CAN bus.
+  the Pi, so the robot runs in simulation on real hardware, and watches
+  the loop for a regression against a stored baseline. The Driver
+  Station attaches to no simulation but its own, so the loop it measures
+  is the disabled one. `real-hal-boot` is its sibling, which deploys the
+  actual robot artifact against an empty CAN bus and asserts four things
+  about the running program.

--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,60 @@ jar {
     from('build.gradle') { into 'backup' }
 }
 
+// Departs from the template: GradleRIO's simulation tasks only ever build for the desktop
+// platform, and sim-hitl is a simulation that runs on the bench Pi. `linuxarm64` is the sim HAL
+// for that architecture and `linuxsystemcore` is the real one, so this is a second set of natives
+// rather than a flag on the deployed build.
+configurations {
+    simHitlNative
+    simHitlHalsim
+}
+
+dependencies {
+    simHitlNative wpi.java.deps.wpilibJniRelease(wpi.platforms.linuxarm64)
+    simHitlNative wpi.java.vendor.jniRelease(wpi.platforms.linuxarm64)
+    // wpi.sim's own dependency set is fixed to the desktop platform, so the plugin is named here.
+    simHitlHalsim "org.wpilib.halsim:halsim_ds_socket:${wpi.versions.wpilibVersion.get()}:linuxarm64@zip"
+}
+
+tasks.register('simHitlStage', Sync) {
+    group = 'wpilib'
+    description = 'Stages a linuxarm64 simulation build for the bench Pi under build/simhitl'
+    into layout.buildDirectory.dir('simhitl')
+
+    into('classpath') {
+        from jar
+        from configurations.runtimeClasspath
+    }
+
+    into('lib') {
+        from { configurations.simHitlNative.collect { zipTree(it) } }
+        from { configurations.simHitlHalsim.collect { zipTree(it) } }
+        // The zips carry a static/ tree beside the shared one and a .debug beside every library;
+        // the launch line wants one flat directory of the shared ones to be both java.library.path
+        // and LD_LIBRARY_PATH.
+        include '**/shared/**'
+        exclude '**/*.debug'
+        // A relativePath set in eachFile is relative to the task's destination rather than to
+        // this block's, so lib/ is named again here or the files land beside it.
+        eachFile { it.relativePath = new RelativePath(true, 'lib', it.name) }
+        includeEmptyDirs = false
+    }
+
+    // The SystemCore shim is aarch64 and the sim natives are the same architecture, so the sim
+    // build needs it for the same reason the deployed one does. See src/main/native/revshim.
+    into('lib') {
+        from 'src/main/native/revshim/linuxsystemcore'
+    }
+
+    // A simulation reads its deploy directory from the source tree rather than from
+    // /home/systemcore/deploy, so the trajectories land where Filesystem.getDeployDirectory()
+    // will look: <run directory>/src/main/deploy.
+    into('src/main/deploy') {
+        from 'src/main/deploy'
+    }
+}
+
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'

--- a/docs/adr/0013-ci-and-test-strategy.md
+++ b/docs/adr/0013-ci-and-test-strategy.md
@@ -21,6 +21,15 @@ Amended 2026-09-06 by #100: *A pre-flight ABI probe* stays rejected as a
 CI assertion and has been built on the deploy path, where the audience
 is different. The entry says which is which, and names the one thing it
 moves — the nightly's designed red now lands on the deploy step.
+Amended 2026-09-07 by #101: the bench workflow exists, and both its
+jobs are executed rather than designed. `real-hal-boot` is green on the
+bench. `sim-hitl` runs a `linuxarm64` build there, which closes the
+first open item — the Pi does run the sim HAL. Two more close with it:
+Xvfb does run the Driver Station, and opmode selection needs no click
+targets. One opens, and it is the reason the loop assertion moved: the
+Driver Station will not attach to a simulation on another machine, so
+the loop measured is the disabled one. The sections below say so where
+they said otherwise.
 
 Claim tags are defined in the index. WPILib `[source]` claims here were
 read at `~/dev/allwpilib` commit `cafb0cc79` — main, 366 commits past
@@ -490,13 +499,56 @@ links **no `libMrcLib`, no real HAL and no vendor CAN natives** — none of
 what Job 1 exists for. And Job 1 can never enable anything. Neither
 subsumes the other.
 
-What Job 2 gets that Job 1 cannot have: a DS is attached, so
-`DataLogManager` never pauses and the full WPILOG survives; and the
-enabled loop can be measured. **The loop-time regression assertion
-belongs here**, against #10's baseline, and as **deltas against a stored
-baseline, never absolute milliseconds** — a regression detector, not a
-budget check, which stays correct if real SystemCore silicon replaces
-the Pi later. **[decided]**
+What Job 2 gets that Job 1 cannot have is a run that is not over in ten
+seconds. **The loop-time regression assertion belongs here**, as
+**deltas against a stored baseline, never absolute milliseconds** — a
+regression detector, not a budget check, which stays correct if real
+SystemCore silicon replaces the Pi later. **[decided]**
+
+It runs. The build stages from `simHitlStage`, ships as a tarball, and
+runs in the foreground of an open ssh; `halsim_ds_socket` loads, the
+program reaches `Robot program startup complete`, and 45 s of
+`/Telemetry/Robot/LoopDelta` comes back at 200 Hz — p50 5.000 ms, p95
+5.026 ms, p99 5.059 ms across two runs, which is what
+`.github/bench/sim-hitl-baseline.env` now carries. **[executed, via
+#101]**
+
+Two halves of the paragraph above were wrong, and running it is what
+said so. The WPILOG does **not** need a DS to survive: those 44 s were
+recorded with none attached. And the **enabled** loop is not measurable
+at all today, because the Driver Station will not attach to a simulation
+on another machine — the next section. So the assertion is against the
+**disabled** loop, through the same baseline mechanism, and `sim-hitl`
+switches to the enabled numbers on its own the day a DS can attach.
+
+### The Driver Station only drives a local simulation
+
+The Driver Station finds a *simulated* robot only on the box it is
+running on. **[executed, via #101]** Against the real robot it discovers
+the Pi and connects over TCP 1740, having first touched 6810 and 5810;
+against a simulation on its own machine it reports `robotIp 127.0.0.1`
+and drives it; against the bench simulation it reports `robotIp 0.0.0.0`
+and opens nothing at all — with the sim owning 6810 and 5810 on the LAN,
+1740/1741 proxied onto it, the sim's loopback UDP doorbell bridged in
+both directions, and all four ports tunnelled onto the runner's own
+loopback.
+
+Two facts about that path are read rather than guessed at.
+`halsim_ds_socket` no longer implements the DS protocol itself: it calls
+`MRC_SimSystemServer_Initialize` and `ForceDsInstance(GetMrcLibDs())`
+(`simulation/halsim_ds_socket/src/main/native/cpp/main.cpp:195-216`) and
+hands the link to mrclib, which binds loopback. And nothing on that path
+gives the simulation an identity: `MRC_SimSystemServer_SetTeam` exists
+in `mrclib/SimSystemServer.h` and the extension never calls it, while
+the DS holds `TeamNumberRequired`. **[source]** Which of the two the
+Driver Station is actually refusing on is **[unverified]** — what is
+measured is that it refuses.
+
+So `sim-hitl` asserts on the disabled loop and the harness sits behind
+`DS=on`, built and unused. What is missing is upstream's: either a
+Driver Station that can be pointed at an address, or an X server on the
+Pi so the arm64 Driver Station runs beside the sim. Neither is ours to
+add, and neither is worth a workaround that pretends the DS is there.
 
 ### Two jobs, one physical Pi, and they cannot run concurrently
 
@@ -690,6 +742,29 @@ covers, or general code-quality opinion.
   ADR 0005's own signals. That is why the loop-time assertion is Job 2's
   and not Job 1's.
 
+- **`busybox` is setuid on the SystemCore image, so `nohup` and
+  `setsid` silently drop `LD_PRELOAD`.** `/bin/busybox` is
+  `-rwsr-xr-x root root` and both are applets of it, so the loader
+  strips `LD_PRELOAD` and `LD_LIBRARY_PATH` from their environment and
+  from everything they exec. **[executed, via #101]** Backgrounding a
+  robot program that way takes ADR 0015's REVLib shim with it, and the
+  failure is a symbol-lookup abort a long way from the cause. `sim-hitl`
+  runs the program in the foreground of an ssh that stays open instead.
+
+- **The sim wants three of the image's own services out of the way.**
+  `mrccomm.service` holds UDP 1110, and `limelight_diagnosticsprocess`
+  holds the system NetworkTables server on 6810 that
+  `MRC_SimSystemServer_Initialize` wants to be. **[executed, via #101]**
+  Leaving them up costs more than a warning: a program still registered
+  on 6810 makes the next one abort with `Multiple user programs
+  detected` and `terminate called without an active exception`. Stop all
+  three, and start all three again however the job ends — **one at a
+  time, and not before the last program is gone**. Starting them
+  together puts `robot.service` into exactly that abort, at
+  `RestartSec=3`, which is a bench left worse than the job found it.
+  **[executed, via #101]** `sim-hitl` reads `systemctl is-active robot`
+  after its own cleanup for that reason, and says so in the summary.
+
 - **Writing to the DS's NetworkTables server corrupts every other reader
   on it.** Port `6767` is a one-way mirror: writes are accepted, stored,
   shown to other clients, and never propagate to the DS or the robot —
@@ -730,22 +805,25 @@ covers, or general code-quality opinion.
 
 ## Open
 
-- **Nobody has run a `linuxarm64` sim build on the SystemCore image.**
-  That `hal-cpp` and `halsim_ds_socket` publish `linuxarm64`, and that
-  the guard makes it a genuine sim artifact, is verified by reading and
-  by artifact listings — not by execution. That the resulting program
-  runs on the image, and that the real DS drives it from a second box,
-  is **[unverified]**. *Unblocked by* running it: it is the first thing
-  the second map should prove, before any YAML is written. If it fails,
-  Job 2 does not exist and Job 1 is the whole hardware story.
+- **The `linuxarm64` sim build runs on the image; the Driver Station
+  will not drive it.** Both halves are executed now rather than read:
+  `linuxarm64`'s `libwpiHal.so` exports 460 `HALSIM_` symbols and links
+  no `libMrcLib`, the program reaches its loop on the bench and logs at
+  200 Hz, and the Driver Station attaches to no simulation but the one
+  on its own machine. Job 2 exists; its enabled half does not.
+  **[executed, via #101]** What is still open is upstream's: a Driver
+  Station that can be pointed at an address, or an X server on the Pi so
+  the arm64 build runs beside the sim. *Unblocked by* neither of ours,
+  and not worth faking in the meantime.
 
-- **Xvfb has never been run against the Driver Station.** The DS is
-  Avalonia/X11 and fails with `XOpenDisplay failed` when `DISPLAY` is
-  unset; Xvfb is the expected answer and software rendering is known to
-  work, but Xvfb is not installed on the WSL box and the step was never
-  executed. **[unverified — `docs/research/ds-headless-control.md:174-179`]**
-  *Unblocked by* one hour on that box. It is #22's one unproven step and
-  it lands squarely on Job 2.
+- **Xvfb runs the Driver Station, and the click-target question is
+  gone.** The DS comes up headless under `Xvfb :99` with software
+  rendering — window, HTTP server and all — and reads a uinput keyboard
+  the harness creates for it. Selecting an opmode needs no clicking:
+  the id is `(mode << 56) | (name.hashCode() & 0x00FFFFFFFFFFFFFF)`,
+  which `.github/bench/ds-harness.py` computes and writes into the DS's
+  settings file, checked against a value the DS itself had stored.
+  **[executed, via #101]** Both were open here and in #22; neither is.
 
 - **The analyzer set has never been run against our Java, because there
   is none.** Inheriting 647 lines of rules is a bet that WPILib's

--- a/docs/bench-runner.md
+++ b/docs/bench-runner.md
@@ -1,0 +1,103 @@
+# The bench runner
+
+[ADR 0013](adr/0013-ci-and-test-strategy.md) decides what the bench workflow runs and what it
+asserts. This is the box it runs on, and it is the one piece of that ADR that is provisioning
+rather than design.
+
+There is one bench Pi, so the workflow can gate nothing. Nothing here should ever be made a
+required check.
+
+## What the runner is
+
+A Linux box on the same LAN as the bench Pi, registered as a self-hosted GitHub runner with the
+labels `self-hosted`, `linux` and `bench`. It builds, deploys over ssh, and — with `DS=on` —
+runs the Driver Station.
+
+The Pi has to be able to send UDP back to it, not only receive: the simulation's Driver Station
+link is two-way. A runner behind NAT from the Pi cannot run `sim-hitl` with `DS=on`.
+
+## Registering it
+
+```bash
+# A registration token, from a repo admin's gh:
+gh api -X POST repos/Drew-Robotics/2027beta/actions/runners/registration-token --jq .token
+
+mkdir ~/actions-runner && cd ~/actions-runner
+curl -sL https://github.com/actions/runner/releases/latest/download/actions-runner-linux-x64.tar.gz | tar xz
+./config.sh --url https://github.com/Drew-Robotics/2027beta --token <token> \
+    --labels self-hosted,linux,bench --unattended
+sudo ./svc.sh install && sudo ./svc.sh start
+```
+
+Two repo settings go with it, and it is both rather than either:
+
+- **Actions → Fork pull request workflows from outside collaborators → require approval for all
+  outside collaborators.** A self-hosted runner on a public repo runs whatever a workflow tells
+  it to.
+- **Branch protection on `main` must not list `real-hal-boot` or `sim-hitl`.** They are allowed
+  to be red, and they are allowed to be absent.
+
+The workflow itself triggers only on pushes to `main`, the nightly schedule and manual dispatch —
+never on `pull_request` — for the same reason.
+
+## What the runner needs installed
+
+| what | why |
+|---|---|
+| an ssh key in `systemcore@<bench>`'s `authorized_keys` | every job reaches the bench over `BatchMode=yes` ssh |
+| `python3` | the WPILOG reader and the Driver Station relay |
+| JDK 25 | `actions/setup-java` provides it in CI; a hand run needs one |
+
+For `DS=on` only:
+
+| what | why |
+|---|---|
+| `xvfb` | the Driver Station is Avalonia/X11 and exits with `XOpenDisplay failed` without a display |
+| `/dev/uinput` readable by the runner's user | the harness makes its own keyboard; the DS reads evdev directly, which is why its hotkeys work unfocused |
+| the Driver Station unpacked at `~/ds` | `--ds-home` moves it |
+
+```bash
+sudo apt-get install -y xvfb
+echo 'KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="input", MODE="0660"' |
+    sudo tee /etc/udev/rules.d/99-uinput.rules
+sudo udevadm control --reload-rules && sudo chgrp input /dev/uinput && sudo chmod 660 /dev/uinput
+```
+
+## Running either job by hand
+
+Both scripts print the same Markdown the workflow puts in its step summary, and both treat an
+unreachable bench as a skip that exits 0.
+
+```bash
+BENCH=systemcore@192.168.1.202 .github/bench/real-hal-boot.sh
+BENCH=systemcore@192.168.1.202 .github/bench/sim-hitl.sh
+```
+
+`sim-hitl` stops `robot.service`, `mrccomm.service` and `limelight_diagnosticsprocess.service`
+for the run and starts all three again afterwards, whatever happens. The last two hold UDP 1110
+and the system NetworkTables server on 6810; leaving them up makes the simulation abort with
+`Multiple user programs detected` as soon as a previous program is still registered there.
+
+## Why `DS=on` is not the default
+
+The Driver Station finds a simulated robot **only on the machine it is running on**. Measured on
+this bench:
+
+- against the real robot it discovers the Pi and connects over TCP 1740, having first touched
+  6810 and 5810;
+- against a simulation on its own box it reports `robotIp 127.0.0.1` and drives it;
+- against the bench simulation it reports `robotIp 0.0.0.0` and opens nothing — with the sim
+  owning 6810 and 5810 on the LAN, TCP 1740/1741 proxied onto the LAN, the sim's loopback UDP
+  doorbell bridged both ways, and 6810/1740/1741/5810 tunnelled onto the runner's own loopback.
+
+`halsim_ds_socket` no longer implements the protocol itself; it hands the link to mrclib's
+`MRC_SimSystemServer`, and nothing in that path publishes a team number
+(`MRC_SimSystemServer_SetTeam` exists and the extension never calls it). So a remote simulation
+is not something the Driver Station can be pointed at today, and `sim-hitl` measures the
+**disabled** loop, which is real and regresses the same way.
+
+The harness itself is built and every part of it is exercised: Xvfb runs the Driver Station
+headless, the uinput keyboard appears as an evdev device the DS can read, and an opmode is
+selected by writing `DriverStationStorage.json` — the id is
+`(mode << 56) | (name.hashCode() & 0x00FFFFFFFFFFFFFF)`, so no window coordinates are involved.
+What is missing is upstream's, not ours.


### PR DESCRIPTION
Closes #101.

`.github/workflows/` held one file. ADR 0013 specified a second workflow with two jobs on the bench Pi and `CONTEXT.md` already defined all three terms. Both jobs exist now, both were run against the bench, and neither is a required check — an unreachable bench is a skip, not a red.

## `real-hal-boot`

Deploys the real artifact (`linuxsystemcore`) against an empty CAN bus, waits 30 s, and asserts the ADR's four: `NRestarts` unchanged, `ActiveState=active`, the journal holds `Robot program startup complete`, and it holds no `MRC API version mismatch`. Four numbers go in the step summary and gate nothing.

Green on the bench:

| metric | this run | #10, on a heartbeat program |
|---|---|---|
| RSS | 244 MB | 83 MB |
| Threads | 65 | 36 |
| `SCHED_RR` | 50 (CAN), 40 (Notifier), plus six REV/CTRE threads at 1–3 | two |
| start → `startup complete` | 11.2 s | — |

## `sim-hitl`

A `linuxarm64` build on the same Pi, staged by a new `simHitlStage` task, shipped as a tarball and run against the sim HAL. `libwpiHal.so` for `linuxarm64` exports 460 `HALSIM_` symbols and links no `libMrcLib`, so this is the sim HAL rather than a cross-compiled real one. The loop holds 200 Hz on the Pi: p50 5.000 ms, p95 5.026 ms, p99 5.059 ms, which is what `sim-hitl-baseline.env` now carries. The assertion is deltas against that, never absolute milliseconds.

## Four things the hardware said, and ADR 0013 now carries

- **`busybox` is setuid on the image**, so `nohup` and `setsid` strip `LD_PRELOAD` from everything they exec — which would take ADR 0015's REVLib shim with it, aborting the JVM a long way from the cause. The sim runs in the foreground of an ssh that stays open.
- **`mrccomm` and `limelight_diagnosticsprocess` hold UDP 1110 and the system NT server on 6810.** They are stopped for the run and restarted **one at a time** afterwards: started together, `robot.service` crash-loops on `Multiple user programs detected`. The job checks `systemctl is-active robot` after its own cleanup and says so in the summary.
- **Xvfb does run the Driver Station** — ADR 0013's one unexecuted link — and an opmode is selected by writing `DriverStationStorage.json`, since the id is `(mode << 56) | (name.hashCode() & 0x00FF…)`. That retires the `xwininfo` click-target open item rather than solving it.
- **The Driver Station attaches to no simulation but the one on its own machine.** Against the real robot it finds the Pi and connects over TCP 1740; against a local sim it reports `robotIp 127.0.0.1`; against the bench sim it reports `0.0.0.0` and opens nothing — with 6810 and 5810 on the LAN, 1740/1741 proxied, the loopback UDP doorbell bridged both ways, and every port tunnelled onto the runner's loopback. So the loop measured is the **disabled** one, and the harness sits behind `DS=on`, built and unused. `docs/bench-runner.md` carries the evidence.

## Departures from the ticket

The ticket said to build to ADR 0013 §374 and §430. Job 1 is that section. Job 2 is that section minus the enabled loop, which is not measurable today for the reason above; `sim-hitl` takes the enabled numbers automatically the day a Driver Station can attach. The ADR's open items are updated rather than quietly left.

## Verification

- Both scripts run green against the bench, repeatedly, and leave `robot`, `mrccomm` and `limelight_diagnosticsprocess` active.
- `./gradlew build` green.
- Reviewed at `/code-review high`; ten findings, all fixed — the open-span bug that would have compared enabled samples against the disabled baseline, `trap … INT TERM`, the scoped kills, the leaked `DS=on` processes, and the stale-WPILOG read among them.

The workflow cannot run until a self-hosted runner exists; `docs/bench-runner.md` is the provisioning, including the two repo settings that go with a self-hosted runner on a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3RDz8Bbj4rcGU2b36VDuB