### PR TITLE
Check in the permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git blame *)",
+      "Bash(git grep *)",
+      "Bash(git rev-parse *)",
+      "Bash(git merge-base *)",
+      "Bash(git ls-files *)",
+      "Bash(git branch)",
+      "Bash(git branch --list *)",
+      "Bash(git remote -v)",
+      "Bash(git remote get-url *)",
+      "Bash(git config --get *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue status *)",
+      "Bash(ssh systemcore@*)",
+      "Bash(uv run *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,7 @@ compile_commands.json
 # Eclipse generated file for annotation processors
 .factorypath
 __pycache__/
+
+# Claude Code writes each developer's own permission approvals here. The team's are in
+# .claude/settings.json, which is checked in.
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ and [issue #18](https://github.com/Drew-Robotics/2027beta/issues/18), but is not
 built yet. It reviews successful pull requests for field-only risks that CI
 cannot detect. It is not a replacement for student review.
 
+`.claude/settings.json` is checked in. It is a permission allowlist, so an agent
+runs `./gradlew`, read-only `git`, read-only `gh issue`, `ssh systemcore@...` and
+`uv run` without asking. Claude Code ignores it until you accept the trust dialog
+once, on the first run in a fresh clone. Your own approvals go in
+`.claude/settings.local.json`, which is not checked in.
+
 ## Deploying
 
 Use the VSCode deploy button or `./gradlew deploy`. Deployment stops


### PR DESCRIPTION
`.claude/` did not exist. #18 decided the team's AI setup is *"one file, one skill,
one allowlist and one gated reviewer"*, and only `CLAUDE.md` was built. This is the
allowlist and nothing else — no hooks (#19 owns enforcement), no MCP servers, no
`.claude/rules/*.md` split.

Twenty rules: `./gradlew *`; fourteen read-only `git`; the three read-only
`gh issue` verbs; `ssh systemcore@*`; `uv run *`.

**Read-only `git` is spelled out subcommand by subcommand rather than as `git *`,
because the matcher is a prefix match.** `Bash(git branch *)` would carry
`git branch -D`; `Bash(git config *)` would carry every write. So the pure read
verbs get a wildcard (`git status *`, `git diff *`, `git log *`, …) and the mixed
ones are pinned to their reading form (`git branch --list *`, `git remote get-url *`,
`git config --get *`). The same reason keeps `gh` to `list`, `view` and `status`
rather than `gh issue *`, which would carry `close` and `edit`.

## Measured, not assumed

Every rule was run through a real `claude -p --permission-mode default` session,
twice: once with the file in place and once with it moved aside. The second run is
the one worth reading, because **Claude Code already allows most read-only `git`
without any allowlist at all.**

| command | without the file | with it |
|---|---|---|
| `git status`, `git log`, `git branch`, `git remote -v`, `git config --get`, `git blame`, `git grep`, `git ls-files`, `git merge-base` | ran | ran |
| `git remote get-url origin` | **denied** | ran |
| `gh issue list`, `gh issue view` | **denied** | ran |
| `./gradlew --version` | **denied** | ran |
| `uv run --help` | **denied** | ran |
| `ssh systemcore@192.168.1.202 true` | **denied** | ran (bench is up) |
| `gh pr list` | denied | denied |
| `git branch -D some-branch` | denied | denied |

So the prompting this ticket set out to stop was mostly `./gradlew`, `gh issue`,
`uv run` and `ssh` — nine of the fourteen `git` rules buy nothing *today*. They stay
because that built-in allowance is undocumented and version-dependent, and #99 asked
for read-only `git` in the file rather than in Claude Code's defaults. The two
denials are the guardrail working: `git branch -D` proves "read-only" is real.

Also confirmed: `Bash(git status *)` matches bare `git status`, so the wildcard form
costs no extra rule; and `git check-ignore` puts `.claude/settings.local.json` inside
the ignore and `.claude/settings.json` outside it.

## The README line

#99's done-when is *"a fresh clone stops prompting for the listed commands"*, and the
file alone does not achieve it. In an untrusted clone Claude Code prints *"Ignoring
20 permissions.allow entries from `.claude/settings.json`: this workspace has not
been trusted"* and the allowlist is inert. #18 called this *"one keystroke"*, which is
right, but the keystroke was unwritten anywhere — so the student the safety argument
is aimed at would meet the prompts the allowlist exists to remove. Hence six lines in
README's *AI access* section. That is the only thing here beyond the file and the
ignore.

## Three things for you, not fixed here

1. **`ssh -o … systemcore@…` is not covered.** The rule is a prefix match on
   `ssh systemcore@`, so README's documented form
   (`ssh systemcore@robot.local journalctl -u robot -f`) matches, and the
   `-o BatchMode=yes` form `.github/bench/*.sh` uses does not. Deliberate: widening
   to `ssh * systemcore@*` would admit `-o ProxyCommand=…`, which is arbitrary
   *local* execution. The bench scripts are invoked by path, so they are unaffected.

2. **`ssh systemcore@*` and `uv run *` are unbounded on the far side of the
   wildcard** — any command on the bench Pi, any tool under `uv`. Both are literally
   what #18 named, so they shipped as named. Narrowing them (`ssh systemcore@*
   journalctl *`, `uv run logtool *`) would be guessing at an invocation shape for a
   tool that does not exist yet, and `tools/logtool/**` is exactly what #18 said would
   trigger the first `.claude/rules/*.md` split. Worth revisiting then, not now.

3. **`gh pr` is not on the list, and the workflow needs it.** #18 named read-only
   `gh issue` and #99 repeated it, so that is what shipped — and `gh pr list` is
   denied above to prove it. But *branch + PR + green CI + merge* is how work lands
   here, and `gh pr view`, `gh pr list`, `gh pr diff` and `gh pr checks` are all
   read-only. Say the word and it is a four-line follow-up; I did not widen a
   security file past its ticket on my own judgement.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3RDz8Bbj4rcGU2b36VDuB
