### PR TITLE
Log robot uptime beside the alert start times

### DIFF
--- a/src/main/java/first/robot/Robot.java
+++ b/src/main/java/first/robot/Robot.java
@@ -379,6 +379,7 @@ public class Robot extends OpModeRobot {
     alertLog.log(
         "StartTimes",
         active.stream().mapToDouble(a -> Nanoseconds.of(a.activeStartTime).in(Seconds)).toArray());
+    alertLog.log("Uptime", Nanoseconds.of(RobotController.getTime()));
   }
 
   private static String levelName(AlertInfo alert) {


### PR DESCRIPTION
Adds an uptime field to the alert log, so a WPILOG says how long the program had been up when an alert fired.

`Nanoseconds`, not `Microseconds`: `RobotController.getTime()` changed base in alpha-7 without changing signature, so the microsecond form compiles and logs a number 1000x too large under a seconds unit.

This branch opened as the acceptance check for #102 and caught that hazard from the reviewer itself — [the comment](https://github.com/Drew-Robotics/2027beta/pull/129#discussion_r1) is on the original version of this line. The tamper commit that proved `workflow_run` runs main's definition has been dropped; what is left is the feature, fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3RDz8Bbj4rcGU2b36VDuB