### PR TITLE
Move the two node20 actions to node24

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,7 +62,7 @@ jobs:
           distribution: temurin
           java-version: '25'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       # Deploys the real artifact against an empty CAN bus and asserts four things about it.
       - name: Deploy and assert
@@ -93,7 +93,7 @@ jobs:
           distribution: temurin
           java-version: '25'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       # A linuxarm64 sim build on the Pi, enabled by the real Driver Station on this runner.
       - name: Simulate on the bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: temurin
           java-version: '25'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       # --continue, so a formatting failure cannot hide a test failure.
       - name: Lint, compile and test
@@ -42,7 +42,7 @@ jobs:
 
       - name: Annotate test failures on the diff
         if: always()
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: build/test-results/test/TEST-*.xml
           require_tests: false

--- a/docs/adr/0013-ci-and-test-strategy.md
+++ b/docs/adr/0013-ci-and-test-strategy.md
@@ -108,9 +108,14 @@ person*: **during an event we push to a per-event branch with no
 restrictions and merge afterwards.** An admin override is a habit that
 gets used on a Tuesday; a branch is a thing you have to mean.
 
-This is new. Today `main` has no protection at all and all six
-collaborators hold `admin`, so CI could inform but not gate, and anyone
-can push straight to `main`. **[executed — GitHub API, 2026-08-26]**
+It is in place, as a **ruleset** rather than classic branch protection:
+active on `main`, one required check — `Lint, compile and test` — and an
+empty `bypass_actors`, which is what *including administrators* means
+here. Neither bench job is listed, and neither may be.
+**[executed — GitHub API, 2026-09-07, via #101]** The classic
+`/branches/main/protection` endpoint answers `404 Branch not protected`
+against a repository protected this way, so that 404 is not evidence of
+anything.
 
 ### Tier 1 owns every number
 


### PR DESCRIPTION
Every run of both workflows carried `Node.js 20 is deprecated … being forced to run on Node.js 24`, naming `gradle/actions/setup-gradle@v4` and `mikepenz/action-junit-report@v5`.

- **`setup-gradle` v4 → v5.** v5.0.0 is the Node 24 bump and nothing else.
- **`action-junit-report` v5 → v6.** v6 targets `node24`; `report_paths`, `require_tests` and `detailed_summary` all still exist in v6.5.0's `action.yml`.
- The self-hosted runner is **2.337.0**, past the 2.327.1 both releases require.

**`setup-gradle` v6 is deliberately not taken.** It extracts caching into a separate `gradle-actions-caching` component that is [no longer open source](https://blog.gradle.org/github-actions-for-gradle-v6) and carries Terms of Use you accept by upgrading. That is a licensing call for a human, not a way to clear a warning, and v5 clears the warning without it.

## One ADR correction

ADR 0013 said *"Today `main` has no protection at all and all six collaborators hold `admin`"*. It is protected — by a **ruleset**: active, one required check (`Lint, compile and test`), empty `bypass_actors`, which is what the ADR's *including administrators* means. Neither bench job is listed and neither may be. The classic `/branches/main/protection` endpoint answers `404 Branch not protected` against a repository protected this way, which is what made it look absent when I checked it yesterday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3RDz8Bbj4rcGU2b36VDuB